### PR TITLE
Shortname rework

### DIFF
--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -207,7 +207,7 @@ class iis_shortnames(BaseModule):
 
     async def handle_event(self, event):
         class safety_counter_obj:
-            counter = 1
+            counter = 0
 
         normalized_url = self.normalize_url(event.data)
         self.scanned_tracker.add(normalized_url)

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -172,7 +172,7 @@ class iis_shortnames(BaseModule):
                 node_count += 1
                 safety_counter.counter += 1
                 if safety_counter.counter > 3000:
-                    raise IISShortnamesError(f"Exceeded safety counter threshhold ({safety_counter.counter})")
+                    raise IISShortnamesError(f"Exceeded safety counter threshold ({safety_counter.counter})")
                 self.verbose(f"node_count: {str(node_count)} for node: {target}")
                 if node_count > self.config.get("max_node_count"):
                     self.warning(

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -241,7 +241,9 @@ class iis_shortnames(BaseModule):
                     )
 
                     if len(confirmed_chars) >= len(valid_chars) - 4:
-                        self.debug(f"Detected [{len(confirmed_chars)}] characters (out of {len(valid_chars)}) as valid. This is likely a false positive")
+                        self.debug(
+                            f"Detected [{len(confirmed_chars)}] characters (out of {len(valid_chars)}) as valid. This is likely a false positive"
+                        )
                         continue
 
                     if len(confirmed_chars) > 0:

--- a/bbot/test/test_step_2/module_tests/test_module_iis_shortnames.py
+++ b/bbot/test/test_step_2/module_tests/test_module_iis_shortnames.py
@@ -43,6 +43,11 @@ class TestIIS_Shortnames(ModuleTestBase):
         respond_args = {"response_data": "", "status": 400}
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
+        for char in "BLSHAX":
+            expect_args = {"method": "GET", "uri": re.compile(rf"\/\*{char}\*~1\*.*$")}
+            respond_args = {"response_data": "", "status": 400}
+            module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
     def check(self, module_test, events):
         vulnerabilityEmitted = False
         url_hintEmitted = False


### PR DESCRIPTION
Dramatically increases the speed of the shortname enumeration (detection_only=False). Something like 200-300% speed increase.

Added several safety checks for results that don't make sense and/or infinite loops in the recursive function to address https://github.com/blacklanternsecurity/bbot/issues/883.