### PR TITLE
Ensure .data is always a dictionary/object when serializing events to JSON

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -446,12 +446,10 @@ class BaseEvent:
             if v:
                 j.update({i: v})
         data_attr = getattr(self, f"data_{mode}", None)
-        if isinstance(data_attr, str):
-            data_attr = {self._json_data_key(): data_attr}
         if data_attr is not None:
-            j["data"] = data_attr
+            j["data"] = {self._json_data_key(): data_attr}
         else:
-            j["data"] = smart_decode(self.data)
+            j["data"] = {self._json_data_key(): smart_decode(self.data)}
         web_spider_distance = getattr(self, "web_spider_distance", None)
         if web_spider_distance is not None:
             j["web_spider_distance"] = web_spider_distance
@@ -1055,10 +1053,11 @@ def make_event(
 
 
 def event_from_json(j):
+    event_type = j["type"]
     try:
         kwargs = {
-            "data": j["data"],
-            "event_type": j["type"],
+            "data": j["data"][event_type],
+            "event_type": event_type,
             "scans": j.get("scans", []),
             "tags": j.get("tags", []),
             "confidence": j.get("confidence", 5),

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -379,8 +379,8 @@ class BaseEvent:
         Because self.data can be either a string or a dictionary, this function is used to standardize
         JSON-serialized events so that their .data attributes are _always_ dictionaries.
 
-        By default, simple string-based events like `IP_ADDRESS`, `DNS_NAME`, and `URL` are serialized
-        so that their event type is the sole key, and their data is the value.
+        Events are serialized so that at the top level of their .data object there is a single
+        key which is their event type, and their data is the value.
 
         For example, an `IP_ADDRESS` with .data of `"192.168.0.1"' will be `{"IP_ADDRESS": "192.168.0.1"}`.
         A `DNS_NAME` of `evilcorp.com` will be `{"DNS_NAME": "evilcorp.com"}`, etc.

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -377,18 +377,18 @@ class BaseEvent:
     def _json_data_key(self):
         """
         Because self.data can be either a string or a dictionary, this function is used to standardize
-        JSON serialized events so that their .data attributes are _always_ dictionaries.
+        JSON-serialized events so that their .data attributes are _always_ dictionaries.
 
         By default, simple string-based events like `IP_ADDRESS`, `DNS_NAME`, and `URL` are serialized
-        with their event type in the data.
+        so that their event type is the sole key, and their data is the value.
 
-        For example, an `IP_ADDRESS` will turn from `"192.168.0.1"' into `{"ip_address": "192.168.0.1"}`.
-        A `DNS_NAME` will turn from `evilcorp.com` into `{"dns_name": "evilcorp.com"}`.
+        For example, an `IP_ADDRESS` with .data of `"192.168.0.1"' will be `{"IP_ADDRESS": "192.168.0.1"}`.
+        A `DNS_NAME` of `evilcorp.com` will be `{"DNS_NAME": "evilcorp.com"}`, etc.
 
         Returns:
-            The key to be used when construction a dictionary of the event's data.
+            The key to be used when constructing a dictionary of the event's data.
         """
-        return self.type.lower()
+        return self.type
 
     @property
     def pretty_string(self):

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -374,6 +374,22 @@ class BaseEvent:
     def _data_id(self):
         return self.data
 
+    def _json_data_key(self):
+        """
+        Because self.data can be either a string or a dictionary, this function is used to standardize
+        JSON serialized events so that their .data attributes are _always_ dictionaries.
+
+        By default, simple string-based events like `IP_ADDRESS`, `DNS_NAME`, and `URL` are serialized
+        with their event type in the data.
+
+        For example, an `IP_ADDRESS` will turn from `"192.168.0.1"' into `{"ip_address": "192.168.0.1"}`.
+        A `DNS_NAME` will turn from `evilcorp.com` into `{"dns_name": "evilcorp.com"}`.
+
+        Returns:
+            The key to be used when construction a dictionary of the event's data.
+        """
+        return self.type.lower()
+
     @property
     def pretty_string(self):
         """
@@ -430,6 +446,8 @@ class BaseEvent:
             if v:
                 j.update({i: v})
         data_attr = getattr(self, f"data_{mode}", None)
+        if isinstance(data_attr, str):
+            data_attr = {self._json_data_key(): data_attr}
         if data_attr is not None:
             j["data"] = data_attr
         else:

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -342,7 +342,7 @@ async def test_events(events, scan, helpers, bbot_config):
     timestamp = db_event.timestamp.timestamp()
     json_event = db_event.json()
     assert json_event["scope_distance"] == 1
-    assert json_event["data"] == "127.0.0.1"
+    assert json_event["data"] == {"IP_ADDRESS": "127.0.0.1"}
     assert json_event["type"] == "IP_ADDRESS"
     assert json_event["timestamp"] == timestamp
     reconstituted_event = event_from_json(json_event)
@@ -355,7 +355,8 @@ async def test_events(events, scan, helpers, bbot_config):
     assert http_response.source_id == scan.root_event.id
     assert http_response.data["input"] == "http://example.com:80"
     json_event = http_response.json(mode="graph")
-    assert isinstance(json_event["data"], str)
+    assert isinstance(json_event["data"], dict)
+    assert isinstance(json_event["data"]["HTTP_RESPONSE"], str)
     json_event = http_response.json()
     assert isinstance(json_event["data"], dict)
     assert json_event["type"] == "HTTP_RESPONSE"

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -9,6 +9,9 @@ class TestJSON(ModuleTestBase):
         txt_file = module_test.scan.home / "output.ndjson"
         lines = list(module_test.scan.helpers.read_file(txt_file))
         assert lines
-        e = event_from_json(json.loads(lines[0]))
+        json_event = json.loads(lines[0])
+        assert json_event["type"] == "SCAN"
+        assert json_event["data"] == {"SCAN": f"{module_test.scan.name} ({module_test.scan.id})"}
+        e = event_from_json(json_event)
         assert e.type == "SCAN"
-        assert e.data == {"SCAN": f"{module_test.scan.name} ({module_test.scan.id})"}
+        assert e.data == f"{module_test.scan.name} ({module_test.scan.id})"

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -11,4 +11,4 @@ class TestJSON(ModuleTestBase):
         assert lines
         e = event_from_json(json.loads(lines[0]))
         assert e.type == "SCAN"
-        assert e.data == f"{module_test.scan.name} ({module_test.scan.id})"
+        assert e.data == {"SCAN": f"{module_test.scan.name} ({module_test.scan.id})"}


### PR DESCRIPTION
This PR changes JSON-serialized events so that their .data attribute is _always_ a dictionary object.

As discussed in https://github.com/blacklanternsecurity/bbot/discussions/736, this change came about because of the inconsistency between events' `.data` sometimes being a string:
```json
{
    "type": "IP_ADDRESS",
    "data": "192.168.0.1"
}
```
...and sometimes being a dictionary:
```json
{
    "type": "FINDING",
    "data": {
        "url": "https://evilcorp.com",
        "description": "Something interesting",
    }
}
```

This creates problems when ingesting BBOT data into places like elasticsearch, which expect an attribute's data type to be consistent across all instances. (Thanks to @nicpenning for pointing this out).

This PR leaves events unchanged internally in BBOT, where the `.data` attribute still varies between a dictionary and string. However, now when events are serialized to JSON, their `.data` is placed under a single key which is the event type. For example, an `IP_ADDRESS` would change to:

```json
{
    "type": "IP_ADDRESS",
    "data": {
        "IP_ADDRESS": "192.168.0.1"
    }
}
```

A `DNS_NAME`'s data would change from `evilcorp.com` to `{"DNS_NAME": "evilcorp.com"}`, etc. This ensures that `.data` is a consistent data type across the board.

**NOTE: DO NOT MERGE THIS YET.** We will need to coordinate with @batgoose and @SpamFaux to ensure that this does not screw with their ASM/frontend efforts. Also, since this is a breaking change, it will probably warrant a new BBOT version, e.g. `1.2.0`.