### PR TITLE
Removing Odd Characters from docs

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -70,7 +70,7 @@ class nuclei(BaseModule):
         else:
             self.warning("Error running nuclei template update command")
         self.proxy = self.scan.config.get("http_proxy", "")
-        self.mode = self.config.get("mode", "severe")
+        self.mode = self.config.get("mode", "severe").lower()
         self.ratelimit = int(self.config.get("ratelimit", 150))
         self.concurrency = int(self.config.get("concurrency", 25))
         self.budget = int(self.config.get("budget", 1))

--- a/docs/modules/nuclei.md
+++ b/docs/modules/nuclei.md
@@ -8,7 +8,7 @@ BBOT integrates with [Nuclei](https://github.com/projectdiscovery/nuclei), an op
 
 
 * The BBOT Nuclei module ingests **[URL]** events and emits events of type **[VULNERABILITY]** or **[FINDING]**
-* Vulnerabilities will inherit their severity from the Nuclei templates​
+* Vulnerabilities will inherit their severity from the Nuclei templates
 * Nuclei templates of severity INFO will be emitted as **[FINDINGS]**
 
 ## Default Behavior
@@ -59,15 +59,15 @@ This is equivalent to the Nuclei '-as' scan option. It only use templates that m
 
 #### Budget
 
-Budget mode is unique to BBOT. ​
+Budget mode is unique to BBOT.
 
-For larger scans with thousands of targets, doing a FULL Nuclei scan (1000s of Requests) for each is not realistic. ​
-As an alternative to the other modes, you can take advantage of Nuclei's "collapsible" template feature. ​
+For larger scans with thousands of targets, doing a FULL Nuclei scan (1000s of Requests) for each is not realistic. 
+As an alternative to the other modes, you can take advantage of Nuclei's "collapsible" template feature. 
 
 For only the cost of one (or more) "extra" request(s) per host, it can activate several hundred modules. These are modules which happen to look at a BaseUrl, and typically look for a specific string or other attribute. Nuclei is smart about reusing the request data when it can, and we can use this to our advantage. 
 
-The budget parameter is the # of extra requests per host you are willing to send to "feed" Nuclei templates​ (defaults to 1).
-For those times when vulnerability scanning isn't the main focus, but you want to look for easy wins.​
+The budget parameter is the # of extra requests per host you are willing to send to "feed" Nuclei templates (defaults to 1).
+For those times when vulnerability scanning isn't the main focus, but you want to look for easy wins.
 
 Of course, there is a rapidly diminishing return when you set he value to more than a handful. Eventually, this becomes 1 template per 1 budget value increase. However, in the 1-10 range there is a lot of value. This graphic should give you a rough visual idea of this concept.
 
@@ -86,20 +86,20 @@ The **ratelimit** and **concurrency** settings default to the same defaults that
 
 ```bash
 # Scan a SINGLE target with a basic port scan and web modules
-bbot -f web-basic -m nmap nuclei --allow-deadly -t app.evilcorp.com​
+bbot -f web-basic -m nmap nuclei --allow-deadly -t app.evilcorp.com
 ```
 
 ```bash
 # Scanning MULTIPLE targets
-bbot -f web-basic -m nmap nuclei --allow-deadly -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com​
+bbot -f web-basic -m nmap nuclei --allow-deadly -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com
 ```
 
 ```bash
 # Scanning MULTIPLE targets while performing subdomain enumeration
-bbot -f subdomain-enum web-basic -m nmap nuclei –allow-deadly -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com​
+bbot -f subdomain-enum web-basic -m nmap nuclei --allow-deadly -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com
 ```
 
 ```bash
-# Scanning MULTIPLE targets on a BUDGET​
-bbot -f subdomain-enum web-basic -m nmap nuclei –allow-deadly –c modules.nuclei.mode=Budget -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com​
+# Scanning MULTIPLE targets on a BUDGET
+bbot -f subdomain-enum web-basic -m nmap nuclei --allow-deadly -c modules.nuclei.mode=budget -t app1.evilcorp.com app2.evilcorp.com app3.evilcorp.com
 ```

--- a/docs/scanning/events.md
+++ b/docs/scanning/events.md
@@ -87,12 +87,12 @@ BBOT has a sharp distinction between Findings and Vulnerabilities:
 
 **VULNERABILITY**
 
-* There's a higher standard for what is allowed to be a vulnerability. They should be considered **confirmed** and **actionable​** - no additional confirmation required
-* They are always assigned a severity. The possible severities are: LOW, MEDIUM, HIGH, or CRITICAL​
+* There's a higher standard for what is allowed to be a vulnerability. They should be considered **confirmed** and **actionable** - no additional confirmation required
+* They are always assigned a severity. The possible severities are: LOW, MEDIUM, HIGH, or CRITICAL
 
-**FINDING​**
+**FINDING**
 
-* Findings can range anywhere from "slightly interesting behavior" to "likely, but unconfirmed vulnerability"​
+* Findings can range anywhere from "slightly interesting behavior" to "likely, but unconfirmed vulnerability"
 * Are often false positives
 
 By making this separation, actionable vulnerabilities can be identified quickly in the midst of a large scan


### PR DESCRIPTION
Strange characters ended up in the docs which was probably the root cause of this issue: https://github.com/blacklanternsecurity/bbot/issues/1054

Also made the nuclei budget mode case-insensitive