### PR TITLE
Wildcard Performance Boost

### DIFF
--- a/bbot/core/helpers/dns.py
+++ b/bbot/core/helpers/dns.py
@@ -456,15 +456,6 @@ class DNSHelper:
                                     f'Wildcard detected, changing event.data "{event.data}" --> "{wildcard_data}"'
                                 )
                                 event.data = wildcard_data
-                else:
-                    # check if this domain is using wildcard dns
-                    event_target = "target" in event.tags
-                    wildcard_domain_results = await self.is_wildcard_domain(event_host, log_info=event_target)
-                    for hostname, wildcard_domain_rdtypes in wildcard_domain_results.items():
-                        if wildcard_domain_rdtypes:
-                            event.add_tag("wildcard-domain")
-                            for rdtype, ips in wildcard_domain_rdtypes.items():
-                                event.add_tag(f"{rdtype.lower()}-wildcard-domain")
         finally:
             log.debug(f"Finished handle_wildcard_event({event}, children={children})")
 

--- a/bbot/core/helpers/dns.py
+++ b/bbot/core/helpers/dns.py
@@ -456,6 +456,15 @@ class DNSHelper:
                                     f'Wildcard detected, changing event.data "{event.data}" --> "{wildcard_data}"'
                                 )
                                 event.data = wildcard_data
+                # tag wildcard domains for convenience
+                elif is_domain(event_host) or hash(event_host) in self._wildcard_cache:
+                    event_target = "target" in event.tags
+                    wildcard_domain_results = await self.is_wildcard_domain(event_host, log_info=event_target)
+                    for hostname, wildcard_domain_rdtypes in wildcard_domain_results.items():
+                        if wildcard_domain_rdtypes:
+                            event.add_tag("wildcard-domain")
+                            for rdtype, ips in wildcard_domain_rdtypes.items():
+                                event.add_tag(f"{rdtype.lower()}-wildcard-domain")
         finally:
             log.debug(f"Finished handle_wildcard_event({event}, children={children})")
 

--- a/bbot/modules/templates/subdomain_enum.py
+++ b/bbot/modules/templates/subdomain_enum.py
@@ -138,8 +138,6 @@ class subdomain_enum(BaseModule):
         # this helps weed out unwanted results when scanning IP_RANGES and wildcard domains
         if "in-scope" not in event.tags:
             return True
-        if await self._is_wildcard(event.data):
-            return True
         return False
 
 


### PR DESCRIPTION
This PR removes certain redundant wildcard checks (such as the one in `abort_if` for subdomain enumeration modules) that were slowing down the scan. 

This is a small change but it results in a huge performance increase, at least 3X.

It may seem scary to remove this check, but the one in `subdomain_enum.py` is redundant because wildcard checks happen automatically in `emit_event()`, and wildcards are automatically truncated and deduplicated, e.g. to `_wildcard.evilcorp.com`.