### PR TITLE
Include wordlists in --install-all-deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PIP_NO_CACHE_DIR=off
 
 WORKDIR /usr/src/bbot
 
-RUN apt-get update && apt-get install -y openssl gcc git make curl wget nano
+RUN apt-get update && apt-get install -y openssl gcc git make curl wget nano sudo
 
 COPY . .
 

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -76,7 +76,7 @@ def main():
             from bbot.scanner import Scanner
 
             try:
-                if options.list_modules and not any([options.flags, options.modules]):
+                if (options.install_all_deps or options.list_modules) and not any([options.flags, options.modules]):
                     modules = set(module_loader.preloaded(type="scan"))
                 else:
                     modules = set(options.modules)
@@ -107,6 +107,9 @@ def main():
                     all_modules = list(module_loader.preloaded())
                     scanner.helpers.depsinstaller.force_deps = True
                     scanner.helpers.depsinstaller.install(*all_modules)
+                    log.info("Running module setups")
+                    scanner.prep()
+                    scanner.cleanup()
                     log.info("Finished installing module dependencies")
                     return
 

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -77,7 +77,9 @@ def main():
 
             try:
                 module_filtering = False
-                if (options.list_modules or options.install_all_deps or options.help_all) and not any([options.flags, options.modules]):
+                if (options.list_modules or options.install_all_deps or options.help_all) and not any(
+                    [options.flags, options.modules]
+                ):
                     module_filtering = True
                     modules = set(module_loader.preloaded(type="scan"))
                 else:

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -77,7 +77,7 @@ class DepsInstaller:
                         if not notified:
                             log.hugeinfo(f"Installing module dependencies. Please be patient, this may take a while.")
                             notified = True
-                        log.verbose(f'Installing dependencies for module "{m}"')
+                        log.info(f"Installing dependencies for {m}")
                         # get sudo access if we need it
                         if preloaded.get("sudo", False) == True:
                             self.ensure_root(f'Module "{m}" needs root privileges to install its dependencies.')

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -16,7 +16,16 @@ def wordlist(self, path, lines=None, **kwargs):
         raise WordlistError(f"Invalid wordlist: {path}")
     if not "cache_hrs" in kwargs:
         kwargs["cache_hrs"] = 720
+    if not "retries" in kwargs:
+        kwargs["retries"] = 1
+    # longer timeout for large wordlists
+    if not "timeout" in kwargs:
+        kwargs["timeout"] = 60
     if self.is_url(path):
+        msg = f"Downloading wordlist from {path}"
+        if lines is not None:
+            msg += f" with lines={lines}"
+        log.verbose(msg)
         filename = self.download(str(path), **kwargs)
         if filename is None:
             raise WordlistError(f"Unable to retrieve wordlist from {path}")

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -83,6 +83,7 @@ class BaseModule:
 
     def __init__(self, scan):
         self.scan = scan
+        # whether this module is in an error state
         self.errored = False
         self._log = None
         self._event_queue = None
@@ -292,11 +293,13 @@ class BaseModule:
                 msg = status_codes[status]
             self.debug(f"Finished setting up module {self.name}")
         except Exception as e:
-            self.set_error_state()
             if isinstance(e, WordlistError):
                 status = None
             msg = f"{e}"
             self.debug(traceback.format_exc())
+        finally:
+            if status == False:
+                self.set_error_state()
         return status, str(msg)
 
     @property

--- a/bbot/modules/generic_ssrf.py
+++ b/bbot/modules/generic_ssrf.py
@@ -177,13 +177,12 @@ class generic_ssrf(BaseModule):
                 self.interactsh_instance = self.helpers.interactsh()
                 self.interactsh_domain = self.interactsh_instance.register(callback=self.interactsh_callback)
             except InteractshError as e:
-                self.warning(f"Interactsh failure: {e}")
-                return False
+                return False, f"Interactsh failure: {e}"
         else:
-            self.warning(
-                "The generic_ssrf module is completely dependent on interactsh to function, but it is disabled globally. Aborting."
+            return (
+                None,
+                "The generic_ssrf module is completely dependent on interactsh to function, but it is disabled globally. Aborting.",
             )
-            return None
 
         # instantiate submodules
         for m in BaseSubmodule.__subclasses__():
@@ -232,3 +231,14 @@ class generic_ssrf(BaseModule):
         sleep(5)
         for r in self.interactsh_instance.poll():
             self.interactsh_callback(r)
+
+    def cleanup(self):
+        try:
+            self.interactsh_instance.deregister()
+            self.debug(
+                f"successfully deregistered interactsh session with correlation_id {self.interactsh_instance.correlation_id}"
+            )
+        except InteractshError as e:
+            self.warning(f"Interactsh failure: {e}")
+        except AttributeError:
+            pass

--- a/bbot/modules/host_header.py
+++ b/bbot/modules/host_header.py
@@ -21,8 +21,7 @@ class host_header(BaseModule):
                 self.interactsh_instance = self.helpers.interactsh()
                 self.interactsh_domain = self.interactsh_instance.register(callback=self.interactsh_callback)
             except InteractshError as e:
-                self.warning(f"Interactsh failure: {e}")
-                return False
+                return False, f"Interactsh failure: {e}"
         return True
 
     def interactsh_callback(self, r):
@@ -60,6 +59,8 @@ class host_header(BaseModule):
             )
         except InteractshError as e:
             self.warning(f"Interactsh failure: {e}")
+        except AttributeError:
+            pass
 
     def handle_event(self, event):
 

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -135,16 +135,6 @@ class Scanner:
     def prep(self):
         self.helpers.mkdir(self.home)
         if not self._prepped:
-            start_msg = f"Scan with {len(self._scan_modules):,} modules seeded with {len(self.target):,} targets"
-            details = []
-            if self.whitelist != self.target:
-                details.append(f"{len(self.whitelist):,} in whitelist")
-            if self.blacklist:
-                details.append(f"{len(self.blacklist):,} in blacklist")
-            if details:
-                start_msg += f" ({', '.join(details)})"
-            self.hugeinfo(start_msg)
-
             self.load_modules()
 
             self.info(f"Setting up modules...")
@@ -161,6 +151,16 @@ class Scanner:
 
         if not self.target:
             self.warning(f"No scan targets specified")
+
+        start_msg = f"Scan with {len(self._scan_modules):,} modules seeded with {len(self.target):,} targets"
+        details = []
+        if self.whitelist != self.target:
+            details.append(f"{len(self.whitelist):,} in whitelist")
+        if self.blacklist:
+            details.append(f"{len(self.blacklist):,} in blacklist")
+        if details:
+            start_msg += f" ({', '.join(details)})"
+        self.hugeinfo(start_msg)
 
         try:
             self.status = "STARTING"

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -1036,13 +1036,19 @@ def test_modules_basic(
                 type(msg) == str
             ), f"if tuple, the second element of {module.name}.setup()'s return value must be a message of type str"
         else:
-            assert result in (
+            status = result
+            assert status in (
                 True,
                 False,
                 None,
             ), f"{module.name}.setup() must return a status of either True, False, or None"
-        if result == False:
+        if status == False:
             module.set_error_state()
+
+    scan_dir_contents = scan2.home.glob("**/*")
+    assert not list(
+        scan_dir_contents
+    ), f"Scan directory was not empty after running module setups (contents: {scan_dir_contents}). Ensure that modules are not creating files or directories in their .setup() methods."
 
     futures.clear()
 


### PR DESCRIPTION
This PR will run `setup()` and `.cleanup()` for each module for `--install-all-deps` to ensure that wordlists, etc. are installed along with each module's python and ansible dependencies.