### PR TITLE
Softer warnings for soft-failed modules

### DIFF
--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -175,6 +175,8 @@ class ScanManager:
             on_success_callback = kwargs.pop("on_success_callback", None)
             abort_if = kwargs.pop("abort_if", None)
 
+            log.debug(f"EMIT {event} 1")
+
             # skip DNS resolution if it's disabled in the config and the event is a target and we don't have a blacklist
             skip_dns_resolution = (not self.dns_resolution) and "target" in event.tags and not self.scan.blacklist
             if skip_dns_resolution:
@@ -198,6 +200,8 @@ class ScanManager:
                         for ip in ips:
                             resolved_hosts.add(ip)
 
+            log.debug(f"EMIT {event} 2")
+
             # kill runaway DNS chains
             dns_resolve_distance = getattr(event, "dns_resolve_distance", 0)
             if dns_resolve_distance >= self.scan.helpers.dns.max_dns_resolve_distance:
@@ -205,6 +209,8 @@ class ScanManager:
                     f"Skipping DNS children for {event} because their DNS resolve distances would be greater than the configured value for this scan ({self.scan.helpers.dns.max_dns_resolve_distance})"
                 )
                 dns_children = {}
+
+            log.debug(f"EMIT {event} 3")
 
             if event.type in ("DNS_NAME", "IP_ADDRESS"):
                 for tag in dns_tags:
@@ -222,12 +228,16 @@ class ScanManager:
                 log.debug(f"Omitting due to blacklisted {reason}: {event}")
                 return
 
+            log.debug(f"EMIT {event} 4")
+
             # DNS_NAME --> DNS_NAME_UNRESOLVED
             if event.type == "DNS_NAME" and "unresolved" in event.tags and not "target" in event.tags:
                 event.type = "DNS_NAME_UNRESOLVED"
 
             # Cloud tagging
             await self.scan.helpers.cloud.tag_event(event)
+
+            log.debug(f"EMIT {event} 5")
 
             # Scope shepherding
             # here is where we make sure in-scope events are set to their proper scope distance
@@ -243,17 +253,23 @@ class ScanManager:
                 )
                 event.internal = True
 
+            log.debug(f"EMIT {event} 6")
+
             # check for wildcards
             if event.scope_distance <= self.scan.scope_search_distance:
                 if not "unresolved" in event.tags:
                     if not self.scan.helpers.is_ip_type(event.host):
                         await self.scan.helpers.dns.handle_wildcard_event(event, dns_children)
 
+            log.debug(f"EMIT {event} 7")
+
             # For DNS_NAMEs, we've waited to do this until now, in case event.data changed during handle_wildcard_event()
             if event.type == "DNS_NAME":
                 acceptable = self._event_precheck(event)
                 if not acceptable:
                     return
+
+            log.debug(f"EMIT {event} 8")
 
             # if we discovered something interesting from an internal event,
             # make sure we preserve its chain of parents
@@ -266,6 +282,8 @@ class ScanManager:
                     source._graph_important = True
                     log.debug(f"Re-queuing internal event {source} with parent {event}")
                     self.queue_event(source)
+
+            log.debug(f"EMIT {event} 9")
 
             # now that the event is properly tagged, we can finally make decisions about it
             abort_result = False
@@ -280,13 +298,19 @@ class ScanManager:
                     log.debug(msg)
                     return
 
+            log.debug(f"EMIT {event} 10")
+
             # run success callback before distributing event (so it can add tags, etc.)
             if callable(on_success_callback):
                 async with self.scan._acatch(context=on_success_callback):
                     await self.scan.helpers.execute_sync_or_async(on_success_callback, event)
 
+            log.debug(f"EMIT {event} 11")
+
             await self.distribute_event(event)
             event_distributed = True
+
+            log.debug(f"EMIT {event} 12")
 
             # speculate DNS_NAMES and IP_ADDRESSes from other event types
             source_event = event
@@ -304,6 +328,8 @@ class ScanManager:
                     if "target" in event.tags:
                         source_event.add_tag("target")
                     self.queue_event(source_event)
+
+            log.debug(f"EMIT {event} 13")
 
             ### Emit DNS children ###
             if self.dns_resolution:
@@ -335,6 +361,8 @@ class ScanManager:
                                     )
                     for child_event in dns_child_events:
                         self.queue_event(child_event)
