### PR TITLE
Emergency Bugfix for Python3.9/3.10

### DIFF
--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -255,7 +255,7 @@ class Scanner:
             mp.set_start_method("spawn")
         except Exception:
             self.warning(f"Failed to set multiprocessing spawn method. This may negatively affect performance.")
-        self.process_pool = ProcessPoolExecutor(max_tasks_per_child=100)
+        self.process_pool = ProcessPoolExecutor()
 
         self._stopping = False
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ line-length = 119
 [tool.poetry-dynamic-versioning]
 enable = true
 metadata = false
-format-jinja = 'v1.1.2{% if branch == "dev" %}.{{ distance }}rc{% endif %}'
+format-jinja = 'v1.1.2.1{% if branch == "dev" %}.{{ distance }}rc{% endif %}'
 
 [tool.poetry-dynamic-versioning.substitution]
 files = ["*/__init__.py"]


### PR DESCRIPTION
Fixes an issue arising from `max_tasks_per_child`, which was added in python 3.11:

```python
  File "/opt/bbot/bbot/cli.py", line 138, in _main
    scanner = Scanner(
  File "/opt/bbot/bbot/scanner/scanner.py", line 258, in __init__
    self.process_pool = ProcessPoolExecutor(max_tasks_per_child=100)
TypeError: ProcessPoolExecutor.__init__() got an unexpected keyword argument 'max_tasks_per_child'
```