### PR TITLE
Dastardly scanner

### DIFF
--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -278,8 +278,8 @@ class DepsInstaller:
         success = res.status == "successful"
         err = ""
         for e in res.events:
-            # if self.ansible_debug and not success:
-            #    log.debug(json.dumps(e, indent=4))
+            if self.ansible_debug and not success:
+               log.debug(json.dumps(e, indent=4))
             if e["event"] == "runner_on_failed":
                 err = e["event_data"]["res"]["msg"]
                 break

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -278,8 +278,9 @@ class DepsInstaller:
         success = res.status == "successful"
         err = ""
         for e in res.events:
+            log.critical(f"ANSIBLE DEBUG: {self.ansible_debug}, SUCCESS: {success}")
             if self.ansible_debug and not success:
-                log.debug(json.dumps(e, indent=4))
+                log.critical(json.dumps(e, indent=4))
             if e["event"] == "runner_on_failed":
                 err = e["event_data"]["res"]["msg"]
                 break

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -279,7 +279,7 @@ class DepsInstaller:
         err = ""
         for e in res.events:
             if self.ansible_debug and not success:
-               log.debug(json.dumps(e, indent=4))
+                log.debug(json.dumps(e, indent=4))
             if e["event"] == "runner_on_failed":
                 err = e["event_data"]["res"]["msg"]
                 break

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -44,7 +44,7 @@ class DepsInstaller:
         self.setup_status = self.read_setup_status()
 
         self.no_deps = self.parent_helper.config.get("no_deps", False)
-        self.ansible_debug = self.parent_helper.config.get("debug", False)
+        self.ansible_debug = True
         self.force_deps = self.parent_helper.config.get("force_deps", False)
         self.retry_deps = self.parent_helper.config.get("retry_deps", False)
         self.ignore_failed_deps = self.parent_helper.config.get("ignore_failed_deps", False)

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -278,9 +278,8 @@ class DepsInstaller:
         success = res.status == "successful"
         err = ""
         for e in res.events:
-            log.critical(f"ANSIBLE DEBUG: {self.ansible_debug}, SUCCESS: {success}")
             if self.ansible_debug and not success:
-                log.critical(json.dumps(e, indent=4))
+                log.debug(json.dumps(e, indent=4))
             if e["event"] == "runner_on_failed":
                 err = e["event_data"]["res"]["msg"]
                 break

--- a/bbot/modules/deadly/dastardly.py
+++ b/bbot/modules/deadly/dastardly.py
@@ -11,10 +11,16 @@ class dastardly(BaseModule):
     deps_pip = ["lxml~=4.9.2"]
     deps_ansible = [
         {
+            "name": "Check if Docker is already installed",
+            "command": "docker --version",
+            "register": "docker_installed",
+            "ignore_errors": True,
+        },
+        {
             "name": "Install Docker (Non-Debian)",
             "package": {"name": "docker", "state": "present"},
             "become": True,
-            "when": "ansible_facts['os_family'] != 'Debian'",
+            "when": "ansible_facts['os_family'] != 'Debian' and docker_installed.rc != 0",
         },
         {
             "name": "Install Docker (Debian)",
@@ -23,7 +29,7 @@ class dastardly(BaseModule):
                 "state": "present",
             },
             "become": True,
-            "when": "ansible_facts['os_family'] == 'Debian'",
+            "when": "ansible_facts['os_family'] == 'Debian' and docker_installed.rc != 0",
         },
     ]
     per_host_only = True

