### PR TITLE
Fix: postman module including out-of-scope workspaces

### DIFF
--- a/bbot/modules/postman.py
+++ b/bbot/modules/postman.py
@@ -70,16 +70,22 @@ class postman(subdomain_enum):
                     workspaces.append(workspace)
         for item in workspaces:
             id = item.get("id", "")
-            interesting_urls.append(f"{self.base_url}/workspace/{id}")
-            environments, collections = await self.search_workspace(id)
-            interesting_urls.append(f"{self.base_url}/workspace/{id}/globals")
-            for e_id in environments:
-                interesting_urls.append(f"{self.base_url}/environment/{e_id}")
-            for c_id in collections:
-                interesting_urls.append(f"{self.base_url}/collection/{c_id}")
-            requests = await self.search_collections(id)
-            for r_id in requests:
-                interesting_urls.append(f"{self.base_url}/request/{r_id}")
+            name = item.get("name", "")
+            tldextract = self.helpers.tldextract(query)
+            if tldextract.domain.lower() in name.lower():
+                self.verbose(f"Discovered workspace {name} ({id})")
+                interesting_urls.append(f"{self.base_url}/workspace/{id}")
+                environments, collections = await self.search_workspace(id)
+                interesting_urls.append(f"{self.base_url}/workspace/{id}/globals")
+                for e_id in environments:
+                    interesting_urls.append(f"{self.base_url}/environment/{e_id}")
+                for c_id in collections:
+                    interesting_urls.append(f"{self.base_url}/collection/{c_id}")
+                requests = await self.search_collections(id)
+                for r_id in requests:
+                    interesting_urls.append(f"{self.base_url}/request/{r_id}")
+            else:
+                self.verbose(f"Skipping workspace {name} ({id}) as it does not appear to be in scope")
         return interesting_urls
 
     async def search_workspace(self, id):

--- a/bbot/test/test_step_2/module_tests/test_module_postman.py
+++ b/bbot/test/test_step_2/module_tests/test_module_postman.py
@@ -30,9 +30,9 @@ class TestPostman(ModuleTestBase):
                             "workspaces": [
                                 {
                                     "visibilityStatus": "public",
-                                    "name": "SpilledSecrets",
+                                    "name": "BlackLanternSecuritySpilledSecrets",
                                     "id": "afa061be-9cb0-4520-9d4d-fe63361daf0f",
-                                    "slug": "spilledsecrets",
+                                    "slug": "blacklanternsecurityspilledsecrets",
                                 }
                             ],
                             "collectionForkLabel": "",
@@ -50,6 +50,52 @@ class TestPostman(ModuleTestBase):
                             "documentType": "request",
                             "collection": {
                                 "id": "28129865-d9f8833b-3dd2-4b07-9634-1831206d5205",
+                                "name": "Secret Collection",
+                                "tags": [],
+                                "forkCount": 0,
+                                "watcherCount": 0,
+                                "views": 31,
+                                "apiId": "",
+                                "apiName": "",
+                            },
+                        },
+                    },
+                    {
+                        "score": 498.22398,
+                        "normalizedScore": 8.43312266976538,
+                        "document": {
+                            "isPublisherVerified": False,
+                            "publisherType": "user",
+                            "curatedInList": [],
+                            "publisherId": "28329861",
+                            "publisherHandle": "",
+                            "publisherLogo": "",
+                            "isPublic": True,
+                            "customHostName": "",
+                            "id": "b7fa2137-b7fa2137-23bf-45d1-b176-35359af30ded",
+                            "workspaces": [
+                                {
+                                    "visibilityStatus": "public",
+                                    "name": "SpilledSecrets",
+                                    "id": "92d0451b-119d-4ef0-b74c-22c400e5ce05",
+                                    "slug": "spilledsecrets",
+                                }
+                            ],
+                            "collectionForkLabel": "",
+                            "method": "POST",
+                            "entityType": "request",
+                            "url": "www.example.com/index",
+                            "isBlacklisted": False,
+                            "warehouse__updated_at_collection": "2023-12-11 02:00:00",
+                            "isPrivateNetworkEntity": False,
+                            "warehouse__updated_at_request": "2023-12-11 02:00:00",
+                            "publisherName": "NA",
+                            "name": "A test post request",
+                            "privateNetworkMeta": "",
+                            "privateNetworkFolders": [],
+                            "documentType": "request",
+                            "collection": {
+                                "id": "007e8d67-007e8d67-932b-46ff-b95c-a2aa216edaf3",
                                 "name": "Secret Collection",
                                 "tags": [],
                                 "forkCount": 0,
@@ -199,6 +245,9 @@ class TestPostman(ModuleTestBase):
         assert any(
             e.data == "http://127.0.0.1:8888/_api/workspace/afa061be-9cb0-4520-9d4d-fe63361daf0f" for e in events
         ), "Failed to detect workspace"
+        assert any(
+            e.data != "http://127.0.0.1:8888/_api/workspace/92d0451b-119d-4ef0-b74c-22c400e5ce05" for e in events
+        ), "Workspace should not be detected"
         assert any(
             e.data == "http://127.0.0.1:8888/_api/workspace/afa061be-9cb0-4520-9d4d-fe63361daf0f/globals"
             for e in events


### PR DESCRIPTION
The postman module was including out-of-scope workspaces as discussed in #1008.

The query to the postman public API was including results for workspaces that were not explicitly matching the original query, This PR will discard any workspaces from the results that do not contain the domain name. To use the example from the discussion:
By sending the query
```
"queryText":"watsons.com",
```

This yielded results for:
```
"workspaces":[{"visibilityStatus":"public","name":"IBM Watson","id":"5c59cf9e-5dac-43d6-8e43-02bff365be1c","slug":"ibm-watson"}],
```

Which should not be deemed in scope so I have added an if statement which should discard these:
```
>>> "watsons" in "ibm watson"
False
```

The test has also been updated so the query responds with two workspaces one does not contain the target organization so it should be discarded