### PR TITLE
Url manipulation

### DIFF
--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -163,7 +163,6 @@ class HttpCompare:
             )
             diff_conditions.append("code")
 
-
         different_headers = self.compare_headers(self.baseline.headers, subject_response.headers)
         if different_headers:
             log.debug(f"headers were different, no match [{different_headers}]")

--- a/bbot/modules/bypass403.py
+++ b/bbot/modules/bypass403.py
@@ -106,7 +106,9 @@ class bypass403(BaseModule):
                         reported_signature = f"Modified URL: {sig[1]}"
                     description = f"403 Bypass Reasons: [{','.join(reasons)}] Sig: [{reported_signature}]"
                     self.emit_event(
-                        {"description": description, "host": event.host, "url": event.data}, "FINDING", source=event
+                        {"description": description, "host": str(event.host), "url": event.data},
+                        "FINDING",
+                        source=event,
                     )
                 else:
                     self.debug(f"Status code changed to {str(subject_response.status_code)}, ignoring")

--- a/bbot/modules/bypass403.py
+++ b/bbot/modules/bypass403.py
@@ -92,7 +92,7 @@ class bypass403(BaseModule):
                 headers = dict(sig[2])
             else:
                 headers = None
-            match, reason, reflection, subject_response = compare_helper.compare(
+            match, reasons, reflection, subject_response = compare_helper.compare(
                 sig[1], headers=headers, method=sig[0], allow_redirects=True
             )
 
@@ -104,7 +104,7 @@ class bypass403(BaseModule):
                         reported_signature = f"Added Header: {added_header_tuple[0]}: {added_header_tuple[1]}"
                     else:
                         reported_signature = f"Modified URL: {sig[1]}"
-                    description = f"403 Bypass Reason: [{reason}] Sig: [{reported_signature}]"
+                    description = f"403 Bypass Reasons: [{','.join(reasons)}] Sig: [{reported_signature}]"
                     self.emit_event(
                         {"description": description, "host": event.host, "url": event.data}, "FINDING", source=event
                     )

--- a/bbot/modules/header_brute.py
+++ b/bbot/modules/header_brute.py
@@ -75,7 +75,6 @@ class header_brute(BaseModule):
             pass
 
         for result, reasons, reflection in results:
-            self.hugewarning(reasons)
 
             tags = []
             if reflection:

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -1,0 +1,80 @@
+from bbot.modules.base import BaseModule
+from bbot.core.errors import HttpCompareError
+
+# ([string]method,[string]path,[bool]strip trailing slash)
+signatures = []
+
+extensions = [
+    ".css",
+    ".js",
+    ".xls",
+    ".png",
+    ".jpg",
+    ".swf",
+    ".xml",
+    ".pdf",
+    ".gif",
+]
+
+
+# Test for abuse of extension based routing
+for ext in extensions:
+    signatures.append(("GET", "{scheme}://{netloc}/{path}?foo=%s" % ext, None, True))
+
+
+class url_manipulation(BaseModule):
+
+    watched_events = ["URL"]
+    produced_events = ["FINDING"]
+    flags = ["active", "aggressive", "web-advanced"]
+    meta = {"description": "Attempt to identify URL parsing/routing based vulnerabilities"}
+    in_scope_only = True
+
+    def handle_event(self, event):
+
+        try:
+            compare_helper = self.helpers.http_compare(event.data, allow_redirects=True)
+        except HttpCompareError as e:
+            self.debug(e)
+            return
+
+        for sig in signatures:
+
+            sig = self.format_signature(sig, event)
+            self.hugeinfo(sig[1])
+            match, reasons, reflection, subject_response = compare_helper.compare(
+                sig[1], method=sig[0], allow_redirects=True
+            )
+
+            if match == False:
+                if str(subject_response.status_code)[0] == "2":
+
+                    if "body" in reasons:
+                        reported_signature = f"Modified URL: {sig[1]}"
+                        description = f"Url Manipulation: [{','.join(reasons)}] Sig: [{reported_signature}]"
+                        self.emit_event(
+                            {"description": description, "host": event.host, "url": event.data},
+                            "FINDING",
+                            source=event,
+                        )
+                else:
+                    self.debug(f"Status code changed to {str(subject_response.status_code)}, ignoring")
+
+    def filter_event(self, event):
+
+        accepted_status_codes = ["200", "301", "302"]
+
+        for c in accepted_status_codes:
+            if f"status-{c}" in event.tags:
+                return True
+        return False
+
+    def format_signature(self, sig, event):
+        if sig[2] == True:
+            cleaned_path = event.parsed.path.strip("/")
+        else:
+            cleaned_path = event.parsed.path.lstrip("/")
+
+        kwargs = {"scheme": event.parsed.scheme, "netloc": event.parsed.netloc, "path": cleaned_path}
+        formatted_url = sig[1].format(**kwargs)
+        return (sig[0], formatted_url)

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -42,7 +42,7 @@ class url_manipulation(BaseModule):
 
             sig = self.format_signature(sig, event)
             match, reasons, reflection, subject_response = compare_helper.compare(
-                sig[1], method=sig[0], allow_redirects=True
+                sig[1], method=sig[0], allow_redirects=False
             )
 
             if match == False:

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -52,7 +52,7 @@ class url_manipulation(BaseModule):
                         reported_signature = f"Modified URL: {sig[1]}"
                         description = f"Url Manipulation: [{','.join(reasons)}] Sig: [{reported_signature}]"
                         self.emit_event(
-                            {"description": description, "host": event.host, "url": event.data},
+                            {"description": description, "host": str(event.host), "url": event.data},
                             "FINDING",
                             source=event,
                         )

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -41,7 +41,6 @@ class url_manipulation(BaseModule):
         for sig in signatures:
 
             sig = self.format_signature(sig, event)
-            self.hugeinfo(sig[1])
             match, reasons, reflection, subject_response = compare_helper.compare(
                 sig[1], method=sig[0], allow_redirects=True
             )

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -19,7 +19,7 @@ extensions = [
 
 # Test for abuse of extension based routing
 for ext in extensions:
-    signatures.append(("GET", "{scheme}://{netloc}/{path}?foo=%s" % ext, None, True))
+    signatures.append(("GET", "{scheme}://{netloc}/{path}?foo=%s" % ext, False))
 
 
 class url_manipulation(BaseModule):
@@ -46,7 +46,7 @@ class url_manipulation(BaseModule):
             )
 
             if match == False:
-                if str(subject_response.status_code)[0] == "2":
+                if str(subject_response.status_code).startswith("2"):
 
                     if "body" in reasons:
                         reported_signature = f"Modified URL: {sig[1]}"


### PR DESCRIPTION
New Module: url_manipulation

This module will uses signatures to append/modify a URL and then utilize the http_compare helper to look for changes in the body. So, for example, it will find places where adding ?foo=.css causes the traffic to be routed to an entirely different server, and therefore a different HTTP body.

This required a few modifications to the http_compare helper. Namely, I needed to modify it so that it return all of the "matching" conditions, instead of stopping when it hit one. That allowed for filtering based on the specific matching condition (header, body, or code) the was different and ignore the ones that aren't desired.

There are a few small modifications to other modules as a result of the changes to http_compare helper

The PR also includes a bug fix that applies to the bypass403 module. 