--- a/bbot/modules/deadly/dastardly.py
+++ b/bbot/modules/deadly/dastardly.py
@@ -1,0 +1,126 @@
+from lxml import etree
+from bbot.modules.base import BaseModule
+
+
+class dastardly(BaseModule):
+    watched_events = ["URL"]
+    produced_events = ["FINDING", "VULNERABILITY"]
+    flags = ["active", "aggressive"]
+    meta = {"description": "Lightweight web application security scanner"}
+
+    deps_apt = ["docker.io"]
+    deps_pip = ["lxml~=4.9.2"]
+    deps_ansible = [
+        {
+            "name": "Pull the dastardly image",
+            "docker_image": {
+                "name": "public.ecr.aws/portswigger/dastardly:latest"
+            },
+        }
+    ]
+    in_scope_only = True
+
+    async def setup(self):
+        self.helpers.depsinstaller.ensure_root(message="Dastardly: docker requires root privileges")
+        return True
+
+    async def handle_event(self, event):
+        host = str(event.data)
+        command, output_file = self.construct_command(host)
+        try:
+            await self.helpers.run(command, sudo=True)
+            for testsuite in self.parse_dastardly_xml(output_file):
+                url = testcase.endpoint
+                for testcase in testsuite.testcases:
+                    for failure in testcase.failures:
+                        message = failure.instance
+                        detail = failure.text
+                        if failure.severity == "Info":
+                            self.emit_event(
+                                {
+                                    "host": str(event.host),
+                                    "url": url,
+                                    "description": message,
+                                    "detail": detail,
+                                },
+                                "FINDING",
+                                event,
+                            )
+                        else:
+                            self.emit_event(
+                                {
+                                    "severity": severity,
+                                    "host": str(event.host),
+                                    "url": url,
+                                    "description": message,
+                                    "detail": detail,
+                                },
+                                "VULNERABILITY",
+                                event,
+                            )
+        finally:
+            output_file.unlink(missing_ok=True)
+
+    def construct_command(self, target):
+        temp_filename = self.helpers.temp_filename(extension="xml")
+        command = [
+            'docker',
+            'run',
+            '--user',
+            '$(id -u)',
+            '--rm',
+            '-v',
+            '$(pwd):/dastardly',
+            '-e',
+            'BURP_START_URL={target}',
+            '-e',
+            'BURP_REPORT_FILE_PATH=/dastardly/{temp_filename}',
+            'public.ecr.aws/portswigger/dastardly:latest'
+        ]
+        return command, temp_filename
+
+    def parse_dastardly_xml(self, xml_file):
+        try:
+            with open(xml_file, "rb") as f:
+                et = etree.parse(f)
+                for testsuite in et.iter("testsuite"):
+                    yield TestSuite(testsuite)
+        except Exception as e:
+            self.warning(f"Error parsing Nmap XML at {xml_file}: {e}")
+
+    async def cleanup(self):
+        resume_file = self.helpers.current_dir / "resume.cfg"
+        resume_file.unlink(missing_ok=True)
+
+class Failure:
+    def __init__(self, xml):
+        self.etree = xml
+
+        # instance information
+        self.instance = self.etree.attrib.get("message", "")
+        self.severity = self.etree.attrib.get("type", "")
+        self.text = self.etree.text
+
+class TestCase:
+    def __init__(self, xml):
+        self.etree = xml
+
+        # title information
+        self.title = self.etree.attrib.get("name", "")
+
+        # findings / failures(as dastardly names them)
+        self.failures = []
+        for failure in self.etree.findall("failure"):
+            self.testcases.append(Failure(failure))
+
+class TestSuite:
+    def __init__(self, xml):
+        self.etree = xml
+
+        # endpoint information
+        self.endpoint = self.etree.attrib.get("name", "")
+
+        # test cases
+        self.testcases = []
+        for testcase in self.etree.findall("testcase"):
+            self.testcases.append(TestCase(testcase))

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -35,7 +35,7 @@ def assert_all_responses_were_requested() -> bool:
 
 @pytest.fixture
 def bbot_httpserver():
-    server = HTTPServer(host="0.0.0.0", port=8888)
+    server = HTTPServer(host="127.0.0.1", port=8888)
     server.start()
 
     yield server

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -76,7 +76,6 @@ def bbot_httpserver_ssl():
 
 @pytest.fixture
 def bbot_httpserver_allinterfaces():
-
     server = HTTPServer(host="0.0.0.0", port=5556)
     server.start()
 

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -75,6 +75,21 @@ def bbot_httpserver_ssl():
 
 
 @pytest.fixture
+def bbot_httpserver_allinterfaces():
+
+    server = HTTPServer(host="0.0.0.0", port=5556)
+    server.start()
+
+    yield server
+
+    server.clear()
+    if server.is_running():
+        server.stop()
+    server.check_assertions()
+    server.clear()
+
+
+@pytest.fixture
 def interactsh_mock_instance():
     interactsh_mock = Interactsh_mock()
     return interactsh_mock

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -35,7 +35,7 @@ def assert_all_responses_were_requested() -> bool:
 
 @pytest.fixture
 def bbot_httpserver():
-    server = HTTPServer(host="127.0.0.1", port=8888)
+    server = HTTPServer(host="0.0.0.0", port=8888)
     server.start()
 
     yield server

--- a/bbot/test/test.conf
+++ b/bbot/test/test.conf
@@ -29,7 +29,7 @@ scope_search_distance: 0
 scope_report_distance: 0
 scope_dns_search_distance: 1
 plumbus: asdf
-dns_debug: true
+dns_debug: false
 user_agent: "BBOT Test User-Agent"
 http_debug: false
 agent_url: ws://127.0.0.1:8765

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -71,7 +71,7 @@ async def test_cli(monkeypatch, bbot_config):
     await cli._main()
 
     # install all deps
-    monkeypatch.setattr("sys.argv", ["bbot", "-d", "--install-all-deps"])
+    monkeypatch.setattr("sys.argv", ["bbot", "--install-all-deps"])
     success = await cli._main()
     assert success, "--install-all-deps failed for at least one module"
 

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -71,7 +71,7 @@ async def test_cli(monkeypatch, bbot_config):
     await cli._main()
 
     # install all deps
-    monkeypatch.setattr("sys.argv", ["bbot", "--install-all-deps"])
+    monkeypatch.setattr("sys.argv", ["bbot", "-d", "--install-all-deps"])
     success = await cli._main()
     assert success, "--install-all-deps failed for at least one module"
 

