### PR TITLE
fixing false positives caused by cookies being tracked over multiple requests

### DIFF
--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -1,4 +1,5 @@
 import re
+from requests import Session
 
 from bbot.modules.base import BaseModule
 
@@ -31,8 +32,12 @@ class iis_shortnames(BaseModule):
         test_url = f"{target}*~1*/a.aspx"
 
         for method in ["GET", "POST", "OPTIONS", "DEBUG", "HEAD", "TRACE"]:
-            control = self.helpers.request(method=method, url=control_url, allow_redirects=False, retries=2)
-            test = self.helpers.request(method=method, url=test_url, allow_redirects=False, retries=2)
+            control = self.helpers.request(
+                method=method, url=control_url, allow_redirects=False, retries=2, session=Session()
+            )
+            test = self.helpers.request(
+                method=method, url=test_url, allow_redirects=False, retries=2, session=Session()
+            )
             if (control != None) and (test != None):
                 if control.status_code != test.status_code:
                     technique = f"{str(control.status_code)}/{str(test.status_code)} HTTP Code"
@@ -48,7 +53,9 @@ class iis_shortnames(BaseModule):
     def directory_confirm(self, target, method, url_hint, affirmative_status_code):
         payload = encode_all(f"{url_hint}")
         url = f"{target}{payload}"
-        directory_confirm_result = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2)
+        directory_confirm_result = self.helpers.request(
+            method=method, url=url, allow_redirects=False, retries=2, session=Session()
+        )
 
         if directory_confirm_result.status_code == affirmative_status_code:
             return True
@@ -65,7 +72,9 @@ class iis_shortnames(BaseModule):
             payload = encode_all(f"{base_hint}~{str(count)}*")
             url = f"{target}{payload}{suffix}"
 
-            duplicate_check_results = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2)
+            duplicate_check_results = self.helpers.request(
+                method=method, url=url, allow_redirects=False, retries=2, session=Session()
+            )
             if duplicate_check_results.status_code != affirmative_status_code:
                 break
             else:
@@ -79,7 +88,7 @@ class iis_shortnames(BaseModule):
         return duplicates
 
     def threaded_request(self, method, url, affirmative_status_code):
-        r = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2)
+        r = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2, session=Session())
         if r is not None:
             if r.status_code == affirmative_status_code:
                 return True
@@ -116,7 +125,7 @@ class iis_shortnames(BaseModule):
                 wildcard = "~1*"
                 payload = encode_all(f"{prefix}{c}{wildcard}")
                 url = f"{target}{payload}{suffix}"
-                r = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2)
+                r = self.helpers.request(method=method, url=url, allow_redirects=False, retries=2, session=Session())
                 if r is not None:
                     if r.status_code == affirmative_status_code:
                         url_hint_list.append(f"{prefix}{c}")


### PR DESCRIPTION
Requests was tracking cookies/sessions, the cookies assigned and resent automatically were interfering with the shortname detection process in some cases, such as when the website is behind an F5 w/authentication