### PR TITLE
Port Scanners - better handling of IPv6

### DIFF
--- a/bbot/modules/masscan.py
+++ b/bbot/modules/masscan.py
@@ -190,7 +190,7 @@ class masscan(portscanner):
             with suppress(KeyError):
                 source = self.alive_hosts[ip]
             if proto != "icmp":
-                result += f":{port_number}"
+                result = self.helpers.make_netloc(result, port_number)
                 if source is None:
                     source = self.make_event(ip, "IP_ADDRESS", source=self.get_source_event(ip))
                     self.emit_event(source)

--- a/bbot/modules/templates/portscanner.py
+++ b/bbot/modules/templates/portscanner.py
@@ -1,3 +1,5 @@
+import ipaddress
+
 from bbot.modules.base import BaseModule
 
 
@@ -38,7 +40,7 @@ class portscanner(BaseModule):
             return False, f"skipping IP_RANGE {event.host} because asset_inventory.use_previous=True"
         return True
 
-    def _build_targets(self, target, delimiter=","):
+    def _build_targets(self, target):
         invalid_targets = 0
         targets = []
         for t in target:
@@ -47,7 +49,7 @@ class portscanner(BaseModule):
                 invalid_targets += 1
             else:
                 if self.helpers.is_ip(t):
-                    targets.append(f"{t}/32")
+                    targets.append(str(ipaddress.ip_network(t)))
                 else:
                     targets.append(str(t))
         return targets, invalid_targets

--- a/bbot/test/test_step_1/test_dns.py
+++ b/bbot/test/test_step_1/test_dns.py
@@ -3,50 +3,50 @@ from ..bbot_fixtures import *
 
 @pytest.mark.asyncio
 async def test_dns(bbot_scanner, bbot_config):
-    scan = bbot_scanner("8.8.8.8", config=bbot_config)
+    scan = bbot_scanner("1.1.1.1", config=bbot_config)
     helpers = scan.helpers
 
     # lowest level functions
-    a_responses = await helpers._resolve_hostname("dns.google")
-    aaaa_responses = await helpers._resolve_hostname("dns.google", rdtype="AAAA")
-    ip_responses = await helpers._resolve_ip("8.8.8.8")
-    assert a_responses[0].response.answer[0][0].address in ("8.8.8.8", "8.8.4.4")
-    assert aaaa_responses[0].response.answer[0][0].address in ("2001:4860:4860::8888", "2001:4860:4860::8844")
-    assert ip_responses[0].response.answer[0][0].target.to_text() in ("dns.google.",)
+    a_responses = await helpers._resolve_hostname("one.one.one.one")
+    aaaa_responses = await helpers._resolve_hostname("one.one.one.one", rdtype="AAAA")
+    ip_responses = await helpers._resolve_ip("1.1.1.1")
+    assert a_responses[0].response.answer[0][0].address in ("1.1.1.1", "1.0.0.1")
+    assert aaaa_responses[0].response.answer[0][0].address in ("2606:4700:4700::1111", "2606:4700:4700::1001")
+    assert ip_responses[0].response.answer[0][0].target.to_text() in ("one.one.one.one.",)
 
     # mid level functions
-    _responses, errors = await helpers.resolve_raw("dns.google")
+    _responses, errors = await helpers.resolve_raw("one.one.one.one")
     responses = []
     for rdtype, response in _responses:
         for answers in response:
             responses += list(helpers.extract_targets(answers))
-    assert ("A", "8.8.8.8") in responses
-    _responses, errors = await helpers.resolve_raw("dns.google", rdtype="AAAA")
+    assert ("A", "1.1.1.1") in responses
+    _responses, errors = await helpers.resolve_raw("one.one.one.one", rdtype="AAAA")
     responses = []
     for rdtype, response in _responses:
         for answers in response:
             responses += list(helpers.extract_targets(answers))
-    assert ("AAAA", "2001:4860:4860::8888") in responses
-    _responses, errors = await helpers.resolve_raw("8.8.8.8")
+    assert ("AAAA", "2606:4700:4700::1111") in responses
+    _responses, errors = await helpers.resolve_raw("1.1.1.1")
     responses = []
     for rdtype, response in _responses:
         for answers in response:
             responses += list(helpers.extract_targets(answers))
