### PR TITLE
Iis shortnames better detection

### DIFF
--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -18,7 +18,7 @@ class ffuf(BaseModule):
         "max_depth": 0,
         "version": "1.5.0",
         "extensions": "",
-        "ignore_redirects": False,
+        "ignore_redirects": True,
     }
 
     options_desc = {
@@ -27,7 +27,7 @@ class ffuf(BaseModule):
         "max_depth": "the maxium directory depth to attempt to solve",
         "version": "ffuf version",
         "extensions": "Optionally include a list of extensions to extend the keyword with (comma separated)",
-        "ignore_redirects": "Explicitly ignore redirects. Enable if getting a excessive false positives.",
+        "ignore_redirects": "Explicitly ignore redirects (301,302)",
     }
 
     blacklist = ["images", "css", "image"]

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -18,7 +18,7 @@ class ffuf_shortnames(ffuf):
         "max_depth": 1,
         "version": "1.5.0",
         "extensions": "",
-        "ignore_redirects": False,
+        "ignore_redirects": True,
     }
 
     options_desc = {

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -28,7 +28,7 @@ class ffuf_shortnames(ffuf):
         "max_depth": "the maxium directory depth to attempt to solve",
         "version": "ffuf version",
         "extensions": "Optionally include a list of extensions to extend the keyword with (comma separated)",
-        "ignore_redirects": "Explicitly ignore redirects. Enable if getting a excessive false positives.",
+        "ignore_redirects": "Explicitly ignore redirects (301,302)",
     }
 
     in_scope_only = True

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -184,12 +184,12 @@ class iis_shortnames(BaseModule):
                             method, normalized_url, f"{y}.", affirmative_status_code, extension_mode=True
                         )
                         for z in file_name_extension_hints:
+                            if z.endswith("."):
+                                z = z.rstrip(".")
                             self.verbose(f"Found new file URL_HINT: {z} from node {normalized_url}")
                             url_hint_list.append(z)
 
                     for url_hint in url_hint_list:
-                        if url_hint.endswith("."):
-                            url_hint = url_hint.rstrip(".")
                         if "." in url_hint:
                             hint_type = "shortname-file"
                         else:

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -164,3 +164,7 @@ class iis_shortnames(BaseModule):
                         else:
                             hint_type = "shortname-directory"
                         self.emit_event(f"{normalized_url}/{url_hint}", "URL_HINT", event, tags=[hint_type])
+
+        def filter_event(self, event):
+            if "dir" in event.tags:
+                return True


### PR DESCRIPTION
It turns out there are tons of edge cases where you can exploit iis_shortnames where codes other than 400/404 are given. This fix will let the module work against any combination of status codes where the control and test URLs differ.