### PR TITLE
Wildcard rework

### DIFF
--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -192,12 +192,16 @@ def main():
                 if options.help_all:
                     log_fn(parser.format_help())
 
-                log_fn("\n### MODULES ###\n")
+                log_fn("")
+                log_fn("### MODULES ###")
+                log_fn("")
                 for row in module_loader.modules_table(modules=help_modules).splitlines():
                     log_fn(row)
 
                 if options.help_all:
-                    log_fn("\n### MODULE OPTIONS ###\n")
+                    log_fn("")
+                    log_fn("### MODULE OPTIONS ###")
+                    log_fn("")
                     for row in module_loader.modules_options_table(modules=help_modules).splitlines():
                         log_fn(row)
 

--- a/bbot/core/helpers/dns.py
+++ b/bbot/core/helpers/dns.py
@@ -301,7 +301,7 @@ class DNSHelper:
                     wildcard_rdtypes_set = set(wildcard_rdtypes)
                     # consider the event a full wildcard if all its records are wildcards
                     event_is_wildcard = all(r in wildcard_rdtypes_set for r in resolved_rdtypes)
-                    if event_is_wildcard and event.type in ("DNS_NAME",):
+                    if event_is_wildcard and event.type in ("DNS_NAME",) and not "_wildcard" in event.data.split("."):
                         wildcard_parent = self.parent_helper.parent_domain(event_host)
                         for rdtype, (_is_wildcard, _parent_domain) in wildcard_rdtypes.items():
                             if _is_wildcard:

--- a/bbot/db/neo4j.py
+++ b/bbot/db/neo4j.py
@@ -17,20 +17,7 @@ class Neo4j:
         self.graph = py2neo.Graph(uri=uri, auth=(username, password))
 
     def insert_event(self, event):
-        event_json = event.json(mode="graph")
-        source_id = event_json.get("source", "")
-        if not source_id:
-            log.warning(f"Skipping event without source: {event}")
-            return
-        source_type = source_id.split(":")[0]
-        source_node = self.make_node({"type": source_type, "id": source_id})
-
-        module = event_json.pop("module", "TARGET")
-        timestamp = datetime.fromtimestamp(event_json.pop("timestamp"))
-        event_node = self.make_node(event_json)
-
-        relationship = py2neo.Relationship(source_node, module, event_node, timestamp=timestamp)
-        self.graph.merge(relationship)
+        self.insert_events([event])
 
     def insert_events(self, events):
         event_nodes = dict()

--- a/bbot/modules/crobat.py
+++ b/bbot/modules/crobat.py
@@ -36,8 +36,12 @@ class crobat(BaseModule):
         query = self.make_query(event)
         if self.already_processed(query):
             return False
-        is_wildcard = self.helpers.is_wildcard_domain(query)
-        if is_wildcard != False:
+        # discard dns-names with errors
+        if any([t in event.tags for t in ("a-error", "aaaa-error")]):
+            return False
+        # discard wildcards
+        wildcard_rdtypes = self.helpers.is_wildcard_domain(query)
+        if any([t in wildcard_rdtypes for t in ("A", "AAAA")]):
             return False
         self.processed.add(hash(query))
         return True

--- a/bbot/modules/crobat.py
+++ b/bbot/modules/crobat.py
@@ -70,9 +70,10 @@ class crobat(BaseModule):
 
     def make_query(self, event):
         if "target" in event.tags:
-            return str(event.data)
+            query = str(event.data)
         else:
-            return self.helpers.parent_domain(event.data).lower()
+            query = self.helpers.parent_domain(event.data).lower()
+        return ".".join([s for s in query.split(".") if s != "_wildcard"])
 
     def parse_results(self, r, query=None):
         json = r.json()

--- a/bbot/modules/dnscommonsrv.py
+++ b/bbot/modules/dnscommonsrv.py
@@ -97,8 +97,8 @@ class dnscommonsrv(BaseModule):
     max_event_handlers = 10
 
     def filter_event(self, event):
-        is_wildcard, _ = self.helpers.is_wildcard(event.host)
-        if is_wildcard != False:
+        # skip SRV wildcards
+        if "SRV" in self.helpers.is_wildcard(event.host):
             return False
         return True
 