-    assert ("PTR", "dns.google") in responses
+    assert ("PTR", "one.one.one.one") in responses
 
     # high level functions
-    assert "8.8.8.8" in await helpers.resolve("dns.google")
-    assert "2001:4860:4860::8888" in await helpers.resolve("dns.google", type="AAAA")
-    assert "dns.google" in await helpers.resolve("8.8.8.8")
+    assert "1.1.1.1" in await helpers.resolve("one.one.one.one")
+    assert "2606:4700:4700::1111" in await helpers.resolve("one.one.one.one", type="AAAA")
+    assert "one.one.one.one" in await helpers.resolve("1.1.1.1")
     for rdtype in ("NS", "SOA", "MX", "TXT"):
         assert len(await helpers.resolve("google.com", type=rdtype)) > 0
 
     # batch resolution
-    batch_results = [r async for r in helpers.resolve_batch(["8.8.8.8", "dns.google"])]
+    batch_results = [r async for r in helpers.resolve_batch(["1.1.1.1", "one.one.one.one"])]
     assert len(batch_results) == 2
     batch_results = dict(batch_results)
-    assert any([x in batch_results["dns.google"] for x in ("8.8.8.8", "8.8.4.4")])
-    assert "dns.google" in batch_results["8.8.8.8"]
+    assert any([x in batch_results["one.one.one.one"] for x in ("1.1.1.1", "1.0.0.1")])
+    assert "one.one.one.one" in batch_results["1.1.1.1"]
 
     # "any" type
     resolved = await helpers.resolve("google.com", type="any")
@@ -54,38 +54,38 @@ async def test_dns(bbot_scanner, bbot_config):
 
     # dns cache
     helpers.dns._dns_cache.clear()
-    assert hash(f"8.8.8.8:PTR") not in helpers.dns._dns_cache
-    assert hash(f"dns.google:A") not in helpers.dns._dns_cache
-    assert hash(f"dns.google:AAAA") not in helpers.dns._dns_cache
-    await helpers.resolve("8.8.8.8", use_cache=False)
-    await helpers.resolve("dns.google", use_cache=False)
-    assert hash(f"8.8.8.8:PTR") not in helpers.dns._dns_cache
-    assert hash(f"dns.google:A") not in helpers.dns._dns_cache
-    assert hash(f"dns.google:AAAA") not in helpers.dns._dns_cache
+    assert hash(f"1.1.1.1:PTR") not in helpers.dns._dns_cache
+    assert hash(f"one.one.one.one:A") not in helpers.dns._dns_cache
+    assert hash(f"one.one.one.one:AAAA") not in helpers.dns._dns_cache
+    await helpers.resolve("1.1.1.1", use_cache=False)
+    await helpers.resolve("one.one.one.one", use_cache=False)
+    assert hash(f"1.1.1.1:PTR") not in helpers.dns._dns_cache
+    assert hash(f"one.one.one.one:A") not in helpers.dns._dns_cache
+    assert hash(f"one.one.one.one:AAAA") not in helpers.dns._dns_cache
 
-    await helpers.resolve("8.8.8.8")
-    assert hash(f"8.8.8.8:PTR") in helpers.dns._dns_cache
-    await helpers.resolve("dns.google")
-    assert hash(f"dns.google:A") in helpers.dns._dns_cache
-    assert hash(f"dns.google:AAAA") in helpers.dns._dns_cache
+    await helpers.resolve("1.1.1.1")
+    assert hash(f"1.1.1.1:PTR") in helpers.dns._dns_cache
+    await helpers.resolve("one.one.one.one")
+    assert hash(f"one.one.one.one:A") in helpers.dns._dns_cache
+    assert hash(f"one.one.one.one:AAAA") in helpers.dns._dns_cache
 
     # Ensure events with hosts have resolved_hosts attribute populated
-    resolved_hosts_event1 = scan.make_event("dns.google", "DNS_NAME", dummy=True)
-    resolved_hosts_event2 = scan.make_event("http://dns.google/", "URL_UNVERIFIED", dummy=True)
+    resolved_hosts_event1 = scan.make_event("one.one.one.one", "DNS_NAME", dummy=True)
+    resolved_hosts_event2 = scan.make_event("http://one.one.one.one/", "URL_UNVERIFIED", dummy=True)
     event_tags1, event_whitelisted1, event_blacklisted1, children1 = await scan.helpers.resolve_event(
         resolved_hosts_event1
     )
     event_tags2, event_whitelisted2, event_blacklisted2, children2 = await scan.helpers.resolve_event(
         resolved_hosts_event2
     )
