### PR TITLE
Added Ability to Kill Modules During Scan

### DIFF
--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -346,6 +346,10 @@ class ScanManager:
         except Exception:
             log.critical(traceback.format_exc())
 
+    def kill_module(self, module_name, message=None):
+        module = self.scan.modules[module_name]
+        module.set_error_state(message=message, clear_outgoing_queue=True)
+
     @property
     def modules_by_priority(self):
         if not self._modules_by_priority:


### PR DESCRIPTION
Addresses https://github.com/blacklanternsecurity/bbot/issues/750.

During a scan, you can now type `kill <module>`, e.g. `kill nmap` and press enter. This will kill the module and remove its events from the queue.