### PR TITLE
Gowitness Chromium Fix + Better Tests

### DIFF
--- a/bbot-docker.sh
+++ b/bbot-docker.sh
@@ -1,4 +1,4 @@
 # build docker image if it doesn't exist already
 [[ ! -z `docker images -q bbot` ]] || docker build "$( dirname -- "${BASH_SOURCE[0]}"; )" -t bbot
 # run the docker image
-docker run --rm -it -v /tmp/.bbot:/root/.bbot -v /tmp/.config/bbot:/root/.config/bbot bbot "$@"
+docker run --rm -it -v "$HOME/.bbot:/root/.bbot" -v "$HOME/.config/bbot:/root/.config/bbot" bbot "$@"

--- a/bbot/core/configurator/__init__.py
+++ b/bbot/core/configurator/__init__.py
@@ -6,7 +6,7 @@ from omegaconf import OmegaConf
 from . import files, args, environ
 from ..errors import ConfigLoadError
 from ...modules import module_loader
-from ..helpers.misc import mkdir, error_and_exit, filter_dict, clean_dict
+from ..helpers.misc import mkdir, error_and_exit, filter_dict, clean_dict, log_to_stderr
 
 try:
     config = OmegaConf.merge(
@@ -34,14 +34,14 @@ config["home"] = str(home)
 
 # ensure bbot.yml
 if not files.config_filename.exists():
-    print(f"[INFO] Creating BBOT config at {files.config_filename}")
+    log_to_stderr(f"Creating BBOT config at {files.config_filename}")
     no_secrets_config = OmegaConf.to_object(config)
     no_secrets_config = clean_dict(no_secrets_config, "api_key", "username", "password", "token", fuzzy=True)
     OmegaConf.save(config=OmegaConf.create(no_secrets_config), f=str(files.config_filename))
 
 # ensure secrets.yml
 if not files.secrets_filename.exists():
-    print(f"[INFO] Creating BBOT secrets at {files.secrets_filename}")
+    log_to_stderr(f"Creating BBOT secrets at {files.secrets_filename}")
     secrets_only_config = OmegaConf.to_object(config)
     secrets_only_config = filter_dict(
         secrets_only_config, "api_key", "username", "password", "token", "secret", "_id", fuzzy=True

--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -10,6 +10,7 @@ import string
 import logging
 import ipaddress
 import wordninja
+import subprocess as sp
 from pathlib import Path
 from itertools import islice
 from datetime import datetime
@@ -444,9 +445,9 @@ def search_format_dict(d, **kwargs):
     elif isinstance(d, list):
         return [search_format_dict(v, **kwargs) for v in d]
     elif isinstance(d, str):
-        return d.format(**kwargs)
-    else:
-        return d
+        for k, v in kwargs.items():
+            d = d.replace("#{" + str(k) + "}", v)
+    return d
 
 
 def filter_dict(d, *key_names, fuzzy=False, invert=False):
@@ -664,3 +665,17 @@ def log_to_stderr(msg, level="INFO"):
         if levelname == "CRITICAL" or levelname.startswith("HUGE"):
             msg = colorize(msg)
         print(f"{levelshort} bbot: {msg}", file=sys.stderr)
+
+
+def verify_sudo_password(sudo_pass):
+    try:
+        sp.run(
+            ["sudo", "-S", "-k", "true"],
+            input=smart_encode(sudo_pass),
+            stderr=sp.DEVNULL,
+            stdout=sp.DEVNULL,
+            check=True,
+        )
+    except sp.CalledProcessError:
+        return False
+    return True

--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -35,9 +35,9 @@ class ffuf(BaseModule):
         {
             "name": "Download ffuf",
             "unarchive": {
-                "src": "https://github.com/ffuf/ffuf/releases/download/v{BBOT_MODULES_FFUF_VERSION}/ffuf_{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
+                "src": "https://github.com/ffuf/ffuf/releases/download/v#{BBOT_MODULES_FFUF_VERSION}/ffuf_#{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
                 "include": "ffuf",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         }

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -39,9 +39,9 @@ class nuclei(BaseModule):
         {
             "name": "Download nuclei",
             "unarchive": {
-                "src": "https://github.com/projectdiscovery/nuclei/releases/download/v{BBOT_MODULES_NUCLEI_VERSION}/nuclei_{BBOT_MODULES_NUCLEI_VERSION}_linux_amd64.zip",
+                "src": "https://github.com/projectdiscovery/nuclei/releases/download/v#{BBOT_MODULES_NUCLEI_VERSION}/nuclei_#{BBOT_MODULES_NUCLEI_VERSION}_linux_amd64.zip",
                 "include": "nuclei",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         }

--- a/bbot/modules/deadly/vhost.py
+++ b/bbot/modules/deadly/vhost.py
@@ -21,9 +21,9 @@ class vhost(BaseModule):
         {
             "name": "Download ffuf",
             "unarchive": {
-                "src": "https://github.com/ffuf/ffuf/releases/download/v{BBOT_MODULES_FFUF_VERSION}/ffuf_{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
+                "src": "https://github.com/ffuf/ffuf/releases/download/v#{BBOT_MODULES_FFUF_VERSION}/ffuf_#{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
                 "include": "ffuf",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         }

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -25,9 +25,9 @@ class ffuf_shortnames(ffuf):
         {
             "name": "Download ffuf",
             "unarchive": {
-                "src": "https://github.com/ffuf/ffuf/releases/download/v{BBOT_MODULES_FFUF_VERSION}/ffuf_{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
+                "src": "https://github.com/ffuf/ffuf/releases/download/v#{BBOT_MODULES_FFUF_VERSION}/ffuf_#{BBOT_MODULES_FFUF_VERSION}_linux_amd64.tar.gz",
                 "include": "ffuf",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         }

--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -21,9 +21,9 @@ class httpx(BaseModule):
         {
             "name": "Download httpx",
             "unarchive": {
-                "src": "https://github.com/projectdiscovery/httpx/releases/download/v{BBOT_MODULES_HTTPX_VERSION}/httpx_{BBOT_MODULES_HTTPX_VERSION}_linux_amd64.zip",
+                "src": "https://github.com/projectdiscovery/httpx/releases/download/v#{BBOT_MODULES_HTTPX_VERSION}/httpx_#{BBOT_MODULES_HTTPX_VERSION}_linux_amd64.zip",
                 "include": "httpx",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         }

--- a/bbot/modules/massdns.py
+++ b/bbot/modules/massdns.py
@@ -22,18 +22,18 @@ class massdns(crobat):
             "name": "Download massdns source code",
             "git": {
                 "repo": "https://github.com/blechschmidt/massdns.git",
-                "dest": "{BBOT_TEMP}/massdns",
+                "dest": "#{BBOT_TEMP}/massdns",
                 "single_branch": True,
                 "version": "master",
             },
         },
         {
             "name": "Build massdns",
-            "command": {"chdir": "{BBOT_TEMP}/massdns", "cmd": "make", "creates": "{BBOT_TEMP}/massdns/bin/massdns"},
+            "command": {"chdir": "#{BBOT_TEMP}/massdns", "cmd": "make", "creates": "#{BBOT_TEMP}/massdns/bin/massdns"},
         },
         {
             "name": "Install massdns",
-            "copy": {"src": "{BBOT_TEMP}/massdns/bin/massdns", "dest": "{BBOT_TOOLS}/", "mode": "u+x,g+x,o+x"},
+            "copy": {"src": "#{BBOT_TEMP}/massdns/bin/massdns", "dest": "#{BBOT_TOOLS}/", "mode": "u+x,g+x,o+x"},
         },
     ]
 

--- a/bbot/modules/naabu.py
+++ b/bbot/modules/naabu.py
@@ -37,16 +37,16 @@ class naabu(BaseModule):
         },
         {
             "name": "symlink libpcap",
-            "file": {"src": "/usr/lib/libpcap.so", "dest": "{BBOT_LIB}/libpcap.so.0.8", "state": "link"},
+            "file": {"src": "/usr/lib/libpcap.so", "dest": "#{BBOT_LIB}/libpcap.so.0.8", "state": "link"},
             "ignore_errors": "yes",
             "when": """ansible_facts['os_family'] != 'Debian'""",
         },
         {
             "name": "Download naabu",
             "unarchive": {
-                "src": "https://github.com/projectdiscovery/naabu/releases/download/v{BBOT_MODULES_NAABU_VERSION}/naabu_{BBOT_MODULES_NAABU_VERSION}_linux_amd64.zip",
+                "src": "https://github.com/projectdiscovery/naabu/releases/download/v#{BBOT_MODULES_NAABU_VERSION}/naabu_#{BBOT_MODULES_NAABU_VERSION}_linux_amd64.zip",
                 "include": "naabu",
-                "dest": "{BBOT_TOOLS}",
+                "dest": "#{BBOT_TOOLS}",
                 "remote_src": True,
             },
         },

--- a/bbot/modules/smuggler.py
+++ b/bbot/modules/smuggler.py
@@ -18,7 +18,7 @@ class smuggler(BaseModule):
     deps_ansible = [
         {
             "name": "Get smuggler repo",
-            "git": {"repo": "https://github.com/defparam/smuggler.git", "dest": "{BBOT_TOOLS}/smuggler"},
+            "git": {"repo": "https://github.com/defparam/smuggler.git", "dest": "#{BBOT_TOOLS}/smuggler"},
         }
     ]
 

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -108,14 +108,14 @@ class telerik(BaseModule):
     deps_pip = ["pycryptodome"]
 
     deps_ansible = [
-        {"name": "Create telerik dir", "file": {"state": "directory", "path": "{BBOT_TOOLS}/telerik/"}},
-        {"file": {"state": "touch", "path": "{BBOT_TOOLS}/telerik/testfile.txt"}},
+        {"name": "Create telerik dir", "file": {"state": "directory", "path": "#{BBOT_TOOLS}/telerik/"}},
+        {"file": {"state": "touch", "path": "#{BBOT_TOOLS}/telerik/testfile.txt"}},
         {
             "name": "Download RAU_crypto",
             "unarchive": {
                 "src": "https://github.com/bao7uo/RAU_crypto/archive/refs/heads/master.zip",
                 "include": "RAU_crypto-master/RAU_crypto.py",
-                "dest": "{BBOT_TOOLS}/telerik/",
+                "dest": "#{BBOT_TOOLS}/telerik/",
                 "remote_src": True,
             },
         },

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -1,5 +1,7 @@
+import os
 import sys
 import pytest
+import getpass
 import logging
 import urllib3
 import requests
@@ -7,6 +9,8 @@ import subprocess
 import tldextract
 from pathlib import Path
 from omegaconf import OmegaConf
+
+from bbot.core.helpers.misc import verify_sudo_password
 
 # make the necessary web requests before nuking them to high heaven
 example_url = "https://api.publicapis.org/health"
@@ -17,6 +21,21 @@ tldextract.extract("www.evilcorp.com")
 
 
 log = logging.getLogger(f"bbot.test.fixtures")
+
+
+@pytest.fixture
+def ensure_root():
+    if not os.geteuid() == 0:
+        sudo_pass = os.environ.get("BBOT_SUDO_PASS", None)
+        while 1:
+            if sudo_pass is None:
+                sudo_pass = getpass.getpass(prompt="[USER] Please enter sudo password: ")
+            if verify_sudo_password(sudo_pass):
+                log.success("Authentication successful")
+                break
+            log.warning("Invalid password")
+            sudo_pass = None
+        os.environ["BBOT_SUDO_PASS"] = sudo_pass
 
 
 @pytest.fixture
@@ -34,7 +53,8 @@ def patch_requests(monkeypatch):
 
 
 @pytest.fixture
-def patch_commands(monkeypatch):
+def patch_commands():
+
     import subprocess
 
     sample_output = [
@@ -57,24 +77,26 @@ def patch_commands(monkeypatch):
         "https://8.8.8.8",
     ]
 
-    def run(*args, **kwargs):
-        text = kwargs.get("text", True)
-        return subprocess.run(["echo", "\n".join(sample_output)], text=text, stdout=subprocess.PIPE)
+    def patch_scan_commands(scanner):
+        def run(*args, **kwargs):
+            text = kwargs.get("text", True)
+            return subprocess.run(["echo", "\n".join(sample_output)], text=text, stdout=subprocess.PIPE)
 
-    def run_live(*args, **kwargs):
-        for line in sample_output:
-            yield line
+        def run_live(*args, **kwargs):
+            for line in sample_output:
+                yield line
 
-    from bbot.core.helpers.command import run as old_run, run_live as old_run_live
+        from bbot.core.helpers.command import run as old_run, run_live as old_run_live
 
-    monkeypatch.setattr("bbot.core.helpers.command.run", run)
-    monkeypatch.setattr("bbot.core.helpers.command.run_live", run_live)
+        scanner.helpers.run = run
+        scanner.helpers.run_live = run_live
+        return old_run, old_run_live
 
-    return old_run, old_run_live
+    return patch_scan_commands
 
 
 @pytest.fixture
-def bbot_scanner(patch_commands, patch_requests, neuter_ansible):
+def bbot_scanner(patch_requests):
     from bbot.scanner import Scanner
 
     return Scanner
@@ -100,7 +122,7 @@ def neograph(monkeypatch, helpers):
 
 
 @pytest.fixture
-def neuter_ansible(monkeypatch):
+def patch_ansible(monkeypatch):
     from ansible_runner.interface import run
 
     class AnsibleRunnerResult:
@@ -115,17 +137,21 @@ def neuter_ansible(monkeypatch):
 
     ensure_root = installer.DepsInstaller.ensure_root
 
-    monkeypatch.setattr(installer, "run", ansible_run)
-    monkeypatch.setattr(installer.DepsInstaller, "ensure_root", lambda *args, **kwargs: None)
+    def patch_scan_ansible(scanner):
+        monkeypatch.setattr(installer, "run", ansible_run)
+        monkeypatch.setattr(scanner.helpers.depsinstaller, "ensure_root", lambda *args, **kwargs: None)
+        return run, ensure_root
 
-    return run, ensure_root
+    return patch_scan_ansible
 
 
 @pytest.fixture
-def scan(neuter_ansible, patch_requests, patch_commands, bbot_config):
+def scan(patch_ansible, patch_requests, patch_commands, bbot_config):
     from bbot.scanner import Scanner
 
     bbot_scan = Scanner("127.0.0.1", modules=["ipneighbor"], config=bbot_config)
+    patch_commands(bbot_scan)
+    patch_ansible(bbot_scan)
     bbot_scan.status = "RUNNING"
     return bbot_scan
 
@@ -283,7 +309,7 @@ available_output_modules = list(module_loader.configs(type="output"))
 
 
 @pytest.fixture(autouse=True)
-def install_all_python_deps(neuter_ansible):
+def install_all_python_deps():
     deps_pip = set()
     for module in module_loader.preloaded().values():
         deps_pip.update(set(module.get("deps", {}).get("pip", [])))

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -25,17 +25,16 @@ log = logging.getLogger(f"bbot.test.fixtures")
 
 @pytest.fixture
 def ensure_root():
-    if os.geteuid() != 0:
-        sudo_pass = os.environ.get("BBOT_SUDO_PASS", None)
-        while 1:
-            if sudo_pass is None:
-                sudo_pass = getpass.getpass(prompt="[USER] Please enter sudo password: ")
-            if verify_sudo_password(sudo_pass):
-                log.success("Authentication successful")
-                break
-            log.warning("Invalid password")
-            sudo_pass = None
-        os.environ["BBOT_SUDO_PASS"] = sudo_pass
+    sudo_pass = os.environ.get("BBOT_SUDO_PASS", "")
+    while 1:
+        if sudo_pass is None:
+            sudo_pass = getpass.getpass(prompt="[USER] Please enter sudo password: ")
+        if verify_sudo_password(sudo_pass):
+            log.success("Authentication successful")
+            break
+        log.warning("Invalid password")
+        sudo_pass = None
+    os.environ["BBOT_SUDO_PASS"] = sudo_pass
 
 
 @pytest.fixture

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -25,7 +25,7 @@ log = logging.getLogger(f"bbot.test.fixtures")
 
 @pytest.fixture
 def ensure_root():
-    if os.getuid() != 0:
+    if os.geteuid() != 0:
         sudo_pass = os.environ.get("BBOT_SUDO_PASS", None)
         while 1:
             if sudo_pass is None:

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -25,7 +25,7 @@ log = logging.getLogger(f"bbot.test.fixtures")
 
 @pytest.fixture
 def ensure_root():
-    if not os.geteuid() == 0:
+    if os.getuid() != 0:
         sudo_pass = os.environ.get("BBOT_SUDO_PASS", None)
         while 1:
             if sudo_pass is None:

--- a/bbot/test/test.conf
+++ b/bbot/test/test.conf
@@ -6,8 +6,6 @@ modules:
     prefix_busting: true
   ipneighbor:
     test_option: ipneighbor
-  gowitness:
-    output_path: /tmp/.bbot_test/gowitness
 output_modules:
   http:
     url: http://127.0.0.1:11111

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -22,6 +22,7 @@ root_logger = logging.getLogger()
 for h in root_logger.handlers:
     h.addFilter(lambda x: x.levelno != 100)
 
+log.critical(f"uid: {os.getuid()} euid: {os.geteuid()}")
 
 def test_events(events, scan, helpers, bbot_config):
 

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -22,8 +22,6 @@ root_logger = logging.getLogger()
 for h in root_logger.handlers:
     h.addFilter(lambda x: x.levelno != 100)
 
-os.environ["BBOT_SUDO_PASS"] = "nah"
-
 
 def test_events(events, scan, helpers, bbot_config):
 
@@ -425,9 +423,8 @@ def test_curl(helpers):
     )
 
 
-def test_helpers(patch_requests, patch_commands, helpers, scan):
+def test_helpers(patch_requests, helpers, scan, bbot_scanner):
 
-    old_run, old_run_live = patch_commands
     request, download = patch_requests
 
     ### URL ###
@@ -600,7 +597,9 @@ def test_helpers(patch_requests, patch_commands, helpers, scan):
     assert "filterme" in cleaned_dict3["modules"]["c99"]
     assert "ipneighbor" in cleaned_dict3["modules"]
 
-    replaced = helpers.search_format_dict({"asdf": [{"wat": {"here": "{replaceme}!"}}, {500: True}]}, replaceme="asdf")
+    replaced = helpers.search_format_dict(
+        {"asdf": [{"wat": {"here": "#{replaceme}!"}}, {500: True}]}, replaceme="asdf"
+    )
     assert replaced["asdf"][1][500] == True
     assert replaced["asdf"][0]["wat"]["here"] == "asdf!"
 
@@ -698,16 +697,17 @@ def test_helpers(patch_requests, patch_commands, helpers, scan):
     command.catch(raise_brokenpipe)
 
     ### COMMAND ###
-    assert "plumbus\n" in old_run(helpers, ["echo", "plumbus"], text=True).stdout
-    assert "plumbus\n" in list(old_run_live(helpers, ["echo", "plumbus"]))
+    scan1 = bbot_scanner()
+    assert "plumbus\n" in scan1.helpers.run(["echo", "plumbus"], text=True).stdout
+    assert "plumbus\n" in list(scan1.helpers.run_live(["echo", "plumbus"]))
     expected_output = ["lumbus\n", "plumbus\n", "rumbus\n"]
-    assert list(old_run_live(helpers, ["cat"], input="lumbus\nplumbus\nrumbus")) == expected_output
+    assert list(scan1.helpers.run_live(["cat"], input="lumbus\nplumbus\nrumbus")) == expected_output
 
     def plumbus_generator():
         yield "lumbus"
         yield "plumbus"
 
-    assert "plumbus\n" in list(old_run_live(helpers, ["cat"], input=plumbus_generator()))
+    assert "plumbus\n" in list(scan1.helpers.run_live(["cat"], input=plumbus_generator()))
     tempfile = helpers.tempfile(("lumbus", "plumbus"), pipe=True)
     with open(tempfile) as f:
         assert "plumbus\n" in list(f)
@@ -891,7 +891,9 @@ def test_word_cloud(helpers, bbot_config, bbot_scanner):
     assert word_cloud["rumbus"] == 1
 
 
-def test_modules(patch_requests, patch_commands, scan, helpers, events, bbot_config, bbot_scanner):
+def test_modules_basic(
+    patch_requests, patch_commands, patch_ansible, scan, helpers, events, bbot_config, bbot_scanner
+):
 
     # base module _filter_event()
     from bbot.modules.base import BaseModule
@@ -948,6 +950,8 @@ def test_modules(patch_requests, patch_commands, scan, helpers, events, bbot_con
     scan2 = bbot_scanner(
         modules=list(available_modules), output_modules=list(available_output_modules), config=bbot_config
     )
+    patch_commands(scan2)
+    patch_ansible(scan2)
     scan2.load_modules()
     scan2.status = "RUNNING"
 
@@ -1101,7 +1105,7 @@ def test_config(bbot_config, bbot_scanner):
     assert scan1.modules["speculate"].config.test_option == "speculate"
 
 
-def test_target(neuter_ansible, patch_requests, patch_commands, bbot_config, bbot_scanner):
+def test_target(patch_ansible, patch_requests, bbot_config, bbot_scanner):
     scan1 = bbot_scanner("api.publicapis.org", "8.8.8.8/30", "2001:4860:4860::8888/126", config=bbot_config)
     scan2 = bbot_scanner("8.8.8.8/29", "publicapis.org", "2001:4860:4860::8888/125", config=bbot_config)
     scan3 = bbot_scanner("8.8.8.8/29", "publicapis.org", "2001:4860:4860::8888/125", config=bbot_config)
@@ -1134,7 +1138,7 @@ def test_target(neuter_ansible, patch_requests, patch_commands, bbot_config, bbo
 
 
 def test_scan(
-    neuter_ansible,
+    patch_ansible,
     patch_requests,
     patch_commands,
     events,
@@ -1191,6 +1195,8 @@ def test_scan(
         blacklist=["http://127.0.0.3:8000/asdf"],
         whitelist=["127.0.0.0/29"],
     )
+    patch_commands(scan3)
+    patch_ansible(scan3)
     assert "targets" in scan3.json
     assert "127.0.0.3" in scan3.target
     assert "127.0.0.4" not in scan3.target
@@ -1266,15 +1272,7 @@ def test_cli(monkeypatch, bbot_config):
         assert len(lines) > 1
 
 
-def test_depsinstaller(monkeypatch, neuter_ansible, bbot_config, bbot_scanner):
-    # un-neuter ansible
-    from bbot.core.helpers.depsinstaller import installer
-
-    run, ensure_root = neuter_ansible
-    ensure_root = installer.DepsInstaller.ensure_root
-    monkeypatch.setattr(installer, "run", run)
-    monkeypatch.setattr(installer.DepsInstaller, "ensure_root", ensure_root)
-
+def test_depsinstaller(monkeypatch, bbot_config, bbot_scanner):
     scan = bbot_scanner(
         "127.0.0.1",
         modules=["dnsresolve"],

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -24,6 +24,7 @@ for h in root_logger.handlers:
 
 log.critical(f"uid: {os.getuid()} euid: {os.geteuid()}")
 
+
 def test_events(events, scan, helpers, bbot_config):
 
     assert events.ipv4.type == "IP_ADDRESS"

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -22,8 +22,6 @@ root_logger = logging.getLogger()
 for h in root_logger.handlers:
     h.addFilter(lambda x: x.levelno != 100)
 
-log.critical(f"uid: {os.getuid()} euid: {os.geteuid()}")
-
 
 def test_events(events, scan, helpers, bbot_config):
 

--- a/bbot/test/test_modules_full.py
+++ b/bbot/test/test_modules_full.py
@@ -22,4 +22,4 @@ def test_gowitness(monkeypatch, bbot_config, ensure_root):  # noqa: F811
 
     screenshots_path = Path(bbot_config["home"]) / "scans" / "gowitness_test" / "gowitness" / "screenshots"
     screenshots = list(screenshots_path.glob("*.png"))
-    assert screenshots
+    assert screenshots, "Gowitness failed to generate screenshots"

--- a/bbot/test/test_modules_full.py
+++ b/bbot/test/test_modules_full.py
@@ -1,0 +1,22 @@
+import sys
+import logging
+from pathlib import Path
+
+from bbot import cli
+from .bbot_fixtures import bbot_config, ensure_root  # noqa: F401
+
+log = logging.getLogger(f"bbot.test")
+
+
+def test_gowitness(monkeypatch, bbot_config, ensure_root):  # noqa: F811
+
+    monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
+    monkeypatch.setattr(cli, "config", bbot_config)
+    monkeypatch.setattr(
+        sys, "argv", ["bbot", "-y", "-m", "gowitness", "httpx", "-t", "http://www.example.com", "-n", "gowitness_test"]
+    )
+    cli.main()
+
+    screenshots_path = Path(bbot_config["home"]) / "scans" / "gowitness_test" / "gowitness" / "screenshots"
+    screenshots = list(screenshots_path.glob("*.png"))
+    assert screenshots

--- a/bbot/test/test_modules_full.py
+++ b/bbot/test/test_modules_full.py
@@ -1,6 +1,7 @@
 import sys
 import logging
 from pathlib import Path
+from omegaconf import OmegaConf
 
 from bbot import cli
 from .bbot_fixtures import bbot_config, ensure_root  # noqa: F401
@@ -10,8 +11,10 @@ log = logging.getLogger(f"bbot.test")
 
 def test_gowitness(monkeypatch, bbot_config, ensure_root):  # noqa: F811
 
+    config = OmegaConf.merge(bbot_config, OmegaConf.create({"force_deps": True}))
+
     monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
-    monkeypatch.setattr(cli, "config", bbot_config)
+    monkeypatch.setattr(cli, "config", config)
     monkeypatch.setattr(
         sys, "argv", ["bbot", "-y", "-m", "gowitness", "httpx", "-t", "http://www.example.com", "-n", "gowitness_test"]
     )


### PR DESCRIPTION
The original purpose of this PR was to fix Gowitness for Ubuntu, but several other changes were needed in order to accomplish this:

- Fix environment variable syntax in ansible playbooks (from `{VAR_NAME}` to `#{VAR_NAME}`) to enable passthrough of double brackets to Ansible's jinja2 engine
- For Debian-based distros, download BBOT's own Chromium instance into its tools directory.
- Build a system for testing modules directly (without monkey-patching of web requests / subprocess output)
- Write a test for the gowitness module that fully installs all required dependencies and actually takes a screenshot