### PR TITLE
Fix Passive Portscanner Bug

### DIFF
--- a/bbot/modules/internal/speculate.py
+++ b/bbot/modules/internal/speculate.py
@@ -37,7 +37,8 @@ class speculate(BaseInternalModule):
     async def setup(self):
         scan_modules = [m for m in self.scan.modules.values() if m._type == "scan"]
         self.open_port_consumers = any(["OPEN_TCP_PORT" in m.watched_events for m in scan_modules])
-        self.portscanner_enabled = any(["portscan" in m.flags for m in self.scan.modules.values()])
+        # only consider active portscanners (still speculate if only passive ones are enabled)
+        self.portscanner_enabled = any(["portscan" in m.flags and "active" in m.flags for m in self.scan.modules.values()])
         self.emit_open_ports = self.open_port_consumers and not self.portscanner_enabled
         self.range_to_ip = True
         self.dns_resolution = self.scan.config.get("dns_resolution", True)

--- a/bbot/modules/internal/speculate.py
+++ b/bbot/modules/internal/speculate.py
@@ -38,7 +38,9 @@ class speculate(BaseInternalModule):
         scan_modules = [m for m in self.scan.modules.values() if m._type == "scan"]
         self.open_port_consumers = any(["OPEN_TCP_PORT" in m.watched_events for m in scan_modules])
         # only consider active portscanners (still speculate if only passive ones are enabled)
-        self.portscanner_enabled = any(["portscan" in m.flags and "active" in m.flags for m in self.scan.modules.values()])
+        self.portscanner_enabled = any(
+            ["portscan" in m.flags and "active" in m.flags for m in self.scan.modules.values()]
+        )
         self.emit_open_ports = self.open_port_consumers and not self.portscanner_enabled
         self.range_to_ip = True
         self.dns_resolution = self.scan.config.get("dns_resolution", True)

--- a/bbot/test/test_step_2/module_tests/test_module_speculate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_speculate.py
@@ -20,3 +20,67 @@ class TestSpeculate_Subdirectories(ModuleTestBase):
 
     def check(self, module_test, events):
         assert any(e.type == "URL_UNVERIFIED" and e.data == "http://127.0.0.1:8888/subdir1/" for e in events)
+
+
+class TestSpeculate_OpenPorts(ModuleTestBase):
+    targets = ["evilcorp.com"]
+    modules_overrides = ["speculate", "certspotter", "internetdb"]
+    config_overrides = {"speculate": True}
+
+    async def setup_before_prep(self, module_test):
+        module_test.scan.helpers.dns.mock_dns(
+            {
+                ("evilcorp.com", "A"): "127.0.254.1",
+                ("asdf.evilcorp.com", "A"): "127.0.254.2",
+            }
+        )
+
+        module_test.httpx_mock.add_response(
+            url="https://api.certspotter.com/v1/issuances?domain=evilcorp.com&include_subdomains=true&expand=dns_names",
+            json=[{"dns_names": ["*.asdf.evilcorp.com"]}],
+        )
+
+        from bbot.modules.base import BaseModule
+
+        class DummyModule(BaseModule):
+            _name = "dummy"
+            watched_events = ["OPEN_TCP_PORT"]
+            scope_distance_modifier = 10
+            accept_dupes = True
+
+            async def setup(self):
+                self.events = []
+                return True
+
+            async def handle_event(self, event):
+                self.events.append(event)
+
+        module_test.scan.modules["dummy"] = DummyModule(module_test.scan)
+
+    def check(self, module_test, events):
+        events_data = set()
+        for e in module_test.scan.modules["dummy"].events:
+            events_data.add(e.data)
+        assert all(
+            [
+                x in events_data
+                for x in ("evilcorp.com:80", "evilcorp.com:443", "asdf.evilcorp.com:80", "asdf.evilcorp.com:443")
+            ]
+        )
+
+
+class TestSpeculate_OpenPorts_Portscanner(TestSpeculate_OpenPorts):
+    targets = ["evilcorp.com"]
+    modules_overrides = ["speculate", "certspotter", "nmap"]
+    config_overrides = {"speculate": True}
+
+    def check(self, module_test, events):
+        events_data = set()
+        for e in module_test.scan.modules["dummy"].events:
+            events_data.add(e.data)
+        assert not any(
+            [
+                x in events_data
+                for x in ("evilcorp.com:80", "evilcorp.com:443", "asdf.evilcorp.com:80", "asdf.evilcorp.com:443")
+            ]
+        )


### PR DESCRIPTION
This fixes a bug where if a passive portscanner was enabled (e.g. `internetdb`), `speculate` would not emit open ports. After this fix, `speculate` will always emit open ports unless an _active_ port scanner is enabled.