--- a/bbot/modules/massdns.py
+++ b/bbot/modules/massdns.py
@@ -36,6 +36,7 @@ class massdns(crobat):
             "copy": {"src": "#{BBOT_TEMP}/massdns/bin/massdns", "dest": "#{BBOT_TOOLS}/", "mode": "u+x,g+x,o+x"},
         },
     ]
+    _qsize = 100
 
     def setup(self):
         self.found = dict()
@@ -137,6 +138,7 @@ class massdns(crobat):
             "-q",
         )
         subdomains = self.gen_subdomains(subdomains, domain)
+        hosts_yielded = set()
         for line in self.helpers.run_live(command, stderr=subprocess.DEVNULL, input=subdomains):
             try:
                 j = json.loads(line)
@@ -144,19 +146,25 @@ class massdns(crobat):
                 self.debug(f"Failed to decode line: {line}")
                 continue
             answers = j.get("data", {}).get("answers", [])
-            if type(answers) == list:
-                for answer in answers:
-                    hostname = answer.get("name", "")
-                    if hostname:
-                        data = answer.get("data", "")
-                        # avoid garbage answers like this:
-                        # 8AAAA queries have been locally blocked by dnscrypt-proxy/Set block_ipv6 to false to disable this feature
-                        if not " " in data:
-                            is_wildcard, _ = self.helpers.is_wildcard(hostname, ips=(data,))
-                            rdtype = answer.get("type", "").upper()
-                            # as long as it's not a wildcard we're okay
-                            if rdtype not in ("A", "AAAA") or is_wildcard == False:
-                                yield hostname.rstrip(".")
+            if type(answers) == list and len(answers) > 0:
+                answer = answers[0]
+                hostname = answer.get("name", "")
+                if hostname:
+                    data = answer.get("data", "")
+                    rdtype = answer.get("type", "").upper()
+                    # avoid garbage answers like this:
+                    # 8AAAA queries have been locally blocked by dnscrypt-proxy/Set block_ipv6 to false to disable this feature
+                    if data and rdtype and not " " in data:
+                        # skip wildcards
+                        wildcard_rdtypes = self.helpers.is_wildcard(hostname, ips=(data,))
+                        if rdtype in wildcard_rdtypes:
+                            self.debug(f"Skipping {hostname}:{rdtype} because it's a wildcard")
+                            continue
+                        hostname = hostname.rstrip(".").lower()
+                        hostname_hash = hash(hostname)
+                        if hostname_hash not in hosts_yielded:
+                            hosts_yielded.add(hostname_hash)
+                            yield hostname
 
     def finish(self):
         found = list(self.found.items())

--- a/bbot/modules/massdns.py
+++ b/bbot/modules/massdns.py
@@ -49,7 +49,7 @@ class massdns(crobat):
         return ret
 
     def filter_event(self, event):
-        if "unresolved" in event.tags:
+        if "unresolved" in event.tags and not "target" in event.tags:
             return False
         query = self.make_query(event)
         if self.already_processed(query):
@@ -62,11 +62,6 @@ class massdns(crobat):
         h = hash(query)
         if not h in self.source_events:
             self.source_events[h] = event
-
-        # make sure base query resolves
-        if not self.helpers.resolve(query, type="any"):
-            self.debug(f"Skipping unresolved query: {query}")
-            return
 
         self.info(f"Brute-forcing subdomains for {query}")
         for hostname in self.massdns(query, self.helpers.read_file(self.subdomain_file)):

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -35,7 +35,8 @@ class ScanManager:
         seed scanner with target events
         """
         self.distribute_event(self.scan.root_event)
-        for event in self.scan.target.events:
+        sorted_events = sorted(self.scan.target.events, key=lambda e: len(e.data))
+        for event in sorted_events:
             self.scan.verbose(f"Target: {event}")
             self.emit_event(event)
         # force submit batches


### PR DESCRIPTION
This PR updates BBOT's wildcard detection to account for non-A/AAAA wildcards. Wildcard checks are now performed against all possible record types, including A, AAAA, CNAME, NS, SRV, etc.

Wildcard domains are now tagged with record-specific tags in addition to `wildcard`, such as `aaaa-wildcard`, `ns-wildcard`, etc. 

DNS errors have received the same treatment. Now, instead of a generic `dns-error` tag, an errored hostname will be tagged with the specific lookup type that failed, e.g. `aaaa-error` or `ns-error`.