### PR TITLE
Decrease default DNS search distance

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -36,7 +36,7 @@ web_spider_links_per_page: 25
 # How far out from the main scope to search
 scope_search_distance: 0
 # How far out from the main scope to resolve DNS names / IPs
-scope_dns_search_distance: 2
+scope_dns_search_distance: 1
 # Limit how many DNS records can be followed in a row (stop malicious/runaway DNS records)
 dns_resolve_distance: 5
 

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -226,7 +226,7 @@ class Scanner:
         # scope distance
         self.scope_search_distance = max(0, int(self.config.get("scope_search_distance", 0)))
         self.scope_dns_search_distance = max(
-            self.scope_search_distance, int(self.config.get("scope_dns_search_distance", 2))
+            self.scope_search_distance, int(self.config.get("scope_dns_search_distance", 1))
         )
         self.scope_report_distance = int(self.config.get("scope_report_distance", 1))
 


### PR DESCRIPTION
This PR decreases the default DNS search distance. This is a performance optimization, and does not seriously affect results.

Addresses https://github.com/blacklanternsecurity/bbot/issues/950.