+
+            log.debug(f"EMIT {event} 14")
 
         except ValidationError as e:
             log.warning(f"Event validation failed with kwargs={kwargs}: {e}")

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -175,8 +175,6 @@ class ScanManager:
             on_success_callback = kwargs.pop("on_success_callback", None)
             abort_if = kwargs.pop("abort_if", None)
 
-            log.debug(f"EMIT {event} 1")
-
             # skip DNS resolution if it's disabled in the config and the event is a target and we don't have a blacklist
             skip_dns_resolution = (not self.dns_resolution) and "target" in event.tags and not self.scan.blacklist
             if skip_dns_resolution:
@@ -200,8 +198,6 @@ class ScanManager:
                         for ip in ips:
                             resolved_hosts.add(ip)
 
-            log.debug(f"EMIT {event} 2")
-
             # kill runaway DNS chains
             dns_resolve_distance = getattr(event, "dns_resolve_distance", 0)
             if dns_resolve_distance >= self.scan.helpers.dns.max_dns_resolve_distance:
@@ -209,8 +205,6 @@ class ScanManager:
                     f"Skipping DNS children for {event} because their DNS resolve distances would be greater than the configured value for this scan ({self.scan.helpers.dns.max_dns_resolve_distance})"
                 )
                 dns_children = {}
-
-            log.debug(f"EMIT {event} 3")
 
             if event.type in ("DNS_NAME", "IP_ADDRESS"):
                 for tag in dns_tags:
@@ -228,16 +222,12 @@ class ScanManager:
                 log.debug(f"Omitting due to blacklisted {reason}: {event}")
                 return
 
-            log.debug(f"EMIT {event} 4")
-
             # DNS_NAME --> DNS_NAME_UNRESOLVED
             if event.type == "DNS_NAME" and "unresolved" in event.tags and not "target" in event.tags:
                 event.type = "DNS_NAME_UNRESOLVED"
 
             # Cloud tagging
             await self.scan.helpers.cloud.tag_event(event)
-
-            log.debug(f"EMIT {event} 5")
 
             # Scope shepherding
             # here is where we make sure in-scope events are set to their proper scope distance
@@ -253,23 +243,17 @@ class ScanManager:
                 )
                 event.internal = True
 
-            log.debug(f"EMIT {event} 6")
-
             # check for wildcards
             if event.scope_distance <= self.scan.scope_search_distance:
                 if not "unresolved" in event.tags:
                     if not self.scan.helpers.is_ip_type(event.host):
                         await self.scan.helpers.dns.handle_wildcard_event(event, dns_children)
 
-            log.debug(f"EMIT {event} 7")
-
             # For DNS_NAMEs, we've waited to do this until now, in case event.data changed during handle_wildcard_event()
             if event.type == "DNS_NAME":
                 acceptable = self._event_precheck(event)
                 if not acceptable:
                     return
-
-            log.debug(f"EMIT {event} 8")
 
             # if we discovered something interesting from an internal event,
             # make sure we preserve its chain of parents
@@ -282,8 +266,6 @@ class ScanManager:
                     source._graph_important = True
                     log.debug(f"Re-queuing internal event {source} with parent {event}")
                     self.queue_event(source)
-
-            log.debug(f"EMIT {event} 9")
 
             # now that the event is properly tagged, we can finally make decisions about it
             abort_result = False
@@ -298,19 +280,13 @@ class ScanManager:
                     log.debug(msg)
                     return
 
-            log.debug(f"EMIT {event} 10")
-
             # run success callback before distributing event (so it can add tags, etc.)
             if callable(on_success_callback):
                 async with self.scan._acatch(context=on_success_callback):
                     await self.scan.helpers.execute_sync_or_async(on_success_callback, event)
 
-            log.debug(f"EMIT {event} 11")
-
             await self.distribute_event(event)
             event_distributed = True
-
-            log.debug(f"EMIT {event} 12")
 
             # speculate DNS_NAMES and IP_ADDRESSes from other event types
             source_event = event
@@ -328,8 +304,6 @@ class ScanManager:
                     if "target" in event.tags:
                         source_event.add_tag("target")
                     self.queue_event(source_event)
-
-            log.debug(f"EMIT {event} 13")
 
             ### Emit DNS children ###
             if self.dns_resolution:
@@ -361,8 +335,6 @@ class ScanManager:
                                     )
                     for child_event in dns_child_events:
                         self.queue_event(child_event)
