### PR TITLE
Internalize open ports from internetdb

### DIFF
--- a/bbot/modules/internetdb.py
+++ b/bbot/modules/internetdb.py
@@ -95,7 +95,9 @@ class internetdb(BaseModule):
         for cpe in data.get("cpes", []):
             self.emit_event({"technology": cpe, "host": str(event.host)}, "TECHNOLOGY", source=event)
         for port in data.get("ports", []):
-            self.emit_event(self.helpers.make_netloc(event.data, port), "OPEN_TCP_PORT", source=event, internal=True, quick=True)
+            self.emit_event(
+                self.helpers.make_netloc(event.data, port), "OPEN_TCP_PORT", source=event, internal=True, quick=True
+            )
         vulns = data.get("vulns", [])
         if vulns:
             vulns_str = ", ".join([str(v) for v in vulns])

--- a/bbot/modules/internetdb.py
+++ b/bbot/modules/internetdb.py
@@ -95,7 +95,7 @@ class internetdb(BaseModule):
         for cpe in data.get("cpes", []):
             self.emit_event({"technology": cpe, "host": str(event.host)}, "TECHNOLOGY", source=event)
         for port in data.get("ports", []):
-            self.emit_event(self.helpers.make_netloc(event.data, port), "OPEN_TCP_PORT", source=event)
+            self.emit_event(self.helpers.make_netloc(event.data, port), "OPEN_TCP_PORT", source=event, internal=True, quick=True)
         vulns = data.get("vulns", [])
         if vulns:
             vulns_str = ", ".join([str(v) for v in vulns])

--- a/bbot/test/test_step_2/module_tests/test_module_internetdb.py
+++ b/bbot/test/test_step_2/module_tests/test_module_internetdb.py
@@ -36,13 +36,12 @@ class TestInternetDB(ModuleTestBase):
         )
 
     def check(self, module_test, events):
-        assert 8 == len([e for e in events if str(e.module) == "internetdb"])
+        assert 5 == len([e for e in events if str(e.module) == "internetdb"])
         assert 1 == len(
             [e for e in events if e.type == "DNS_NAME" and e.data == "autodiscover.blacklanternsecurity.com"]
         )
         assert 1 == len([e for e in events if e.type == "DNS_NAME" and e.data == "mail.blacklanternsecurity.com"])
-        assert 3 == len([e for e in events if e.type == "OPEN_TCP_PORT" and str(e.module) == "internetdb"])
-        assert 1 == len([e for e in events if e.type == "OPEN_TCP_PORT" and e.data == "blacklanternsecurity.com:443"])
+        assert 0 == len([e for e in events if e.type == "OPEN_TCP_PORT"])
         assert 1 == len([e for e in events if e.type == "FINDING" and str(e.module) == "internetdb"])
         assert 1 == len([e for e in events if e.type == "FINDING" and "CVE-2021-26857" in e.data["description"]])
         assert 2 == len([e for e in events if e.type == "TECHNOLOGY" and str(e.module) == "internetdb"])


### PR DESCRIPTION
Unverified `OPEN_TCP_PORT` events (i.e. ones from passive sources) should be emitted as internal events so they're not displayed to the user until something legitimate has been found on them, such as an SSL cert or web server.