### PR TITLE
Fix start scanner from gui

### DIFF
--- a/bbot/agent/agent.py
+++ b/bbot/agent/agent.py
@@ -176,7 +176,7 @@ class Agent:
 
     def _start_scan(self, scan):
         try:
-            scan.start()
+            scan.start_without_generator()
         except bbot.core.errors.ScanError as e:
             log.error(f"Scan error: {e}")
             log.trace(traceback.format_exc())


### PR DESCRIPTION
when we were getting the scanners to work from the gui, the threads getting kicked off from bbot/agent needed to call a different start function