-
-            log.debug(f"EMIT {event} 14")
 
         except ValidationError as e:
             log.warning(f"Event validation failed with kwargs={kwargs}: {e}")

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -426,10 +426,10 @@ class Scanner:
             remove_failed (bool): Flag indicating whether to remove modules that fail setup.
 
         Returns:
-            dict: Dictionary containing lists of module names categorized by their setup status.
-                  'succeeded' - List of modules that successfully set up.
-                  'hard_failed' - List of modules that encountered a hard failure during setup.
-                  'soft_failed' - List of modules that encountered a soft failure during setup.
+            tuple:
+                succeeded - List of modules that successfully set up.
+                hard_failed - List of modules that encountered a hard failure during setup.
+                soft_failed - List of modules that encountered a soft failure during setup.
 
         Raises:
             ScanError: If no output modules could be loaded.
@@ -450,7 +450,7 @@ class Scanner:
                 self.debug(f"Setup succeeded for {module_name} ({msg})")
                 succeeded.append(module_name)
             elif status == False:
-                self.error(f"Setup hard-failed for {module_name}: {msg}")
+                self.warning(f"Setup hard-failed for {module_name}: {msg}")
                 self.modules[module_name].set_error_state()
                 hard_failed.append(module_name)
             else:

--- a/bbot/test/test_step_1/test_agent.py
+++ b/bbot/test/test_step_1/test_agent.py
@@ -31,7 +31,7 @@ async def websocket_handler(websocket, path, scan_done=None):
     assert websocket.request_headers["Authorization"] == "Bearer test"
 
     async for message in websocket:
-        log.critical(f"PHASE: {phase}, MESSAGE: {message}")
+        log.debug(f"PHASE: {phase}, MESSAGE: {message}")
         if not control or not first_run:
             continue
         m = json.loads(message)

--- a/bbot/test/test_step_1/test_agent.py
+++ b/bbot/test/test_step_1/test_agent.py
@@ -140,7 +140,7 @@ async def test_agent(agent):
 
     global success
     async with websockets.serve(_websocket_handler, "127.0.0.1", 8765):
-        asyncio.create_task(agent.start())
+        agent_task = asyncio.create_task(agent.start())
         # wait for 30 seconds
         await asyncio.wait_for(scan_done.wait(), 30)
         assert success
@@ -149,3 +149,10 @@ async def test_agent(agent):
         await agent.start_scan("scan_to_be_rejected", targets=["127.0.0.1"], modules=["ipneighbor"])
         await asyncio.sleep(0.1)
         await agent.stop_scan()
+        tasks = [agent.task, agent_task]
+        for task in tasks:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass

--- a/bbot/test/test_step_1/test_agent.py
+++ b/bbot/test/test_step_1/test_agent.py
@@ -141,8 +141,8 @@ async def test_agent(agent):
     global success
     async with websockets.serve(_websocket_handler, "127.0.0.1", 8765):
         agent_task = asyncio.create_task(agent.start())
-        # wait for 30 seconds
-        await asyncio.wait_for(scan_done.wait(), 30)
+        # wait for 90 seconds
+        await asyncio.wait_for(scan_done.wait(), 90)
         assert success
 
         await agent.start_scan("scan_to_be_cancelled", targets=["127.0.0.1"], modules=["ipneighbor"])

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -212,7 +212,7 @@ class TestExcavateMaxLinksPerPage(TestExcavate):
 
 
 class TestExcavateCSP(TestExcavate):
-    csp_test_header = "default-src 'self'; script-src fake.domain.com; object-src 'none';"
+    csp_test_header = "default-src 'self'; script-src test.asdf.fakedomain; object-src 'none';"
 
     async def setup_before_prep(self, module_test):
         expect_args = {"method": "GET", "uri": "/"}
@@ -220,4 +220,4 @@ class TestExcavateCSP(TestExcavate):
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert any(e.data == "fake.domain.com" for e in events)
+        assert any(e.data == "test.asdf.fakedomain" for e in events)


### PR DESCRIPTION
As pointed out by @The-Honey-Badger, the warnings for soft-failed modules are a bit harsh and glaring considering they're mostly for onconsequential things like missing API keys. 

Addresses https://github.com/blacklanternsecurity/bbot/issues/849.

This PR changes the logtype of these messages from `warning` to `info`. I am also using this PR to debug some of the [issues](https://github.com/blacklanternsecurity/bbot/issues/847) we're currently having with tests.