--- a/bbot/test/test_step_2/module_tests/test_module_dastardly.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dastardly.py
@@ -1,19 +1,63 @@
+import json
+from werkzeug import Response
+
 from .base import ModuleTestBase
 
 
 class TestDastardly(ModuleTestBase):
-    targets = ["ginandjuice.shop"]
-    modules_overrides = ["nmap", "httpx", "dastardly"]
+    targets = ["http://127.0.0.1:8888/"]
+    modules_overrides = ["httpx", "dastardly"]
+
+    web_response = """<!DOCTYPE html>
+    <html>
+    <body>
+        <a href="/test?test=yes">visit this<a/>
+    </body>
+    </html>"""
+
+    def xss_handler(self, request):
+        response = f"""<!DOCTYPE html>
+    <html>
+    <head>
+        <title>Email Form</title>
+    </head>
+    <body>
+        {request.args.get("test", "")}
+    </body>
+    </html>"""
+        return Response(response, content_type="text/html")
+
+    async def get_docker_ip(self, module_test):
+        docker_ip = "172.17.0.1"
+        try:
+            ip_output = await module_test.scan.helpers.run(["ip", "-j", "-4", "a", "show", "dev", "docker0"])
+            interface_json = json.loads(ip_output.stdout)
+            docker_ip = interface_json[0]["addr_info"][0]["local"]
+        except Exception:
+            pass
+        return docker_ip
+
+    async def setup_after_prep(self, module_test):
+        module_test.httpserver.expect_request("/").respond_with_data(self.web_response)
+        module_test.httpserver.expect_request("/test").respond_with_handler(self.xss_handler)
+
+        # get docker IP
+        docker_ip = await self.get_docker_ip(module_test)
+        module_test.scan.target.add_target(docker_ip)
+
+        # replace 127.0.0.1 with docker host IP to allow dastardly access to local http server
+        old_filter_event = module_test.module.filter_event
+
+        def new_filter_event(event):
+            self.new_url = f"http://{docker_ip}:8888/"
+            event.data["url"] = self.new_url
+            event.parsed = module_test.scan.helpers.urlparse(self.new_url)
+            return old_filter_event(event)
+
+        module_test.monkeypatch.setattr(module_test.module, "filter_event", new_filter_event)
 
     def check(self, module_test, events):
-        reflected_xss = False
-        vulnerable_js = False
-        for e in events:
-            if e.type == "VULNERABILITY":
-                if "Cross-site scripting (reflected)" in e.data["description"]:
-                    reflected_xss = True
-            if e.type == "VULNERABILITY":
-                if "Vulnerable JavaScript dependency" in e.data["description"]:
-                    vulnerable_js = True
-        assert reflected_xss
-        assert vulnerable_js
+        assert 1 == len([e for e in events if e.type == "VULNERABILITY"])
+        assert 1 == len(
+            [e for e in events if e.type == "VULNERABILITY" and f"{self.new_url}test" in e.data["description"]]
+        )

--- a/bbot/test/test_step_2/module_tests/test_module_dastardly.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dastardly.py
@@ -1,0 +1,19 @@
+from .base import ModuleTestBase
+
+
+class TestDastardly(ModuleTestBase):
+    targets = ["ginandjuice.shop"]
+    modules_overrides = ["nmap", "httpx", "dastardly"]
+
+    def check(self, module_test, events):
+        reflected_xss = False
+        vulnerable_js = False
+        for e in events:
+            if e.type == "VULNERABILITY":
+                if "Cross-site scripting (reflected)" in e.data["description"]:
+                    reflected_xss = True
+            if e.type == "VULNERABILITY":
+                if "Vulnerable JavaScript dependency" in e.data["description"]:
+                    vulnerable_js = True
+        assert reflected_xss
+        assert vulnerable_js


### PR DESCRIPTION
As mentioned in #895 created a dastardly scanner module.

Dastardly is a lightweight web application security scanner, Originally designed for CI/CD pipelines but added as a module to bbot  to allow for the detection of Reflected XSS, CORS, Vulnerable JS, Content type not specified, Multiple Content Types, HTML Charset and duplicate cookies. 7 common web application security issues.

The module is tagged as aggressive and the `--deadly` flag should be used to activate it.

It will take `in_scope_only` and `URL` events as input and start the dastardly docker container to crawl and audit the url. Dastardly crawling is limited to 10 minutes per url. But with many URLs and sub domains being discovered by other modules this should give a decent coverage of any web application.

Currently the description of each finding/vulnerability would be "Cross-site scripting (reflected) found at https://ginandjuice.shop/catalog/subscribe" (Replace "Cross-site scripting (reflected)" with the finding name and "https://ginandjuice.shop/catalog/subscribe" with the exact URL) as the evidence provided by dastardly is too long to fit into the description which is included in the output.csv.
- Not yet implemented is a way of displaying the evidence in the correct format but it may be possible to create individual evidence files for each dastardly finding

A test case has been added also to run the dastardly module against portswiggers deliberately vulnerable web app `https://ginandjuice.shop/`. (The test case also enables the module nmap to provide TCP_OPEN events and httpx to provide URL events)