### PR TITLE
"Quick Emit" Events

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -90,6 +90,9 @@ class BaseEvent:
     _always_emit = False
     # Always emit events with these tags even if they're not in scope
     _always_emit_tags = ["affiliate"]
+    # Bypass scope checking and dns resolution, distribute immediately to modules
+    # This is useful for "end-of-line" events like FINDING and VULNERABILITY
+    _quick_emit = False
     # Whether this event has been retroactively marked as part of an important discovery chain
     _graph_important = False
     # Exclude from output modules
@@ -319,9 +322,17 @@ class BaseEvent:
 
     @property
     def always_emit(self):
+        """
+        If this returns True, the event will always be distributed to output modules regardless of scope distance
+        """
         always_emit_tags = any(t in self.tags for t in self._always_emit_tags)
         no_host_information = not bool(self.host)
         return self._always_emit or always_emit_tags or no_host_information
+
+    @property
+    def quick_emit(self):
+        no_host_information = not bool(self.host)
+        return self._quick_emit or no_host_information
 
     @property
     def id(self):
@@ -753,6 +764,7 @@ class DictHostEvent(DictEvent):
 
 class ASN(DictEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class CODE_REPOSITORY(DictHostEvent):
@@ -992,6 +1004,7 @@ class HTTP_RESPONSE(URL_UNVERIFIED, DictEvent):
 
 class VULNERABILITY(DictHostEvent):
     _always_emit = True
+    _quick_emit = True
     severity_colors = {
         "CRITICAL": "🟪",
         "HIGH": "🟥",
@@ -1019,6 +1032,7 @@ class VULNERABILITY(DictHostEvent):
 
 class FINDING(DictHostEvent):
     _always_emit = True
+    _quick_emit = True
 
     class _data_validator(BaseModel):
         host: str
@@ -1084,22 +1098,27 @@ class PROTOCOL(DictHostEvent):
 
 class GEOLOCATION(BaseEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class PASSWORD(BaseEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class HASHED_PASSWORD(BaseEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class USERNAME(BaseEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class SOCIAL(DictEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class WEBSCREENSHOT(DictHostEvent):
@@ -1108,10 +1127,12 @@ class WEBSCREENSHOT(DictHostEvent):
 
 class AZURE_TENANT(DictEvent):
     _always_emit = True
+    _quick_emit = True
 
 
 class WAF(DictHostEvent):
     _always_emit = True
+    _quick_emit = True
 
     class _data_validator(BaseModel):
         url: str

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -84,7 +84,7 @@ class ScanManager:
         """
         # "quick" queues the event immediately
         # This is used by speculate
-        quick = kwargs.pop("quick", False)
+        quick = kwargs.pop("quick", False) or getattr(event, "quick_emit", False)
 
         # skip event if it fails precheck
         if event.type != "DNS_NAME":
@@ -96,7 +96,7 @@ class ScanManager:
         log.debug(f'Module "{event.module}" raised {event}')
 
         if quick:
-            log.debug(f'Module "{event.module}" raised {event}')
+            log.debug(f"Quick-emitting {event}")
             event._resolved.set()
             for kwarg in ["abort_if", "on_success_callback"]:
                 kwargs.pop(kwarg, None)

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -379,6 +379,7 @@ class ScanManager:
         Queue event with modules
         """
         async with self.scan._acatch(context=self.distribute_event):
+            # make event internal if it's above our configured report distance
             event_in_report_distance = event.scope_distance <= self.scan.scope_report_distance
             event_will_be_output = event.always_emit or event_in_report_distance
             if not event_will_be_output:

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -86,7 +86,9 @@ class ScanManager:
         callbacks_requested = any([kwargs.get(k, None) is not None for k in callbacks])
         # "quick" queues the event immediately
         # This is used by speculate
-        quick = kwargs.pop("quick", False) or getattr(event, "quick_emit", False) and not callbacks_requested
+        quick_kwarg = kwargs.pop("quick", False)
+        quick_event = getattr(event, "quick_emit", False)
+        quick = (quick_kwarg or quick_event) and not callbacks_requested
 
         # skip event if it fails precheck
         if event.type != "DNS_NAME":

--- a/bbot/test/test_step_1/test_manager_scope_accuracy.py
+++ b/bbot/test/test_step_1/test_manager_scope_accuracy.py
@@ -670,14 +670,14 @@ async def test_manager_scope_accuracy(bbot_config, bbot_scanner, bbot_httpserver
         _dns_mock={("www.bbottest.notreal", "A"): "127.0.1.0", ("test.notreal", "A"): "127.0.0.1"},
     )
 
-    assert len(events) == 5
+    assert len(events) == 6
     assert 1 == len([e for e in events if e.type == "IP_RANGE" and e.data == "127.0.0.0/31" and e.internal == False and e.scope_distance == 0])
     assert 0 == len([e for e in events if e.type == "IP_ADDRESS" and e.data == "127.0.0.0"])
     assert 1 == len([e for e in events if e.type == "IP_ADDRESS" and e.data == "127.0.0.1"])
     assert 0 == len([e for e in events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.0:9999"])
     assert 1 == len([e for e in events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.1:9999"])
     assert 1 == len([e for e in events if e.type == "DNS_NAME" and e.data == "test.notreal" and e.internal == False and e.scope_distance == 0 and str(e.module) == "sslcert"])
-    assert 0 == len([e for e in events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal"])
+    assert 1 == len([e for e in events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == False and e.scope_distance == 1 and str(e.module) == "sslcert" and "affiliate" in e.tags])
     assert 0 == len([e for e in events if e.type == "OPEN_TCP_PORT" and e.data == "test.notreal:9999"])
     assert 0 == len([e for e in events if e.type == "DNS_NAME_UNRESOLVED" and e.data == "notreal"])
 
@@ -688,7 +688,7 @@ async def test_manager_scope_accuracy(bbot_config, bbot_scanner, bbot_httpserver
     assert 1 == len([e for e in all_events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.0:9999" and e.internal == True and e.scope_distance == 0])
     assert 2 == len([e for e in all_events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.1:9999" and e.internal == False and e.scope_distance == 0])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "test.notreal" and e.internal == False and e.scope_distance == 0 and str(e.module) == "sslcert"])
-    assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == True and e.scope_distance == 1 and str(e.module) == "sslcert"])
+    assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == False and e.scope_distance == 1 and str(e.module) == "sslcert"])
     assert 1 == len([e for e in all_events if e.type == "OPEN_TCP_PORT" and e.data == "www.bbottest.notreal:9999" and e.internal == True and e.scope_distance == 1 and str(e.module) == "speculate"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME_UNRESOLVED" and e.data == "bbottest.notreal" and e.internal == True and e.scope_distance == 2 and str(e.module) == "speculate"])
     assert 1 == len([e for e in all_events if e.type == "OPEN_TCP_PORT" and e.data == "test.notreal:9999" and e.internal == True and e.scope_distance == 0 and str(e.module) == "speculate"])
@@ -701,21 +701,21 @@ async def test_manager_scope_accuracy(bbot_config, bbot_scanner, bbot_httpserver
     assert 1 == len([e for e in all_events_nodups if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.0:9999" and e.internal == True and e.scope_distance == 0])
     assert 1 == len([e for e in all_events_nodups if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.1:9999" and e.internal == False and e.scope_distance == 0])
     assert 1 == len([e for e in all_events_nodups if e.type == "DNS_NAME" and e.data == "test.notreal" and e.internal == False and e.scope_distance == 0 and str(e.module) == "sslcert"])
-    assert 1 == len([e for e in all_events_nodups if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == True and e.scope_distance == 1 and str(e.module) == "sslcert"])
+    assert 1 == len([e for e in all_events_nodups if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == False and e.scope_distance == 1 and str(e.module) == "sslcert"])
     assert 1 == len([e for e in all_events_nodups if e.type == "OPEN_TCP_PORT" and e.data == "www.bbottest.notreal:9999" and e.internal == True and e.scope_distance == 1 and str(e.module) == "speculate"])
     assert 1 == len([e for e in all_events_nodups if e.type == "DNS_NAME_UNRESOLVED" and e.data == "bbottest.notreal" and e.internal == True and e.scope_distance == 2 and str(e.module) == "speculate"])
     assert 1 == len([e for e in all_events_nodups if e.type == "OPEN_TCP_PORT" and e.data == "test.notreal:9999" and e.internal == True and e.scope_distance == 0 and str(e.module) == "speculate"])
     assert 1 == len([e for e in all_events_nodups if e.type == "DNS_NAME_UNRESOLVED" and e.data == "notreal" and e.internal == True and e.scope_distance == 1 and str(e.module) == "speculate"])
 
     for _graph_output_events in (graph_output_events, graph_output_batch_events):
-        assert len(_graph_output_events) == 5
+        assert len(_graph_output_events) == 6
         assert 1 == len([e for e in _graph_output_events if e.type == "IP_RANGE" and e.data == "127.0.0.0/31" and e.internal == False and e.scope_distance == 0])
         assert 0 == len([e for e in _graph_output_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.0"])
         assert 1 == len([e for e in _graph_output_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.1" and e.internal == False and e.scope_distance == 0])
         assert 0 == len([e for e in _graph_output_events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.0:9999"])
         assert 1 == len([e for e in _graph_output_events if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.1:9999" and e.internal == False and e.scope_distance == 0])
         assert 1 == len([e for e in _graph_output_events if e.type == "DNS_NAME" and e.data == "test.notreal" and e.internal == False and e.scope_distance == 0 and str(e.module) == "sslcert"])
-        assert 0 == len([e for e in _graph_output_events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal"])
+        assert 1 == len([e for e in _graph_output_events if e.type == "DNS_NAME" and e.data == "www.bbottest.notreal" and e.internal == False and e.scope_distance == 1 and str(e.module) == "sslcert"])
         assert 0 == len([e for e in _graph_output_events if e.type == "OPEN_TCP_PORT" and e.data == "www.bbottest.notreal:9999"])
         assert 0 == len([e for e in _graph_output_events if e.type == "DNS_NAME_UNRESOLVED" and e.data == "bbottest.notreal"])
         assert 0 == len([e for e in _graph_output_events if e.type == "OPEN_TCP_PORT" and e.data == "test.notreal:9999"])


### PR DESCRIPTION
This PR adds a feature which allows certain "end-of-line" events like `FINDING` and `VULNERABILITY` to skip the line and be immediately emitted. This prevents them from unnecessarily taking up space in the queue and makes sure they get surfaced to the user right away. 