### PR TITLE
Event DNS resolution bugfix

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -227,6 +227,8 @@ class BaseModule:
                         on_success_callback=on_success_callback,
                         quick=quick,
                     )
+                except ScanCancelledError:
+                    break
                 except Exception:
                     event.release_semaphore()
                     self.error(f"Unexpected error in {self.name}.emit_event()")


### PR DESCRIPTION
Parent events must be DNS-resolved before their scope distance (and the scope distance of their children) can be calculated. Events submitted by modules need to wait for their parents to resolve before any decisions can be made about their scope distance; otherwise there would be race conditions.

This bug was incorrectly performing this dns resolution check on the event instead of the event's parent. This has been fixed. This PR also includes a performance optimization that moves the "waiting" logic into `emit_event()` so that it doesn't clog up the thread pool.