### PR TITLE
Bump Nuclei Version

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -13,7 +13,7 @@ class nuclei(BaseModule):
     batch_size = 25
 
     options = {
-        "version": "2.9.9",
+        "version": "2.9.15",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
Bumps nuclei version to the latest, `v2.9.15`.