-    assert "8.8.8.8" in [str(x) for x in children1["A"]]
-    assert "8.8.8.8" in [str(x) for x in children2["A"]]
+    assert "1.1.1.1" in [str(x) for x in children1["A"]]
+    assert "1.1.1.1" in [str(x) for x in children2["A"]]
     assert set(children1.keys()) == set(children2.keys())
 
 
 @pytest.mark.asyncio
 async def test_wildcards(bbot_scanner, bbot_config):
-    scan = bbot_scanner("8.8.8.8", config=bbot_config)
+    scan = bbot_scanner("1.1.1.1", config=bbot_config)
     helpers = scan.helpers
 
     # wildcards

--- a/bbot/test/test_step_1/test_scan.py
+++ b/bbot/test/test_step_1/test_scan.py
@@ -11,20 +11,20 @@ async def test_scan(
     bbot_scanner,
 ):
     scan0 = bbot_scanner(
-        "8.8.8.8/31",
+        "1.1.1.1/31",
         "evilcorp.com",
-        blacklist=["8.8.8.8/28", "www.evilcorp.com"],
+        blacklist=["1.1.1.1/28", "www.evilcorp.com"],
         modules=["ipneighbor"],
         config=bbot_config,
     )
     await scan0.load_modules()
-    assert scan0.whitelisted("8.8.8.8")
-    assert scan0.whitelisted("8.8.8.9")
-    assert scan0.blacklisted("8.8.8.15")
-    assert not scan0.blacklisted("8.8.8.16")
-    assert scan0.blacklisted("8.8.8.8/30")
-    assert not scan0.blacklisted("8.8.8.8/27")
-    assert not scan0.in_scope("8.8.8.8")
+    assert scan0.whitelisted("1.1.1.1")
+    assert scan0.whitelisted("1.1.1.0")
+    assert scan0.blacklisted("1.1.1.15")
+    assert not scan0.blacklisted("1.1.1.16")
+    assert scan0.blacklisted("1.1.1.1/30")
+    assert not scan0.blacklisted("1.1.1.1/27")
+    assert not scan0.in_scope("1.1.1.1")
     assert scan0.whitelisted("api.evilcorp.com")
     assert scan0.whitelisted("www.evilcorp.com")
     assert not scan0.blacklisted("api.evilcorp.com")
