### PR TITLE
Nuclei enhance

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
 
     batch_size = 100
     options = {
-        "version": "2.7.3",
+        "version": "2.7.7",
         "tags": "",
         "templates": "",
         "severity": "",
@@ -100,7 +100,7 @@ class nuclei(BaseModule):
 
             self.budget_templates_file = self.helpers.tempfile(self.nucleibudget.collapsable_templates, pipe=False)
             self.hugeinfo(
-                f"Loaded [{str(sum(self.nucleibudget.severity_stats.values()))}] templates based on a budget of [{str(self.config.get('budget'))}]"
+                f"Loaded [{str(sum(self.nucleibudget.severity_stats.values()))}] templates based on a budget of [{str(self.config.get('budget'))}] request"
             )
             self.hugeinfo(
                 f"Template Severity: Critical [{self.nucleibudget.severity_stats['critical']}] High [{self.nucleibudget.severity_stats['high']}] Medium [{self.nucleibudget.severity_stats['medium']}] Low [{self.nucleibudget.severity_stats['low']}] Info [{self.nucleibudget.severity_stats['info']}] Unknown [{self.nucleibudget.severity_stats['unknown']}]"

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -67,7 +67,7 @@ class nuclei(BaseModule):
         else:
             self.warning("Error running nuclei template update command")
 
-        self.mode = self.config.get("mode", "technology")
+        self.mode = self.config.get("mode", "severe")
         self.ratelimit = int(self.config.get("ratelimit", 150))
         self.concurrency = int(self.config.get("concurrency", 25))
         self.budget = int(self.config.get("budget", 1))

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -98,12 +98,14 @@ class nuclei(BaseModule):
             self.info(
                 f"Running nuclei in BUDGET mode. This mode calculates which nuclei templates can be used, constrained by your 'budget' of number of requests. Current budget is set to: {self.config.get('budget')}"
             )
-            self.hugeinfo("Processing nuclei templates to perform budget calculations...")
-            self.nucleibudget = NucleiBudget(self.scan.config.get("budget", 1), nulcei_templates_dir)
 
+            self.hugeinfo("Processing nuclei templates to perform budget calculations...")
+
+            self.nucleibudget = NucleiBudget(self.config.get("budget"), nulcei_templates_dir)
             self.budget_templates_file = self.helpers.tempfile(self.nucleibudget.collapsable_templates, pipe=False)
+
             self.hugeinfo(
-                f"Loaded [{str(sum(self.nucleibudget.severity_stats.values()))}] templates based on a budget of [{str(self.config.get('budget'))}] request"
+                f"Loaded [{str(sum(self.nucleibudget.severity_stats.values()))}] templates based on a budget of [{str(self.config.get('budget'))}] request(s)"
             )
             self.hugeinfo(
                 f"Template Severity: Critical [{self.nucleibudget.severity_stats['critical']}] High [{self.nucleibudget.severity_stats['high']}] Medium [{self.nucleibudget.severity_stats['medium']}] Low [{self.nucleibudget.severity_stats['low']}] Info [{self.nucleibudget.severity_stats['info']}] Unknown [{self.nucleibudget.severity_stats['unknown']}]"
@@ -208,7 +210,6 @@ class nuclei(BaseModule):
 
 class NucleiBudget:
     def __init__(self, budget, templates_dir):
-
         self.templates_dir = templates_dir
         self.yaml_list = self.get_yaml_list()
         self.budget_paths = self.find_budget_paths(budget)

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -55,12 +55,15 @@ class nuclei(BaseModule):
         # attempt to update nuclei templates
         nulcei_templates_dir = f"{self.helpers.tools_dir}/nuclei-templates"
         update_results = self.helpers.run(["nuclei", "-update-directory", nulcei_templates_dir, "-update-templates"])
-        if "Successfully downloaded nuclei-templates" in update_results.stderr:
-            self.hugesuccess("Successfully updated nuclei templates")
-        elif "No new updates found for nuclei templates" in update_results.stderr:
-            self.hugeinfo("Nuclei templates already up-to-date")
+        if update_results.stderr:
+            if "Successfully downloaded nuclei-templates" in update_results.stderr:
+                self.hugesuccess("Successfully updated nuclei templates")
+            elif "No new updates found for nuclei templates" in update_results.stderr:
+                self.hugeinfo("Nuclei templates already up-to-date")
+            else:
+                self.hugewarning("Failure while updating nuclei templates")
         else:
-            self.hugewarning("Failed to update nuclei templates")
+            self.hugewarning("Error running nuclei template update command")
 
         self.templates = self.config.get("templates")
         self.tags = self.config.get("tags")
@@ -289,12 +292,10 @@ class NucleiBudget:
                                 severity_dict[severity] = 1
         return collapsable_templates, severity_dict
 
-    @staticmethod
-    def parse_yaml(yamlfile):
+    def parse_yaml(self, yamlfile):
         with open(yamlfile, "r") as stream:
             try:
                 y = yaml.safe_load(stream)
                 return y
-            except yaml.YAMLError as exc:
-                print(exc)
-                return none
+            except yaml.YAMLError as e:
+                self.debug(f"failed to read yaml file: {e}")

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -1,10 +1,9 @@
 import json
+import yaml
 import subprocess
-
+from pathlib import Path
+from itertools import islice
 from bbot.modules.base import BaseModule
-
-
-technology_map = {"f5 bigip": "bigip", "microsoft asp.net": "asp"}
 
 
 class nuclei(BaseModule):
@@ -24,6 +23,7 @@ class nuclei(BaseModule):
         "concurrency": 25,
         "mode": "severe",
         "etags": "intrusive",
+        "budget": 1,
     }
     options_desc = {
         "version": "nuclei version",
@@ -34,6 +34,7 @@ class nuclei(BaseModule):
         "concurrency": "maximum number of templates to be executed in parallel (default 25)",
         "mode": "technology | severe | manual. Technology: Only activate based on technology events that match nuclei tags. On by default. Severe: Only critical and high severity templates without intrusive. Manual: Fully manual settings",
         "etags": "tags to exclude from the scan",
+        "budget": "Used in budget mode to set the number of requests which will be alloted to the nuclei scan",
     }
     deps_ansible = [
         {
@@ -46,9 +47,20 @@ class nuclei(BaseModule):
             },
         }
     ]
+    deps_pip = ["pyyaml"]
     in_scope_only = True
 
     def setup(self):
+
+        # attempt to update nuclei templates
+        nulcei_templates_dir = f"{self.helpers.tools_dir}/nuclei-templates"
+        update_results = self.helpers.run(["nuclei", "-update-directory", nulcei_templates_dir, "-update-templates"])
+        if "Successfully downloaded nuclei-templates" in update_results.stderr:
+            self.hugesuccess("Successfully updated nuclei templates")
+        elif "No new updates found for nuclei templates" in update_results.stderr:
+            self.hugeinfo("Nuclei templates already up-to-date")
+        else:
+            self.hugewarning("Failed to update nuclei templates")
 
         self.templates = self.config.get("templates")
         self.tags = self.config.get("tags")
@@ -57,36 +69,15 @@ class nuclei(BaseModule):
         self.iserver = self.scan.config.get("interactsh_server", None)
         self.itoken = self.scan.config.get("interactsh_token", None)
 
-        self.template_stats = self.helpers.download(
-            "https://raw.githubusercontent.com/projectdiscovery/nuclei-templates/master/TEMPLATES-STATS.json",
-            cache_hrs=72,
-        )
-        if not self.template_stats:
-            self.warning(f"Failed to download nuclei template stats.")
-            if self.config.get("mode ") == "technology":
-                self.warning("Can't run with technology_mode set to true without template tags JSON")
-                return False
-        else:
-            with open(self.template_stats) as f:
-                self.template_stats_json = json.load(f)
-                try:
-                    self.tag_list = [e.get("name", "") for e in self.template_stats_json.get("tags", [])]
-                except Exception as e:
-                    self.warning(f"Failed to parse template stats: {e}")
-                    return False
-
-        if self.config.get("mode") not in ("technology", "severe", "manual"):
+        if self.config.get("mode") not in ("technology", "severe", "manual", "budget"):
             self.warning(f"Unable to intialize nuclei: invalid mode selected: [{self.config.get('mode')}]")
             return False
 
         if self.config.get("mode") == "technology":
             self.info(
-                "Running nuclei in TECHNOLOGY mode. Scans will only be performed against detected TECHNOLOGY events that match nuclei template tags"
+                "Running nuclei in TECHNOLOGY mode. Scans will only be performed with the --automatic-scan flag set. This limits the templates used to those that match wappalyzer signatures"
             )
-            if "wappalyzer" not in self.scan.modules:
-                self.hugewarning(
-                    "You are running nuclei in technology mode without wappalyzer to emit technologies. It will never execute unless another module is issuing technologies"
-                )
+            self.tags = ""
 
         if self.config.get("mode") == "severe":
             self.info(
@@ -99,64 +90,41 @@ class nuclei(BaseModule):
             self.info(
                 "Running nuclei in MANUAL mode. Settings will be passed directly into nuclei with no modification"
             )
+
+        if self.config.get("mode") == "budget":
+            self.info(
+                f"Running nuclei in BUDGET mode. This mode calculates which nuclei templates can be used, constrained by your 'budget' of number of requests. Current budget is set to: {self.config.get('budget')}"
+            )
+            self.hugeinfo("Processing nuclei templates to perform budget calculations...")
+            self.nucleibudget = NucleiBudget(self.scan.config.get("budget", 1), nulcei_templates_dir)
+
+            self.budget_templates_file = self.helpers.tempfile(self.nucleibudget.collapsable_templates, pipe=False)
+            self.hugeinfo(
+                f"Loaded [{str(sum(self.nucleibudget.severity_stats.values()))}] templates based on a budget of [{str(self.config.get('budget'))}]"
+            )
+            self.hugeinfo(
+                f"Template Severity: Critical [{self.nucleibudget.severity_stats['critical']}] High [{self.nucleibudget.severity_stats['high']}] Medium [{self.nucleibudget.severity_stats['medium']}] Low [{self.nucleibudget.severity_stats['low']}] Info [{self.nucleibudget.severity_stats['info']}] Unknown [{self.nucleibudget.severity_stats['unknown']}]"
+            )
+
         return True
 
     def handle_batch(self, *events):
 
-        if self.config.get("mode") == "technology":
-
-            tags_to_scan = {}
-            for e in events:
-                if e.type == "TECHNOLOGY":
-                    reported_tag = e.data.get("technology", "")
-                    if reported_tag in technology_map.keys():
-                        reported_tag = technology_map[reported_tag]
-                    if reported_tag in self.tag_list:
-                        tag = e.data.get("technology", "")
-                        if tag not in tags_to_scan.keys():
-                            tags_to_scan[tag] = [e]
-                        else:
-                            tags_to_scan[tag].append(e)
-
-            self.debug(f"finished processing this batch's tags with {str(len(tags_to_scan.keys()))} total tags")
-
-            for t in tags_to_scan.keys():
-                nuclei_input = [e.data["url"] for e in tags_to_scan[t]]
-                taglist = self.tags.split(",")
-                taglist.append(t)
-                override_tags = ",".join(taglist).lstrip(",")
-                self.verbose(f"Running nuclei against {str(len(nuclei_input))} host(s) with the {t} tag")
-                for severity, template, host, name in self.execute_nuclei(nuclei_input, override_tags=override_tags):
-                    source_event = self.correlate_event(events, host)
-                    if source_event == None:
-                        continue
-                    self.emit_event(
-                        {
-                            "severity": severity,
-                            "host": str(source_event.host),
-                            "url": host,
-                            "description": f"template: {template}, name: {name}",
-                        },
-                        "VULNERABILITY",
-                        source_event,
-                    )
-
-        else:
-            nuclei_input = [str(e.data) for e in events]
-            for severity, template, host, name in self.execute_nuclei(nuclei_input):
-                source_event = self.correlate_event(events, host)
-                if source_event == None:
-                    continue
-                self.emit_event(
-                    {
-                        "severity": severity,
-                        "host": str(source_event.host),
-                        "url": host,
-                        "description": f"template: {template}, name: {name}",
-                    },
-                    "VULNERABILITY",
-                    source_event,
-                )
+        nuclei_input = [str(e.data) for e in events]
+        for severity, template, host, name in self.execute_nuclei(nuclei_input):
+            source_event = self.correlate_event(events, host)
+            if source_event == None:
+                continue
+            self.emit_event(
+                {
+                    "severity": severity,
+                    "host": str(source_event.host),
+                    "url": host,
+                    "description": f"template: {template}, name: {name}",
+                },
+                "VULNERABILITY",
+                source_event,
+            )
 
     def correlate_event(self, events, host):
         for event in events:
@@ -164,7 +132,7 @@ class nuclei(BaseModule):
                 return event
         self.warning("Failed to correlate nuclei result with event")
 
-    def execute_nuclei(self, nuclei_input, override_tags=""):
+    def execute_nuclei(self, nuclei_input):
 
         command = [
             "nuclei",
@@ -176,6 +144,7 @@ class nuclei(BaseModule):
             self.config.get("ratelimit"),
             "-concurrency",
             str(self.config.get("concurrency")),
+            "-duc",
             # "-r",
             # self.helpers.resolver_file,
         ]
@@ -187,18 +156,21 @@ class nuclei(BaseModule):
                 command.append(f"-{cli_option}")
                 command.append(option)
 
-        if override_tags:
+        setup_tags = getattr(self, "tags")
+        if setup_tags:
             command.append(f"-tags")
-            command.append(override_tags)
-        else:
-            setup_tags = getattr(self, "tags")
-            if setup_tags:
-                command.append(f"-tags")
-                command.append(setup_tags)
+            command.append(setup_tags)
 
         if self.scan.config.get("interactsh_disable") == True:
             self.info("Disbling interactsh in accordance with global settings")
             command.append("-no-interactsh")
+
+        if self.config.get("mode") == "technology":
+            command.append("-as")
+
+        if self.config.get("mode") == "budget":
+            command.append("-t")
+            command.append(self.budget_templates_file)
 
         for line in self.helpers.run_live(command, input=nuclei_input, stderr=subprocess.DEVNULL):
             try:
@@ -229,3 +201,100 @@ class nuclei(BaseModule):
     def cleanup(self):
         resume_file = self.helpers.current_dir / "resume.cfg"
         resume_file.unlink(missing_ok=True)
+
+
+class NucleiBudget:
+    def __init__(self, budget, templates_dir):
+
+        self.templates_dir = templates_dir
+        self.yaml_list = self.get_yaml_list()
+        self.budget_paths = self.find_budget_paths(budget)
+        self.collapsable_templates, self.severity_stats = self.find_collapsable_templates()
+
+    def get_yaml_list(self):
+        return list(Path(self.templates_dir).rglob("*.yaml"))
+
+    # Given the current budget setting, scan all of the templates for paths, sort them by frequency and select the first N (budget) items
+    def find_budget_paths(self, budget):
+        path_frequency = {}
+        for yf in self.yaml_list:
+            if yf:
+                for paths in self.get_yaml_request_attr(yf, "path"):
+                    for path in paths:
+                        if path in path_frequency.keys():
+                            path_frequency[path] += 1
+                        else:
+                            path_frequency[path] = 1
+
+        sorted_dict = dict(sorted(path_frequency.items(), key=lambda item: item[1], reverse=True))
+        return list(dict(islice(sorted_dict.items(), budget)).keys())
+
+    def get_yaml_request_attr(self, yf, attr):
+        p = self.parse_yaml(yf)
+        requests = p.get("requests", [])
+        for r in requests:
+            raw = r.get("raw")
+            if not raw:
+                res = r.get(attr)
+                yield res
+
+    def get_yaml_info_attr(self, yf, attr):
+        p = self.parse_yaml(yf)
+        info = p.get("info", [])
+        res = info.get(attr)
+        yield res
+
+    # Parse through all templates and locate those which match the conditions necessary to collapse down to the budget setting
+    def find_collapsable_templates(self):
+        collapsable_templates = []
+        severity_dict = {}
+        for yf in self.yaml_list:
+            valid = True
+            if yf:
+                for paths in self.get_yaml_request_attr(yf, "path"):
+                    if set(paths).issubset(self.budget_paths):
+
+                        headers = self.get_yaml_request_attr(yf, "headers")
+                        for header in headers:
+                            if header:
+                                valid = False
+
+                        method = self.get_yaml_request_attr(yf, "method")
+                        for m in method:
+                            if m != "GET":
+                                valid = False
+
+                        max_redirects = self.get_yaml_request_attr(yf, "max-redirects")
+                        for mr in max_redirects:
+                            if mr:
+                                valid = False
+
+                        redirects = self.get_yaml_request_attr(yf, "redirects")
+                        for rd in redirects:
+                            if rd:
+                                valid = False
+
+                        cookie_reuse = self.get_yaml_request_attr(yf, "cookie-reuse")
+                        for c in cookie_reuse:
+                            if c:
+                                valid = False
+
+                        if valid:
+                            collapsable_templates.append(str(yf))
+                            severity_gen = self.get_yaml_info_attr(yf, "severity")
+                            severity = next(severity_gen)
+                            if severity in severity_dict.keys():
+                                severity_dict[severity] += 1
+                            else:
+                                severity_dict[severity] = 1
+        return collapsable_templates, severity_dict
+
+    @staticmethod
+    def parse_yaml(yamlfile):
+        with open(yamlfile, "r") as stream:
+            try:
+                y = yaml.safe_load(stream)
+                return y
+            except yaml.YAMLError as exc:
+                print(exc)
+                return none

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -9,7 +9,7 @@ from bbot.modules.base import BaseModule
 class nuclei(BaseModule):
 
     watched_events = ["URL", "TECHNOLOGY"]
-    produced_events = ["VULNERABILITY"]
+    produced_events = ["FINDING", "VULNERABILITY"]
     flags = ["active", "aggressive", "web-advanced"]
     meta = {"description": "Fast and customisable vulnerability scanner"}
 
@@ -120,16 +120,27 @@ class nuclei(BaseModule):
             source_event = self.correlate_event(events, host)
             if source_event == None:
                 continue
-            self.emit_event(
-                {
-                    "severity": severity,
-                    "host": str(source_event.host),
-                    "url": host,
-                    "description": f"template: {template}, name: {name}",
-                },
-                "VULNERABILITY",
-                source_event,
-            )
+            if severity == "INFO":
+                self.emit_event(
+                    {
+                        "host": str(source_event.host),
+                        "url": host,
+                        "description": f"template: {template}, name: {name}",
+                    },
+                    "FINDING",
+                    source_event,
+                )
+            else:
+                self.emit_event(
+                    {
+                        "severity": severity,
+                        "host": str(source_event.host),
+                        "url": host,
+                        "description": f"template: {template}, name: {name}",
+                    },
+                    "VULNERABILITY",
+                    source_event,
+                )
 
     def correlate_event(self, events, host):
         for event in events:


### PR DESCRIPTION
* I have replaced the previous technology mode with instead just calling nuclei's -as option. This does essentially the same thing but relieves us of the complication of mapping wappalyzer tags. This significantly reduces the complexity of the module and prevents potential maintenance issues. 

* Adding a bunch of complication back in with a new mode called "budget" mode. Essentially, it works like this: You specify how many requests you'd like to allot nuclei. Lets say you choose 1. It will parse through the entire nuclei template library and keep track of every template, and it's paths. Then, using similar logic to what nuclei does to collapse the templates, it determines the maximum number of templates will run using only 1 request by choosing those with the most popular path. This allows for taking advantage if the very low cost of 1 additional http request per URL to gain 400+ templates "for free". The number of additional templates starts to diminish quickly, and before long, its a 1-1 mapping when you arrive at templates which have unique paths in them. But its a nice way to tack on some extra potential to a scan while still keeping it lean. 

* Made INFO events report as a FINDING instead of a VULNERABILY, in keeping with the nomenclature previously established of the high bar for events to be vulnerabilities.

* Added functionality to allow for the nuclei templates to be automatically updated during setup(). 