### PR TITLE
Terminal Issues Fix

### DIFF
--- a/bbot/modules/nmap.py
+++ b/bbot/modules/nmap.py
@@ -65,6 +65,7 @@ class nmap(portscanner):
         temp_filename = self.helpers.temp_filename(extension="xml")
         command = [
             "nmap",
+            "--noninteractive",
             "--excludefile",
             str(self.exclude_file),
             "-n",


### PR DESCRIPTION
Sometimes after a scan the terminal is all messed up, and you're unable to see typed characters etc. This is nmap's fault.

Addresses https://github.com/blacklanternsecurity/bbot/issues/882.