@@ -33,43 +33,50 @@ async def test_scan(
     assert not scan0.in_scope("test.www.evilcorp.com")
     assert not scan0.in_scope("www.evilcorp.co.uk")
     j = scan0.json
-    assert "8.8.8.8/31" in j["targets"]
-    assert "8.8.8.8/31" in j["whitelist"]
-    assert "8.8.8.0/28" in j["blacklist"]
+    assert "1.1.1.0/31" in j["targets"]
+    assert "1.1.1.0/31" in j["whitelist"]
+    assert "1.1.1.0/28" in j["blacklist"]
     assert "ipneighbor" in j["modules"]
 
-    scan1 = bbot_scanner("8.8.8.8", whitelist=["8.8.4.4"], config=bbot_config)
-    assert not scan1.blacklisted("8.8.8.8")
-    assert not scan1.blacklisted("8.8.4.4")
-    assert not scan1.whitelisted("8.8.8.8")
-    assert scan1.whitelisted("8.8.4.4")
-    assert scan1.in_scope("8.8.4.4")
-    assert not scan1.in_scope("8.8.8.8")
+    scan1 = bbot_scanner("1.1.1.1", whitelist=["1.0.0.1"], config=bbot_config)
+    assert not scan1.blacklisted("1.1.1.1")
+    assert not scan1.blacklisted("1.0.0.1")
+    assert not scan1.whitelisted("1.1.1.1")
+    assert scan1.whitelisted("1.0.0.1")
+    assert scan1.in_scope("1.0.0.1")
+    assert not scan1.in_scope("1.1.1.1")
 
-    scan2 = bbot_scanner("8.8.8.8", config=bbot_config)
-    assert not scan2.blacklisted("8.8.8.8")
-    assert not scan2.blacklisted("8.8.4.4")
-    assert scan2.whitelisted("8.8.8.8")
-    assert not scan2.whitelisted("8.8.4.4")
-    assert scan2.in_scope("8.8.8.8")
-    assert not scan2.in_scope("8.8.4.4")
+    scan2 = bbot_scanner("1.1.1.1", config=bbot_config)
+    assert not scan2.blacklisted("1.1.1.1")
+    assert not scan2.blacklisted("1.0.0.1")
+    assert scan2.whitelisted("1.1.1.1")
+    assert not scan2.whitelisted("1.0.0.1")
+    assert scan2.in_scope("1.1.1.1")
+    assert not scan2.in_scope("1.0.0.1")
+
+    dns_table = {
+        ("1.1.1.1", "PTR"): "one.one.one.one",
+        ("one.one.one.one", "A"): "1.1.1.1",
+    }
 
     # make sure DNS resolution works
     dns_config = OmegaConf.create({"dns_resolution": True})
     dns_config = OmegaConf.merge(bbot_config, dns_config)
-    scan4 = bbot_scanner("8.8.8.8", config=dns_config)
+    scan4 = bbot_scanner("1.1.1.1", config=dns_config)
+    scan4.helpers.dns.mock_dns(dns_table)
     events = []
     async for event in scan4.async_start():
         events.append(event)
     event_data = [e.data for e in events]
-    assert "dns.google" in event_data
+    assert "one.one.one.one" in event_data
 
     # make sure it doesn't work when you turn it off
     no_dns_config = OmegaConf.create({"dns_resolution": False})
     no_dns_config = OmegaConf.merge(bbot_config, no_dns_config)
-    scan5 = bbot_scanner("8.8.8.8", config=no_dns_config)
+    scan5 = bbot_scanner("1.1.1.1", config=no_dns_config)
+    scan5.helpers.dns.mock_dns(dns_table)
     events = []
     async for event in scan5.async_start():
         events.append(event)
     event_data = [e.data for e in events]
-    assert "dns.google" not in event_data
+    assert "one.one.one.one" not in event_data

--- a/bbot/test/test_step_2/module_tests/test_module_affiliates.py
+++ b/bbot/test/test_step_2/module_tests/test_module_affiliates.py
@@ -6,12 +6,14 @@ class TestAffiliates(ModuleTestBase):
     config_overrides = {"dns_resolution": True}
 
     async def setup_before_prep(self, module_test):
-        module_test.scan.helpers.dns.mock_dns({
-            ("8.8.8.8", "PTR"): "dns.google",
-            ("dns.google", "A"): "8.8.8.8",
-            ("dns.google", "NS"): "ns1.zdns.google",
-            ("ns1.zdns.google", "A"): "1.2.3.4",
-        })
+        module_test.scan.helpers.dns.mock_dns(
+            {
+                ("8.8.8.8", "PTR"): "dns.google",
+                ("dns.google", "A"): "8.8.8.8",
+                ("dns.google", "NS"): "ns1.zdns.google",
+                ("ns1.zdns.google", "A"): "1.2.3.4",
+            }
+        )
 
     def check(self, module_test, events):
         filename = next(module_test.scan.home.glob("affiliates-table*.txt"))

--- a/bbot/test/test_step_2/module_tests/test_module_affiliates.py
+++ b/bbot/test/test_step_2/module_tests/test_module_affiliates.py
@@ -5,6 +5,14 @@ class TestAffiliates(ModuleTestBase):
     targets = ["8.8.8.8"]
     config_overrides = {"dns_resolution": True}
 
+    async def setup_before_prep(self, module_test):
+        module_test.scan.helpers.dns.mock_dns({
+            ("8.8.8.8", "PTR"): "dns.google",
+            ("dns.google", "A"): "8.8.8.8",
+            ("dns.google", "NS"): "ns1.zdns.google",
+            ("ns1.zdns.google", "A"): "1.2.3.4",
+        })
+
     def check(self, module_test, events):
         filename = next(module_test.scan.home.glob("affiliates-table*.txt"))
         with open(filename) as f:


### PR DESCRIPTION
Minor bugfix to resolve a hard-coded `/32` that should be `/128` if the IP is version 6.

This also switches our DNS tests to rely on `1.1.1.1` instead of `8.8.8.8`, as today Google's PTR record is nonexistent with a `SERVFAIL`.