### PR TITLE
Websocket -  preserve graph

### DIFF
--- a/bbot/modules/output/websocket.py
+++ b/bbot/modules/output/websocket.py
@@ -10,6 +10,7 @@ class Websocket(BaseOutputModule):
     meta = {"description": "Output to websockets"}
     options = {"url": "", "token": ""}
     options_desc = {"url": "Web URL", "token": "Authorization Bearer token"}
+    _preserve_graph = True
 
     async def setup(self):
         self.url = self.config.get("url", "")


### PR DESCRIPTION
This PR updates websocket so it preserves the graph structure. This prevents orphans when rendering the results in viva graph js.