### PR TITLE
excavate CSP submodule

### DIFF
--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -51,7 +51,7 @@ class CSPExtractor(BaseExtractor):
                 self.report(domain, event, **kwargs)
 
     def report(self, domain, event, **kwargs):
-        self.excavate.emit_event(domain, "DNS_NAME_UNRESOLVED", source=event)
+        self.excavate.emit_event(domain, "DNS_NAME", source=event, tags=["affiliate"])
 
 
 class HostnameExtractor(BaseExtractor):

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -45,7 +45,6 @@ class CSPExtractor(BaseExtractor):
         return unique_domains
 
     async def search(self, content, event, **kwargs):
-        results = set()
         async for csp, name in self._search(content, event, **kwargs):
             extracted_domains = self.extract_domains(csp)
             for domain in extracted_domains:

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -209,3 +209,15 @@ class TestExcavateMaxLinksPerPage(TestExcavate):
         url_data = [e.data for e in url_events if "spider-danger" not in e.tags]
         assert "http://127.0.0.1:8888/10" in url_data
         assert "http://127.0.0.1:8888/11" not in url_data
+
+
+class TestExcavateCSP(TestExcavate):
+    csp_test_header = "default-src 'self'; script-src fake.domain.com; object-src 'none';"
+
+    async def setup_before_prep(self, module_test):
+        expect_args = {"method": "GET", "uri": "/"}
+        respond_args = {"headers": {"Content-Security-Policy": self.csp_test_header}}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+    def check(self, module_test, events):
+        assert any(e.data == "fake.domain.com" for e in events)


### PR DESCRIPTION
Reference: https://github.com/blacklanternsecurity/bbot/discussions/711

This will allow excavate to harvest domains from CSP headers. This could be an excellent source of subdomains or related (affiliate) domains.