### PR TITLE
Fixed bug in scope distance calculation for new events

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -212,10 +212,10 @@ class BaseEvent:
     def source(self, source):
         if is_event(source):
             self._source = source
-            if source.scope_distance >= 0 and source != self:
+            if source.scope_distance >= 0:
                 new_scope_distance = int(source.scope_distance)
                 # only increment the scope distance if the host changes
-                if not self.host == source.host:
+                if self.host != source.host:
                     new_scope_distance += 1
                 self.scope_distance = new_scope_distance
         elif not self._dummy:

--- a/bbot/modules/leakix.py
+++ b/bbot/modules/leakix.py
@@ -28,10 +28,13 @@ class leakix(crobat):
                 host = s.get("host", "")
                 if not host:
                     continue
-                source_event = self.make_event(host, "DNS_NAME", source=event)
-                if not source_event:
-                    continue
-                self.emit_event(source_event)
+                if host == event:
+                    source_event = event
+                else:
+                    source_event = self.make_event(host, "DNS_NAME", source=event)
+                    if not source_event:
+                        continue
+                    self.emit_event(source_event)
                 ssl = s.get("ssl", {})
                 if not ssl:
                     continue

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -166,6 +166,10 @@ def test_events(events, scan, helpers, bbot_config):
     assert event2._scope_distance == 1
     event3 = scan.make_event("3.4.5.6", source=event2)
     assert event3._scope_distance == 2
+    event4 = scan.make_event("3.4.5.6", source=event3)
+    assert event4._scope_distance == 2
+    event5 = scan.make_event("4.5.6.7", source=event4)
+    assert event5._scope_distance == 3
 
     # internal event tracking
     root_event = scan.make_event("0.0.0.0", dummy=True)


### PR DESCRIPTION
fixed bug where setting an event's source to an identical event caused its scope distance calculation to fail