### PR TITLE
Excavate - increase max redirects with max spider distance

### DIFF
--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -365,7 +365,7 @@ class ScanManager:
         try:
             event_hash = event.module._outgoing_dedup_hash(event)
         except AttributeError:
-            event_hash = hash(event)
+            event_hash = hash(event, str(getattr(event, "module", "")))
         is_dup = event_hash in self.incoming_dup_tracker
         if add:
             self.incoming_dup_tracker.add(event_hash)

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -365,7 +365,7 @@ class ScanManager:
         try:
             event_hash = event.module._outgoing_dedup_hash(event)
         except AttributeError:
-            event_hash = hash(event, str(getattr(event, "module", "")))
+            event_hash = hash((event, str(getattr(event, "module", ""))))
         is_dup = event_hash in self.incoming_dup_tracker
         if add:
             self.incoming_dup_tracker.add(event_hash)


### PR DESCRIPTION
This fixes a small bug in excavate where when `web_spider_distance` was greater than 5, URLs would erroneously be tagged as `spider-danger` because of `max_redirects`. If needed, `max_redirects` is now upscaled to match `web_spider_distance`. A log message has also been added that explains why the event is tagged as `spider-danger`.