### PR TITLE
Add option to store httpx responses

### DIFF
--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -13,12 +13,13 @@ class httpx(BaseModule):
     flags = ["active", "safe", "web-basic", "web-thorough", "social-enum", "subdomain-enum", "cloud-enum"]
     meta = {"description": "Visit webpages. Many other modules rely on httpx"}
 
-    options = {"threads": 50, "in_scope_only": True, "version": "1.2.5", "max_response_size": 5242880}
+    options = {"threads": 50, "in_scope_only": True, "version": "1.2.5", "max_response_size": 5242880, "store_responses": False}
     options_desc = {
         "threads": "Number of httpx threads to use",
         "in_scope_only": "Only visit web resources that are in scope.",
         "version": "httpx version",
         "max_response_size": "Max response size in bytes",
+        "store_responses": "Save raw HTTP responses to scan folder",
     }
     deps_ansible = [
         {
@@ -41,6 +42,7 @@ class httpx(BaseModule):
         self.timeout = self.scan.config.get("httpx_timeout", 5)
         self.retries = self.scan.config.get("httpx_retries", 1)
         self.max_response_size = self.config.get("max_response_size", 5242880)
+        self.store_responses = self.config.get("store_responses", False)
         self.visited = set()
         self.httpx_tempdir_regex = re.compile(r"^httpx\d+$")
         return True
@@ -103,6 +105,11 @@ class httpx(BaseModule):
             "-response-size-to-read",
             f"{self.max_response_size}",
         ]
+
+        if self.store_responses:
+            response_dir = self.scan.home / "httpx"
+            self.helpers.mkdir(response_dir)
+            command += ["-srd", str(response_dir)]
 
         dns_resolvers = ",".join(self.helpers.system_resolvers)
         if dns_resolvers:

--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -13,7 +13,13 @@ class httpx(BaseModule):
     flags = ["active", "safe", "web-basic", "web-thorough", "social-enum", "subdomain-enum", "cloud-enum"]
     meta = {"description": "Visit webpages. Many other modules rely on httpx"}
 
-    options = {"threads": 50, "in_scope_only": True, "version": "1.2.5", "max_response_size": 5242880, "store_responses": False}
+    options = {
+        "threads": 50,
+        "in_scope_only": True,
+        "version": "1.2.5",
+        "max_response_size": 5242880,
+        "store_responses": False,
+    }
     options_desc = {
         "threads": "Number of httpx threads to use",
         "in_scope_only": "Only visit web resources that are in scope.",

--- a/bbot/test/test_step_2/module_tests/test_module_httpx.py
+++ b/bbot/test/test_step_2/module_tests/test_module_httpx.py
@@ -3,6 +3,7 @@ from .base import ModuleTestBase
 
 class TestHTTPX(ModuleTestBase):
     targets = ["http://127.0.0.1:8888/url", "127.0.0.1:8888"]
+    config_overrides = {"modules": {"httpx": {"store_responses": True}}}
 
     # HTML for a page with a login form
     html_with_login = """
@@ -48,6 +49,8 @@ class TestHTTPX(ModuleTestBase):
                     url = True
         assert url, "Failed to visit target URL"
         assert open_port, "Failed to visit target OPEN_TCP_PORT"
+        saved_response = module_test.scan.home / "httpx" / "127.0.0.1.8888[slash]url.txt"
+        assert saved_response.is_file(), "Failed to save raw httpx response"
 
 
 class TestHTTPX_404(ModuleTestBase):


### PR DESCRIPTION
This PR enables `httpx` to store its raw HTTP responses. This is off by default, but can be enabled with `-c modules.httpx.store_responses=true`.

![image](https://github.com/blacklanternsecurity/bbot/assets/20261699/733badad-ee3f-4772-bbe8-2dc3fc61b3b3)

Addresses https://github.com/blacklanternsecurity/bbot/issues/864.