### PR TITLE
Optimized excavate hostname extraction

### DIFF
--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -216,6 +216,8 @@ def main():
 
                     scanner.start()
 
+            except bbot.core.errors.ScanError as e:
+                log_to_stderr(str(e), level="ERROR")
             except Exception:
                 raise
             finally:

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -37,7 +37,7 @@ class HostnameExtractor(BaseExtractor):
         for i, t in enumerate(dns_targets):
             if not any(x in dns_targets_set for x in excavate.helpers.domain_parents(t, include_self=True)):
                 dns_targets_set.add(t)
-                self.regexes[f"dns_name_{i+1}"] = r"(%[a-f0-9]{2})?((?:(?:[\w-]+)\.)+" + re.escape(t) + ")"
+                self.regexes[f"dns_name_{i+1}"] = r"(%[a-fA-F0-9]{2})?((?:(?:[\w-]+)\.)+" + re.escape(t) + ")"
         super().__init__(excavate)
 
     def report(self, result, name, event, **kwargs):

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -31,8 +31,10 @@ class HostnameExtractor(BaseExtractor):
     regexes = {}
 
     def __init__(self, excavate):
-        dns_targets = [t.host for t in excavate.scan.target if t.type == "DNS_NAME"]
-        dns_targets.sort(key=len)
+        dns_targets = set(t.host for t in excavate.scan.target if t.host and isinstance(t.host, str))
+        dns_whitelist = set(t.host for t in excavate.scan.whitelist if t.host and isinstance(t.host, str))
+        dns_targets.update(dns_whitelist)
+        dns_targets = sorted(dns_targets, key=len)
         dns_targets_set = set()
         for i, t in enumerate(dns_targets):
             if not any(x in dns_targets_set for x in excavate.helpers.domain_parents(t, include_self=True)):


### PR DESCRIPTION
Regexes are now only created for parent domains, e.g. so that if 500 subdomains of evilcorp.com are specified as targets, if the base domain is specified as well, only one regex will be created instead of 500.