### PR TITLE
Ip tagging

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -629,7 +629,7 @@ class URL(URL_UNVERIFIED):
 
     @property
     def resolved_hosts(self):
-        return [i.split('-')[1] for i in self.tags if i.startswith('ip-')]
+        return [i.split("-")[1] for i in self.tags if i.startswith("ip-")]
 
 
 class STORAGE_BUCKET(URL_UNVERIFIED, DictEvent):

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -627,6 +627,10 @@ class URL(URL_UNVERIFIED):
             )
         return super().sanitize_data(data)
 
+    @property
+    def resolved_hosts(self):
+        return [i.split('-')[1] for i in self.tags if i.startswith('ip-')]
+
 
 class STORAGE_BUCKET(URL_UNVERIFIED, DictEvent):
     def sanitize_data(self, data):

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -59,6 +59,8 @@ class BaseEvent:
         self.__host = None
         self._port = None
         self.__words = None
+        self._resolved_hosts = set()
+
         self._made_internal = False
         # whether to force-send to output modules
         self._force_output = False
@@ -127,6 +129,14 @@ class BaseEvent:
     @property
     def data(self):
         return self._data
+
+    @property
+    def resolved_hosts(self):
+        if is_ip(self.host):
+            return {
+                self.host,
+            }
+        return self._resolved_hosts
 
     @data.setter
     def data(self, data):
@@ -369,6 +379,8 @@ class BaseEvent:
         j["scope_distance"] = self.scope_distance
         j["scan"] = self.scan.id
         j["timestamp"] = self.timestamp.timestamp()
+        if self.host:
+            j["resolved_hosts"] = [str(h) for h in self.resolved_hosts]
         source_id = self.source_id
         if source_id:
             j["source"] = source_id

--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -123,7 +123,8 @@ class httpx(BaseModule):
                 continue
 
             # main URL
-            url_event = self.make_event(url, "URL", source_event, tags=[f"status-{status_code}"])
+            httpx_ip = j.get("host", "unknown")
+            url_event = self.make_event(url, "URL", source_event, tags=[f"status-{status_code}", f"ip-{httpx_ip}"])
             if url_event and not "httpx-only" in url_event.tags:
                 if url_event != source_event:
                     self.emit_event(url_event)

--- a/bbot/modules/internal/speculate.py
+++ b/bbot/modules/internal/speculate.py
@@ -58,9 +58,14 @@ class speculate(BaseInternalModule):
         # from hosts
         if emit_open_ports:
             # don't act on unresolved DNS_NAMEs
