### PR TITLE
Update nuclei.py for usability and improve error handling

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -66,7 +66,7 @@ class nuclei(BaseModule):
                 self.warning(f"Failure while updating nuclei templates: {update_results.stderr}")
         else:
             self.warning("Error running nuclei template update command")
-
+        self.proxy = self.scan.config.get("http_proxy", "")
         self.mode = self.config.get("mode", "severe")
         self.ratelimit = int(self.config.get("ratelimit", 150))
         self.concurrency = int(self.config.get("concurrency", 25))
@@ -135,8 +135,10 @@ class nuclei(BaseModule):
             cleaned_host = temp_target.get(host)
             source_event = self.correlate_event(events, cleaned_host)
 
-            if url == "":
-                url = str(source_event.data)
+        if url == "":
+            if not source_event:    
+                continue
+            url = str(source_event.data)
 
             description_string = f"template: [{template}], name: [{name}]"
             if len(extracted_results) > 0:
@@ -203,6 +205,10 @@ class nuclei(BaseModule):
         if self.mode == "budget":
             command.append("-t")
             command.append(self.budget_templates_file)
+
+        if self.proxy:
+            command.append("-proxy")
+            command.append(f"{self.proxy}")
 
         stats_file = self.helpers.tempfile_tail(callback=self.log_nuclei_status)
         try:

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -135,10 +135,11 @@ class nuclei(BaseModule):
             cleaned_host = temp_target.get(host)
             source_event = self.correlate_event(events, cleaned_host)
 
-        if url == "":
-            if not source_event:    
+            if not source_event:
                 continue
-            url = str(source_event.data)
+
+            if url == "":
+                url = str(source_event.data)
 
             description_string = f"template: [{template}], name: [{name}]"
             if len(extracted_results) > 0:


### PR DESCRIPTION
- Ensured the proxy is passed through to nuclei when configured in bbot.  This should probably be the default for all modules to ensure no surprises when the operator has configured the proxy to modify in-flight requests and response e.g. ensure  additional scope controls are enforced or make any required modifications in burp e.g. add cookies etc. 
- Fixed failed nuclei scan upon correlation failure for one event (line 140 in nuclei.handle_batch()).  While the root cause of the below issue still needs to be rectified the existing warning should be sufficient,  rather than the whole batch failing.  

```
**[WARN]** nuclei: Failed to correlate nuclei result with event
Failed events (URL("https://host.com/", module=httpx, tags={'status-200', 'in-scope', 'ip-10-10-10-10', 'dir', 'distance-0'}),)
**[ERRR]** Error in nuclei.handle_batch(): /home/name/.local/pipx/venvs/bbot/lib/python3.9/site-packages/bbot/modules/deadly/nuclei.py:142:handle_batch(): 'NoneType' object has no attribute 'data'
**[TRCE]** Traceback (most recent call last):
  File "/home/name/.local/pipx/venvs/bbot/lib/python3.9/site-packages/bbot/scanner/scanner.py", line 730, in acatch
    yield
  File "/home/name/.local/pipx/venvs/bbot/lib/python3.9/site-packages/bbot/modules/base.py", line 223, in _handle_batch
    await self.handle_batch(*events)
  File "/home/name/.local/pipx/venvs/bbot/lib/python3.9/site-packages/bbot/modules/deadly/nuclei.py", line 140, in handle_batch
    url = str(source_event.data)
AttributeError: 'NoneType' object has no attribute 'data'
**[DBUG]** nuclei: Finished handling batch of 1 events
```