### PR TITLE
Reuse httpx client (without persisting cookies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ BBOT is inspired by [Spiderfoot](https://github.com/smicallef/spiderfoot) but ta
 
 BBOT typically outperforms other subdomain enumeration tools by 20-25%. To learn how this is possible, see [How It Works](https://www.blacklanternsecurity.com/bbot/how_it_works/).
 
+## [Documenation](https://www.blacklanternsecurity.com/bbot/)
+
 ## Installation ([pip](https://pypi.org/project/bbot/))
 
 For more installation methods including [Docker](https://hub.docker.com/r/blacklanternsecurity/bbot), see [Installation](https://www.blacklanternsecurity.com/bbot/#installation).
@@ -34,7 +36,7 @@ bbot --help
 
 ## Example Commands
 
-Scan output, logs, etc. are saved to `~/.bbot`. For more detailed examples and explanations, see [Scanning](https://www.blacklanternsecurity.com/scanning).
+Scan output, logs, etc. are saved to `~/.bbot`. For more detailed examples and explanations, see [Scanning](https://www.blacklanternsecurity.com/bbot/scanning).
 
 <!-- BBOT EXAMPLE COMMANDS -->
 **Subdomains:**
@@ -82,14 +84,14 @@ bbot -t evilcorp.com -f subdomain-enum email-enum cloud-enum web-basic -m nmap g
 
 ## Targets
 
-BBOT accepts an unlimited number of targets which you can specify either directly on the command line or in files (or both!). Targets can be any of the following:
+BBOT accepts an unlimited number of targets. You can specify targets either directly on the command line or in files (or both!). Targets can be any of the following:
 
 - DNS_NAME (`evilcorp.com`)
 - IP_ADDRESS (`1.2.3.4`)
 - IP_RANGE (`1.2.3.0/24`)
 - URL (`https://www.evilcorp.com`)
 
-For more information, see [Targets](https://www.blacklanternsecurity.com/scanning/#targets-t). To learn how BBOT handles scope, see [Scope](https://www.blacklanternsecurity.com/scanning/#scope).
+For more information, see [Targets](https://www.blacklanternsecurity.com/bbot/scanning/#targets-t). To learn how BBOT handles scope, see [Scope](https://www.blacklanternsecurity.com/bbot/scanning/#scope).
 
 ## BBOT as a Python library
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ BBOT is inspired by [Spiderfoot](https://github.com/smicallef/spiderfoot) but ta
 
 BBOT typically outperforms other subdomain enumeration tools by 20-25%. To learn how this is possible, see [How It Works](https://www.blacklanternsecurity.com/bbot/how_it_works/).
 
-## [Documentation](https://www.blacklanternsecurity.com/bbot/)
+## Full Documentation [Here](https://www.blacklanternsecurity.com/bbot/).
 
 ## Installation ([pip](https://pypi.org/project/bbot/))
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ BBOT is inspired by [Spiderfoot](https://github.com/smicallef/spiderfoot) but ta
 
 BBOT typically outperforms other subdomain enumeration tools by 20-25%. To learn how this is possible, see [How It Works](https://www.blacklanternsecurity.com/bbot/how_it_works/).
 
-## [Documenation](https://www.blacklanternsecurity.com/bbot/)
+## [Documentation](https://www.blacklanternsecurity.com/bbot/)
 
 ## Installation ([pip](https://pypi.org/project/bbot/))
 

--- a/bbot/core/helpers/names_generator.py
+++ b/bbot/core/helpers/names_generator.py
@@ -25,6 +25,7 @@ adjectives = [
     "childish",
     "chiseled",
     "cold",
+    "condescending",
     "considerate",
     "constipated",
     "contentious",

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -73,15 +73,8 @@ class WebHelper:
     For making HTTP requests
     """
 
-    client_options = (
-        "auth",
-        "params",
-        "headers",
+    client_only_options = (
         "retries",
-        "cookies",
-        "verify",
-        "timeout",
-        "follow_redirects",
         "max_redirects",
     )
 
@@ -121,6 +114,14 @@ class WebHelper:
 
         if not args and "method" not in kwargs:
             kwargs["method"] = "GET"
+
+        client_kwargs = {}
+        for k in list(kwargs):
+            if k in self.client_only_options:
+                v = kwargs.pop(k)
+                client_kwargs[k] = v
+        if client_kwargs:
+            client = self.AsyncClient(**client_kwargs)
 
         try:
             if self.http_debug:

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -7,15 +7,32 @@ import traceback
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+from httpx._models import Cookies
+
 from bbot.core.errors import WordlistError, CurlError
 from bbot.core.helpers.ratelimiter import RateLimiter
 
 log = logging.getLogger("bbot.core.helpers.web")
 
 
+class DummyCookies(Cookies):
+    """
+    Class to disable cookie parsing
+    """
+    def extract_cookies(self, *args, **kwargs):
+        pass
+
+
 class BBOTAsyncClient(httpx.AsyncClient):
     def __init__(self, *args, **kwargs):
+
         self._bbot_scan = kwargs.pop("_bbot_scan")
+
+        http_debug = self._bbot_scan.config.get("http_debug", None)
+        if http_debug:
+            log.debug(f"Creating AsyncClient: {args}, {kwargs}")
+
+        self._persist_cookies = kwargs.pop("persist_cookies", True)
 
         # timeout
         http_timeout = self._bbot_scan.config.get("http_timeout", 20)
@@ -35,11 +52,9 @@ class BBOTAsyncClient(httpx.AsyncClient):
         proxies = self._bbot_scan.config.get("http_proxy", None)
         kwargs["proxies"] = proxies
 
-        http_debug = self._bbot_scan.config.get("http_debug", None)
-        if http_debug:
-            log.debug(f"Creating AsyncClient: {args}, {kwargs}")
-
         super().__init__(*args, **kwargs)
+        if not self._persist_cookies:
+            self._cookies = DummyCookies()
 
     def build_request(self, *args, **kwargs):
         request = super().build_request(*args, **kwargs)
@@ -75,6 +90,7 @@ class WebHelper:
         self.ssl_verify = self.parent_helper.config.get("ssl_verify", False)
         self.web_requests_per_second = self.parent_helper.config.get("web_requests_per_second", 50)
         self.web_rate_limiter = RateLimiter(self.web_requests_per_second, "Web")
+        self.web_client = self.AsyncClient(persist_cookies=False)
 
     def AsyncClient(self, *args, **kwargs):
         kwargs["_bbot_scan"] = self.parent_helper.scan
@@ -87,6 +103,8 @@ class WebHelper:
         raise_error = kwargs.pop("raise_error", False)
         # TODO: use this
         cache_for = kwargs.pop("cache_for", None)  # noqa
+
+        client = kwargs.get("client", self.web_client)
 
         # allow vs follow, httpx why??
         allow_redirects = kwargs.pop("allow_redirects", None)
@@ -103,52 +121,46 @@ class WebHelper:
         if not args and "method" not in kwargs:
             kwargs["method"] = "GET"
 
-        client_kwargs = {}
-        for k in list(kwargs):
-            if k in self.client_options:
-                v = kwargs.pop(k)
-                client_kwargs[k] = v
-        async with self.AsyncClient(**client_kwargs) as client:
-            try:
-                if self.http_debug:
-                    logstr = f"Web request: {str(args)}, {str(kwargs)}"
-                    log.debug(logstr)
-                async with self.web_rate_limiter:
-                    response = await client.request(*args, **kwargs)
-                if self.http_debug:
-                    log.debug(
-                        f"Web response: {response} (Length: {len(response.content)}) headers: {response.headers}"
-                    )
-                return response
-            except httpx.TimeoutException:
-                log.verbose(f"HTTP timeout to URL: {url}")
-                if raise_error:
-                    raise
-            except httpx.ConnectError:
-                log.verbose(f"HTTP connect failed to URL: {url}")
-                if raise_error:
-                    raise
-            except httpx.RequestError as e:
-                log.trace(f"Error with request to URL: {url}: {e}")
-                log.trace(traceback.format_exc())
-                if raise_error:
-                    raise
-            except ssl.SSLError as e:
-                msg = f"SSL error with request to URL: {url}: {e}"
-                log.trace(msg)
-                log.trace(traceback.format_exc())
-                if raise_error:
-                    raise httpx.RequestError(msg)
-            except anyio.EndOfStream as e:
-                msg = f"AnyIO error with request to URL: {url}: {e}"
-                log.trace(msg)
-                log.trace(traceback.format_exc())
-                if raise_error:
-                    raise httpx.RequestError(msg)
-            except BaseException as e:
-                log.trace(f"Unhandled exception with request to URL: {url}: {e}")
-                log.trace(traceback.format_exc())
+        try:
+            if self.http_debug:
+                logstr = f"Web request: {str(args)}, {str(kwargs)}"
+                log.debug(logstr)
+            async with self.web_rate_limiter:
+                response = await client.request(*args, **kwargs)
+            if self.http_debug:
+                log.debug(
+                    f"Web response: {response} (Length: {len(response.content)}) headers: {response.headers}"
+                )
+            return response
+        except httpx.TimeoutException:
+            log.verbose(f"HTTP timeout to URL: {url}")
+            if raise_error:
                 raise
+        except httpx.ConnectError:
+            log.verbose(f"HTTP connect failed to URL: {url}")
+            if raise_error:
+                raise
+        except httpx.RequestError as e:
+            log.trace(f"Error with request to URL: {url}: {e}")
+            log.trace(traceback.format_exc())
+            if raise_error:
+                raise
+        except ssl.SSLError as e:
+            msg = f"SSL error with request to URL: {url}: {e}"
+            log.trace(msg)
+            log.trace(traceback.format_exc())
+            if raise_error:
+                raise httpx.RequestError(msg)
+        except anyio.EndOfStream as e:
+            msg = f"AnyIO error with request to URL: {url}: {e}"
+            log.trace(msg)
+            log.trace(traceback.format_exc())
+            if raise_error:
+                raise httpx.RequestError(msg)
+        except BaseException as e:
+            log.trace(f"Unhandled exception with request to URL: {url}: {e}")
+            log.trace(traceback.format_exc())
+            raise
 
     async def download(self, url, **kwargs):
         """

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -19,13 +19,13 @@ class DummyCookies(Cookies):
     """
     Class to disable cookie parsing
     """
+
     def extract_cookies(self, *args, **kwargs):
         pass
 
 
 class BBOTAsyncClient(httpx.AsyncClient):
     def __init__(self, *args, **kwargs):
-
         self._bbot_scan = kwargs.pop("_bbot_scan")
 
         http_debug = self._bbot_scan.config.get("http_debug", None)
@@ -128,9 +128,7 @@ class WebHelper:
             async with self.web_rate_limiter:
                 response = await client.request(*args, **kwargs)
             if self.http_debug:
-                log.debug(
-                    f"Web response: {response} (Length: {len(response.content)}) headers: {response.headers}"
-                )
+                log.debug(f"Web response: {response} (Length: {len(response.content)}) headers: {response.headers}")
             return response
         except httpx.TimeoutException:
             log.verbose(f"HTTP timeout to URL: {url}")

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -7,10 +7,17 @@ import traceback
 from pathlib import Path
 from bs4 import BeautifulSoup
 
+from httpx._models import Cookies
+
 from bbot.core.errors import WordlistError, CurlError
 from bbot.core.helpers.ratelimiter import RateLimiter
 
 log = logging.getLogger("bbot.core.helpers.web")
+
+
+class DummyCookies(Cookies):
+    def extract_cookies(self, *args, **kwargs):
+        pass
 
 
 class BBOTAsyncClient(httpx.AsyncClient):
@@ -42,6 +49,8 @@ class BBOTAsyncClient(httpx.AsyncClient):
         kwargs["proxies"] = proxies
 
         super().__init__(*args, **kwargs)
+        if not self._persist_cookies:
+            self._cookies = DummyCookies()
 
     def build_request(self, *args, **kwargs):
         request = super().build_request(*args, **kwargs)

--- a/bbot/core/helpers/web.py
+++ b/bbot/core/helpers/web.py
@@ -7,21 +7,10 @@ import traceback
 from pathlib import Path
 from bs4 import BeautifulSoup
 
-from httpx._models import Cookies
-
 from bbot.core.errors import WordlistError, CurlError
 from bbot.core.helpers.ratelimiter import RateLimiter
 
 log = logging.getLogger("bbot.core.helpers.web")
-
-
-class DummyCookies(Cookies):
-    """
-    Class to disable cookie parsing
-    """
-
-    def extract_cookies(self, *args, **kwargs):
-        pass
 
 
 class BBOTAsyncClient(httpx.AsyncClient):
@@ -53,8 +42,6 @@ class BBOTAsyncClient(httpx.AsyncClient):
         kwargs["proxies"] = proxies
 
         super().__init__(*args, **kwargs)
-        if not self._persist_cookies:
-            self._cookies = DummyCookies()
 
     def build_request(self, *args, **kwargs):
         request = super().build_request(*args, **kwargs)
@@ -65,6 +52,11 @@ class BBOTAsyncClient(httpx.AsyncClient):
                 if hk not in request.headers:
                     request.headers[hk] = hv
         return request
+
+    def _merge_cookies(self, cookies):
+        if self._persist_cookies:
+            return super()._merge_cookies(cookies)
+        return cookies
 
 
 class WebHelper:

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -211,3 +211,35 @@ async def test_http_ssl(bbot_scanner, bbot_config, bbot_httpserver_ssl):
     r2 = await scan2.helpers.request(url)
     assert r2 is not None, "Request to self-signed SSL server failed even with ssl_verify=False"
     assert r2.status_code == 200 and r2.text == "test_http_ssl_yep"
+
+
+@pytest.mark.asyncio
+async def test_web_cookies(bbot_scanner, bbot_config, httpx_mock):
+    import httpx
+
+    # make sure cookies work when enabled
+    httpx_mock.add_response(url="http://www.evilcorp.com/cookies", headers=[("set-cookie", "wat=asdf; path=/")])
+    scan = bbot_scanner(config=bbot_config)
+    client = scan.helpers.AsyncClient(persist_cookies=True)
+    r = await client.get(url="http://www.evilcorp.com/cookies")
+    assert r.cookies["wat"] == "asdf"
+    httpx_mock.add_response(url="http://www.evilcorp.com/cookies/test", match_headers={"cookie": "wat=asdf"})
+    r = await client.get(url="http://www.evilcorp.com/cookies/test")
+    # make sure we can manually send cookies
+    httpx_mock.add_response(url="http://www.evilcorp.com/cookies/test2", match_headers={"cookie": "asdf=wat"})
+    r = await scan.helpers.request(url="http://www.evilcorp.com/cookies/test2", cookies={"asdf": "wat"})
+
+    # make sure they don't when they're not
+    httpx_mock.add_response(url="http://www2.evilcorp.com/cookies", headers=[("set-cookie", "wats=fdsa; path=/")])
+    scan = bbot_scanner(config=bbot_config)
+    client2 = scan.helpers.AsyncClient(persist_cookies=False)
+    r = await client2.get(url="http://www2.evilcorp.com/cookies")
+    # make sure we can access the cookies
+    assert "wats" in r.cookies
+    httpx_mock.add_response(url="http://www2.evilcorp.com/cookies/test", match_headers={"cookie": "wats=fdsa"})
+    # but that they're not sent in the response
+    with pytest.raises(httpx.TimeoutException):
+        r = await client2.get(url="http://www2.evilcorp.com/cookies/test")
+    # make sure we can manually send cookies
+    httpx_mock.add_response(url="http://www2.evilcorp.com/cookies/test2", match_headers={"cookie": "fdsa=wats"})
+    r = await client2.get(url="http://www2.evilcorp.com/cookies/test2", cookies={"fdsa": "wats"})

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -228,6 +228,7 @@ async def test_web_cookies(bbot_scanner, bbot_config, httpx_mock):
     # make sure we can manually send cookies
     httpx_mock.add_response(url="http://www.evilcorp.com/cookies/test2", match_headers={"cookie": "asdf=wat"})
     r = await scan.helpers.request(url="http://www.evilcorp.com/cookies/test2", cookies={"asdf": "wat"})
+    assert client.cookies["wat"] == "asdf"
 
     # make sure they don't when they're not
     httpx_mock.add_response(url="http://www2.evilcorp.com/cookies", headers=[("set-cookie", "wats=fdsa; path=/")])
@@ -243,3 +244,4 @@ async def test_web_cookies(bbot_scanner, bbot_config, httpx_mock):
     # make sure we can manually send cookies
     httpx_mock.add_response(url="http://www2.evilcorp.com/cookies/test2", match_headers={"cookie": "fdsa=wats"})
     r = await client2.get(url="http://www2.evilcorp.com/cookies/test2", cookies={"fdsa": "wats"})
+    assert not client2.cookies

--- a/bbot/test/test_step_2/module_tests/test_module_ntlm.py
+++ b/bbot/test/test_step_2/module_tests/test_module_ntlm.py
@@ -20,6 +20,4 @@ class TestNTLM(ModuleTestBase):
         module_test.set_expect_requests(request_args, respond_args)
 
     def check(self, module_test, events):
-        for e in events:
-            module_test.log.critical(e)
         assert any(e.type == "FINDING" and "EXC01.vno.local" in e.data["description"] for e in events)

--- a/bbot/test/test_step_2/module_tests/test_module_ntlm.py
+++ b/bbot/test/test_step_2/module_tests/test_module_ntlm.py
@@ -20,4 +20,6 @@ class TestNTLM(ModuleTestBase):
         module_test.set_expect_requests(request_args, respond_args)
 
     def check(self, module_test, events):
+        for e in events:
+            module_test.log.critical(e)
         assert any(e.type == "FINDING" and "EXC01.vno.local" in e.data["description"] for e in events)


### PR DESCRIPTION
While troubleshooting the httpx bug I discovered that instantiating a separate httpx client for every request was extremely wasteful. The client takes up roughly 1MB of memory, so this change should not only speed up the web modules, but also decrease BBOT's memory footprint by a considerable amount, especially during intensive web scans.