-            if event.type == "IP_ADDRESS" or (
-                event.type == "DNS_NAME" and any([x in event.tags for x in ("a_record", "aaaa_record")])
-            ):
+
+            usable_dns = False
+            if event.type == "DNS_NAME":
+
+                if "a-record" in event.tags or "aaaa-record" in event.tags:
+                    usable_dns = True
+
+            if event.type == "IP_ADDRESS" or usable_dns:
                 self.emit_event(self.helpers.make_netloc(event.data, 80), "OPEN_TCP_PORT", source=event, internal=True)
                 self.emit_event(
                     self.helpers.make_netloc(event.data, 443), "OPEN_TCP_PORT", source=event, internal=True

--- a/bbot/modules/output/csv.py
+++ b/bbot/modules/output/csv.py
@@ -27,7 +27,9 @@ class CSV(BaseOutputModule):
     def writer(self):
         if self._writer is None:
             self._writer = csv.writer(self.file)
-            self._writer.writerow(["Event type", "Event data", "Source Module", "Scope Distance", "Event Tags"])
+            self._writer.writerow(
+                ["Event type", "Event data", "IP Address", "Source Module", "Scope Distance", "Event Tags"]
+            )
         return self._writer
 
     @property
@@ -45,6 +47,7 @@ class CSV(BaseOutputModule):
             [
                 getattr(event, "type", ""),
                 getattr(event, "data", ""),
+                ",".join(str(x) for x in getattr(event, "resolved_hosts", set())),
                 str(getattr(event, "module", "")),
                 str(getattr(event, "scope_distance", "")),
                 ",".join(sorted(list(getattr(event, "tags", [])))),

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -109,7 +109,11 @@ class ScanManager:
                     dns_tags,
                     event_whitelisted_dns,
                     event_blacklisted_dns,
+                    resolved_hosts,
                 ) = self.scan.helpers.dns.resolve_event(event)
+
+                event._resolved_hosts = resolved_hosts
+
                 event_whitelisted = event_whitelisted_dns | self.scan.whitelisted(event)
                 event_blacklisted = event_blacklisted_dns | self.scan.blacklisted(event)
                 if event.type in ("DNS_NAME", "IP_ADDRESS"):

--- a/bbot/test/test_bbot.py
+++ b/bbot/test/test_bbot.py
@@ -806,8 +806,12 @@ def test_helpers(patch_requests, helpers, scan, bbot_scanner):
     assert helpers.is_wildcard("mail.google.com") == (False, "google.com")
     wildcard_event1 = scan.make_event("wat.asdf.fdsa.github.io", "DNS_NAME", dummy=True)
     wildcard_event2 = scan.make_event("wats.asd.fdsa.github.io", "DNS_NAME", dummy=True)
-    children, event_tags1, event_whitelisted1, event_blacklisted1 = scan.helpers.resolve_event(wildcard_event1)
-    children, event_tags2, event_whitelisted2, event_blacklisted2 = scan.helpers.resolve_event(wildcard_event2)
+    children, event_tags1, event_whitelisted1, event_blacklisted1, resolved_hosts = scan.helpers.resolve_event(
+        wildcard_event1
+    )
+    children, event_tags2, event_whitelisted2, event_blacklisted2, resolved_hosts = scan.helpers.resolve_event(
+        wildcard_event2
+    )
     assert "wildcard" in event_tags1
     assert "wildcard" in event_tags2
     assert wildcard_event1.data == "_wildcard.github.io"
@@ -815,6 +819,20 @@ def test_helpers(patch_requests, helpers, scan, bbot_scanner):
     assert event_tags1 == event_tags2
     assert event_whitelisted1 == event_whitelisted2
     assert event_blacklisted1 == event_blacklisted2
+
+    # Ensure events with hosts have resolved_hosts attribute populated
+
+    resolved_hosts_event1 = scan.make_event("dns.google", "DNS_NAME", dummy=True)
+    resolved_hosts_event2 = scan.make_event("http://dns.google/", "URL_UNVERIFIED", dummy=True)
+    children, event_tags1, event_whitelisted1, event_blacklisted1, resolved_hosts1 = scan.helpers.resolve_event(
+        resolved_hosts_event1
+    )
+    children, event_tags2, event_whitelisted2, event_blacklisted2, resolved_hosts2 = scan.helpers.resolve_event(
+        resolved_hosts_event2
+    )
+
+    assert "8.8.8.8" in [str(x) for x in resolved_hosts1]
+    assert resolved_hosts_event1.resolved_hosts == resolved_hosts_event2.resolved_hosts
 
     msg = "Ignore this error, it belongs here"
 
@@ -1298,7 +1316,7 @@ def test_cli(monkeypatch, bbot_config):
     assert (scan_home / "output.json").is_file()
     with open(scan_home / "output.csv") as f:
         lines = f.readlines()
-        assert lines[0] == "Event type,Event data,Source Module,Scope Distance,Event Tags\n"
+        assert lines[0] == "Event type,Event data,IP Address,Source Module,Scope Distance,Event Tags\n"
         assert len(lines) > 1
 
 


### PR DESCRIPTION
This PR adds IP tagging to both URL events and DNS_NAME events. This adds a much needed record of the association between domains and IPs which is lost otherwise anytime NEO4J is not used.

In the case of URL events, the IP is pulled from the HTTPX output, and represents the actual IP visited - even if the domain resolves to multiple IPs. It is then added to the result in the form of a tag, like ip-127.0.0.1. This makes it greppable in all forms out output and serves as a historical record of the IP that was visited

When it comes to DNS_NAME, the IPs are recorded as a new fundamental attribute of events, called resolved_hosts. Much of the lower level code changes in this PR are related to necessary changes to support this change. This attribute is a set() so that it can handle the case when multiple IPs resolve from the domain. As far as output, the set is included in JSON output. It is also included in the CSV output module, in the form of a new column, which was also added in this PR.