### PR TITLE
Improved BBOT Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ Visit the wiki for more [tips and tricks](https://github.com/blacklanternsecurit
 ~~~python
 from bbot.scanner import Scanner
 
-scan = Scanner("evilcorp.com", "1.2.3.0/24", modules=["naabu"], output_modules=["json"])
-scan.start()
+# any number of targets can be specified
+scan = Scanner("evilcorp.com", "1.2.3.0/24", modules=["naabu"])
+for event in scan.start():
+    print(event)
 ~~~
 
 # Output

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -91,6 +91,9 @@ def main():
                                     log.verbose(f'Enabling {m} because it has flag "{f}"')
                                     modules.add(m)
 
+                if not options.output_modules:
+                    options.output_modules = ["human"]
+
                 scanner = Scanner(
                     *options.targets,
                     modules=list(modules),
@@ -214,7 +217,7 @@ def main():
                         log.hugesuccess(f"Scan ready. Press enter to execute {scanner.name}")
                         input()
 
-                    scanner.start()
+                    scanner.start_without_generator()
 
             except Exception:
                 raise

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -333,6 +333,13 @@ class BaseEvent:
                 return json.dumps(self.data, sort_keys=True)
         return smart_decode(self.data)
 
+    @property
+    def data_json(self):
+        """
+        JSON representation of event.data
+        """
+        return self.data
+
     def __contains__(self, other):
         """
         Allows events to be compared using the "in" operator:
@@ -355,7 +362,7 @@ class BaseEvent:
             return host_in_host(other.host, self.host)
         return False
 
-    def json(self, mode="graph"):
+    def json(self, mode="json"):
         j = dict()
         for i in ("type", "id", "web_spider_distance"):
             v = getattr(self, i, "")

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -60,7 +60,13 @@ class DepsInstaller:
                     continue
                 preloaded = self.all_modules_preloaded[m]
                 # make a hash of the dependencies and check if it's already been handled
-                module_hash = self.parent_helper.sha1(str(preloaded["deps"]) + self.venv).hexdigest()
+                # take into consideration whether the venv or bbot home directory changes
+                module_hash = self.parent_helper.sha1(
+                    json.dumps(preloaded["deps"], sort_keys=True)
+                    + self.venv
+                    + str(self.parent_helper.bbot_home)
+                    + os.uname()[1]
+                ).hexdigest()
                 success = self.setup_status.get(module_hash, None)
                 dependencies = list(chain(*preloaded["deps"].values()))
                 if len(dependencies) <= 0:

--- a/bbot/modules/output/python.py
+++ b/bbot/modules/output/python.py
@@ -1,0 +1,9 @@
+from bbot.modules.output.base import BaseOutputModule
+
+
+class python(BaseOutputModule):
+    watched_events = ["*"]
+    meta = {"description": "Output via Python API"}
+
+    def _worker(self):
+        pass

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -320,6 +320,10 @@ class ScanManager:
                     self.modules_status(_log=True, passes=1)
                     last_log_time = now
 
+                if "python" in self.scan.modules:
+                    events, finish, report = self.scan.modules["python"].events_waiting
+                    yield from events
+
                 try:
                     event = self.event_queue.get_nowait()
                     event_counter += 1

--- a/bbot/test/test.conf
+++ b/bbot/test/test.conf
@@ -19,8 +19,8 @@ output_modules:
     token: asdf
   neo4j:
     uri: bolt://127.0.0.1:11111
-  human:
-    test_option: human
+  python:
+    test_option: asdf
 internal_modules:
   speculate:
     test_option: speculate

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -1266,6 +1266,18 @@ def test_cli(monkeypatch, bbot_config):
         assert len(lines) > 1
 
 
+def test_python_api(bbot_config):
+    from bbot.scanner import Scanner
+
+    scan1 = Scanner("127.0.0.1", config=bbot_config)
+    events1 = list(scan1.start())
+    assert any("127.0.0.1" == e for e in events1)
+    scan2 = Scanner("127.0.0.1", config=bbot_config, output_modules=["json"], name="python_api_test")
+    scan2.start_without_generator()
+    out_file = scan2.helpers.scans_dir / "python_api_test" / "output.json"
+    assert list(scan2.helpers.read_file(out_file))
+
+
 def test_depsinstaller(monkeypatch, neuter_ansible, bbot_config, bbot_scanner):
     # un-neuter ansible
     from bbot.core.helpers.depsinstaller import installer

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -264,6 +264,8 @@ def test_events(events, scan, helpers, bbot_config):
     assert http_response.source_id == scan.root_event.id
     assert http_response.data["input"] == "http://example.com"
     json_event = http_response.json()
+    assert isinstance(json_event["data"], dict)
+    json_event = http_response.json(mode="graph")
     assert isinstance(json_event["data"], str)
     assert json_event["type"] == "HTTP_RESPONSE"
     assert json_event["source"] == scan.root_event.id

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -1097,7 +1097,7 @@ def test_config(bbot_config, bbot_scanner):
     scan1.load_modules()
     assert scan1.config.plumbus == "asdf"
     assert scan1.modules["ipneighbor"].config.test_option == "ipneighbor"
-    assert scan1.modules["human"].config.test_option == "human"
+    assert scan1.modules["python"].config.test_option == "asdf"
     assert scan1.modules["speculate"].config.test_option == "speculate"
 
 


### PR DESCRIPTION
The following improvements have been made to BBOT's Python API in order to make it easier to use:

- A new "python" output module has been added which allows events to be consumed directly from the scanner (without using the `json` output module)
- `scan.start()` now yields BBOT event objects directly
- BBOT's scanner now defaults to the main BBOT config and will automatically convert the `config` argument to an OmegaConf object and merge it with the main config.