### PR TITLE
Automate traceback debug logging

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -3,6 +3,7 @@ import logging
 import threading
 import traceback
 from time import sleep
+from sys import exc_info
 from contextlib import suppress
 
 from ..core.helpers.threadpool import ThreadPoolWrapper
@@ -557,12 +558,20 @@ class BaseModule:
 
     def warning(self, *args, **kwargs):
         self.log.warning(*args, extra={"scan_id": self.scan.id}, **kwargs)
+        self._log_traceback()
 
     def hugewarning(self, *args, **kwargs):
         self.log.hugewarning(*args, extra={"scan_id": self.scan.id}, **kwargs)
+        self._log_traceback()
 
     def error(self, *args, **kwargs):
         self.log.error(*args, extra={"scan_id": self.scan.id}, **kwargs)
+        self._log_traceback()
 
     def critical(self, *args, **kwargs):
         self.log.critical(*args, extra={"scan_id": self.scan.id}, **kwargs)
+
+    def _log_traceback(self):
+        e_type, e_val, e_traceback = exc_info()
+        if e_type is not None:
+            self.debug(traceback.format_exc())

--- a/bbot/modules/censys.py
+++ b/bbot/modules/censys.py
@@ -86,10 +86,7 @@ class censys(shodan_dns):
         except exceptions.CensysException as e:
             self.warning(f"Error with API: {e}")
         except Exception as e:
-            import traceback
-
             self.warning(f"Unknown error: {e}")
-            self.debug(traceback.format_exc())
 
         return emails, dns_names, ip_addresses
 

--- a/bbot/modules/output/http.py
+++ b/bbot/modules/output/http.py
@@ -53,7 +53,4 @@ class HTTP(BaseOutputModule):
             timeout = self.config.get("timeout", 10)
             self.session.send(r.prepare(), timeout=timeout)
         except RequestException as e:
-            import traceback
-
             self.warning(f"Error sending {event}: {e}")
-            self.debug(traceback.format_exc())

--- a/bbot/modules/output/neo4j.py
+++ b/bbot/modules/output/neo4j.py
@@ -29,9 +29,6 @@ class neo4j(BaseOutputModule):
             self.neo4j.insert_event(self.scan.root_event)
         except Exception as e:
             self.warning(f"Error setting up Neo4j: {e}")
-            import traceback
-
-            self.debug(traceback.format_exc())
             return False
         return True
 

--- a/bbot/modules/output/websocket.py
+++ b/bbot/modules/output/websocket.py
@@ -1,6 +1,5 @@
 import json
 import threading
-import traceback
 import websocket
 from time import sleep
 
@@ -46,7 +45,6 @@ class Websocket(BaseOutputModule):
                 break
             except Exception as e:
                 self.warning(f"Error sending message: {e}, retrying")
-                self.debug(traceback.format_exc())
                 sleep(1)
                 continue
 

--- a/bbot/modules/report/asn.py
+++ b/bbot/modules/report/asn.py
@@ -1,5 +1,4 @@
 import ipaddress
-import traceback
 
 from bbot.modules.report.base import ReportModule
 
@@ -85,7 +84,6 @@ class asn(ReportModule):
         except Exception as e:
             self.warning(f"Error retrieving ASN for {ip}: {e}")
             self.debug(f"Got data: {getattr(r, 'content', '')}")
-            self.debug(traceback.format_exc())
 
     def get_asn_metadata(self, asn):
         url = f"{self.base_url}/asn/{asn}"
@@ -102,4 +100,3 @@ class asn(ReportModule):
             return list(set(contacts))
         except Exception as e:
             self.warning(f"Error retrieving ASN metadata for {asn}: {e}")
-            self.debug(traceback.format_exc())

--- a/bbot/modules/urlscan.py
+++ b/bbot/modules/urlscan.py
@@ -60,7 +60,4 @@ class urlscan(crobat):
             else:
                 self.debug(f'No results for "{query}"')
         except Exception:
-            import traceback
-
             self.warning(f"Error retrieving urlscan results")
-            self.debug(traceback.format_exc())

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -48,8 +48,8 @@ class ScanManager:
             try:
                 self.queue_event(event, *args, **kwargs)
             except Exception as e:
-                self.error(f"Unexpected error in manager.emit_event(): {e}")
-                self.debug(traceback.format_exc())
+                log.error(f"Unexpected error in manager.emit_event(): {e}")
+                log.debug(traceback.format_exc())
             finally:
                 event.release_semaphore()
         else:
@@ -58,8 +58,8 @@ class ScanManager:
                 self.scan._event_thread_pool.submit_task(self.catch, self._emit_event, event, *args, **kwargs)
             except Exception as e:
                 if not isinstance(e, RuntimeError):
-                    self.error(f"Unexpected error in manager.emit_event(): {e}")
-                    self.debug(traceback.format_exc())
+                    log.error(f"Unexpected error in manager.emit_event(): {e}")
+                    log.debug(traceback.format_exc())
                 event.release_semaphore()
 
     def _emit_event(self, event, *args, **kwargs):

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -1,5 +1,7 @@
 import logging
 import threading
+import traceback
+from sys import exc_info
 from pathlib import Path
 import concurrent.futures
 from omegaconf import OmegaConf
@@ -200,14 +202,10 @@ class Scanner:
             self.error(f"{e}")
 
         except BBOTError as e:
-            import traceback
-
             self.critical(f"Error during scan: {e}")
             self.debug(traceback.format_exc())
 
         except Exception:
-            import traceback
-
             self.critical(f"Unexpected error during scan:\n{traceback.format_exc()}")
 
         finally:
@@ -452,15 +450,23 @@ class Scanner:
 
     def warning(self, *args, **kwargs):
         log.warning(*args, extra={"scan_id": self.id}, **kwargs)
+        self._log_traceback()
 
     def hugewarning(self, *args, **kwargs):
         log.hugewarning(*args, extra={"scan_id": self.id}, **kwargs)
+        self._log_traceback()
 
     def error(self, *args, **kwargs):
         log.error(*args, extra={"scan_id": self.id}, **kwargs)
+        self._log_traceback()
 
     def critical(self, *args, **kwargs):
         log.critical(*args, extra={"scan_id": self.id}, **kwargs)
+
+    def _log_traceback(self):
+        e_type, e_val, e_traceback = exc_info()
+        if e_type is not None:
+            self.debug(traceback.format_exc())
 
     def _internal_modules(self):
         for modname in module_loader.preloaded(type="internal"):
@@ -550,10 +556,7 @@ class Scanner:
                     self.verbose(f'Loaded module "{module_name}"')
                     continue
                 except Exception:
-                    import traceback
-
                     self.warning(f"Failed to load module {module_class}")
-                    self.debug(traceback.format_exc())
             else:
                 self.warning(f'Failed to load unknown module "{module_name}"')
             failed.add(module_name)


### PR DESCRIPTION
When modules raise a log message using `log.warning()` or similar, the current exception (if there is one) is now logged automatically via `log.debug()`.