### PR TITLE
bug fix in aggregate when stats were empty

### DIFF
--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -694,6 +694,9 @@ def make_table(*args, **kwargs):
     | row2      | row2      |
     +-----------+-----------+
     """
+    # fix IndexError: list index out of range
+    if args and not args[0]:
+        args = ([[]],) + args[1:]
     defaults = {"tablefmt": "grid", "disable_numparse": True, "maxcolwidths": 40}
     for k, v in defaults.items():
         if k not in kwargs:

--- a/bbot/scanner/stats.py
+++ b/bbot/scanner/stats.py
@@ -66,8 +66,9 @@ class ScanStats:
         self.perf_stats.sort(key=lambda x: x[-1])
         for callback, runtime in self.perf_stats:
             log.info(f"{callback}\t{runtime}")
-
         table = self.table()
+        if len(table) == 1:
+            table += [["None", "None", "None"]]
         return self.scan.helpers.make_table(table[1:], table[0])
 
 

--- a/bbot/scanner/stats.py
+++ b/bbot/scanner/stats.py
@@ -67,8 +67,6 @@ class ScanStats:
         for callback, runtime in self.perf_stats:
             log.info(f"{callback}\t{runtime}")
         table = self.table()
-        if len(table) == 1:
-            table += [["None", "None", "None"]]
         return self.scan.helpers.make_table(table[1:], table[0])
 
 


### PR DESCRIPTION
Fixed bug in stats.py where aggregate would try to generate a table with no values (from a scan with zero results)