### PR TITLE
Remove Viewdns from subdomain-enum group

### DIFF
--- a/bbot/modules/azure_tenant.py
+++ b/bbot/modules/azure_tenant.py
@@ -6,7 +6,7 @@ from .viewdns import viewdns
 class azure_tenant(viewdns):
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
-    flags = ["subdomain-enum", "passive", "safe"]
+    flags = ["affiliates", "subdomain-enum", "passive", "safe"]
     meta = {"description": "Query Azure for tenant sister domains"}
 
     base_url = "https://autodiscover-s.outlook.com"

--- a/bbot/modules/builtwith.py
+++ b/bbot/modules/builtwith.py
@@ -17,7 +17,7 @@ class builtwith(shodan_dns):
 
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
-    flags = ["subdomain-enum", "passive", "safe"]
+    flags = ["affiliates", "subdomain-enum", "passive", "safe"]
     meta = {"description": "Query Builtwith.com for subdomains", "auth_required": True}
     options = {"api_key": "", "redirects": True}
     options_desc = {"api_key": "Builtwith API key", "redirects": "Also look up inbound and outbound redirects"}

--- a/bbot/modules/sslcert.py
+++ b/bbot/modules/sslcert.py
@@ -12,7 +12,7 @@ from bbot.core.helpers.threadpool import NamedLock
 class sslcert(BaseModule):
     watched_events = ["OPEN_TCP_PORT"]
     produced_events = ["DNS_NAME", "EMAIL_ADDRESS"]
-    flags = ["subdomain-enum", "email-enum", "active", "safe"]
+    flags = ["affiliates", "subdomain-enum", "email-enum", "active", "safe"]
     meta = {
         "description": "Visit open ports and retrieve SSL certificates",
     }

--- a/bbot/modules/viewdns.py
+++ b/bbot/modules/viewdns.py
@@ -8,7 +8,7 @@ class viewdns(BaseModule):
 
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
-    flags = ["subdomain-enum", "passive", "safe"]
+    flags = ["affiliates", "passive", "safe"]
     meta = {
         "description": "Query viewdns.info's reverse whois for related domains",
     }

--- a/bbot/modules/zoomeye.py
+++ b/bbot/modules/zoomeye.py
@@ -4,7 +4,7 @@ from bbot.modules.shodan_dns import shodan_dns
 class zoomeye(shodan_dns):
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
-    flags = ["subdomain-enum", "passive", "safe"]
+    flags = ["affiliates", "subdomain-enum", "passive", "safe"]
     meta = {"description": "Query ZoomEye's API for subdomains", "auth_required": True}
     options = {"api_key": "", "max_pages": 20, "include_related": False}
     options_desc = {


### PR DESCRIPTION
Viewdns sometimes produces large amounts of garbage data, so its `subdomain-enum` flag has been removed, and a new one called `affiliates` has been added instead.