### PR TITLE
Asset Inventory - Verify if hosts are still live across scans and reflect this in the csv

### DIFF
--- a/bbot/modules/output/asset_inventory.py
+++ b/bbot/modules/output/asset_inventory.py
@@ -34,10 +34,11 @@ class asset_inventory(CSV):
     ]
     produced_events = ["IP_ADDRESS", "OPEN_TCP_PORT"]
     meta = {"description": "Merge hosts, open ports, technologies, findings, etc. into a single asset inventory CSV"}
-    options = {"output_file": "", "use_previous": False, "summary_netmask": 16}
+    options = {"output_file": "", "use_previous": False, "recheck": False, "summary_netmask": 16}
     options_desc = {
         "output_file": "Set a custom output file",
         "use_previous": "Emit previous asset inventory as new events (use in conjunction with -n <old_scan_name>)",
+        "recheck": "recheck the open ports and findings from the previous asset inventory (use in conjunction with use_previous)",
         "summary_netmask": "Subnet mask to use when summarizing IP addresses at end of scan",
     }
 
@@ -60,6 +61,7 @@ class asset_inventory(CSV):
     async def setup(self):
         self.assets = {}
         self.use_previous = self.config.get("use_previous", False)
+        self.recheck = self.config.get("recheck", False)
         self.summary_netmask = self.config.get("summary_netmask", 16)
         self.emitted_contents = False
         self._ran_hooks = False
@@ -81,7 +83,7 @@ class asset_inventory(CSV):
         if (await self.filter_event(event))[0]:
             hostkey = _make_hostkey(event.host, event.resolved_hosts)
             if hostkey not in self.assets:
-                self.assets[hostkey] = Asset(event.host)
+                self.assets[hostkey] = Asset(event.host, self.recheck)
             self.assets[hostkey].absorb_event(event)
 
     async def report(self):
@@ -171,7 +173,7 @@ class asset_inventory(CSV):
                         hostkey = _make_hostkey(host, ips)
                         asset = self.assets.get(hostkey, None)
                         if asset is None:
-                            asset = Asset(host)
+                            asset = Asset(host, self.recheck)
                             self.assets[hostkey] = asset
                         asset.absorb_csv_row(row)
                         self.add_custom_headers(list(asset.custom_fields))
@@ -211,7 +213,7 @@ class asset_inventory(CSV):
 
 
 class Asset:
-    def __init__(self, host):
+    def __init__(self, host, recheck):
         self.host = host
         self.ip_addresses = set()
         self.dns_records = set()
@@ -227,6 +229,7 @@ class Asset:
         self.http_status = 0
         self.http_title = ""
         self.redirect_location = ""
+        self.recheck = recheck
 
     def absorb_csv_row(self, row):
         # host
@@ -236,19 +239,21 @@ class Asset:
         # ips
         self.ip_addresses = set(_make_ip_list(row.get("IP (External)", "")))
         self.ip_addresses.update(set(_make_ip_list(row.get("IP (Internal)", ""))))
-        # ports
-        ports = [i.strip() for i in row.get("Open Ports", "").split(",")]
-        self.ports.update(set(i for i in ports if i and is_port(i)))
-        # findings
-        findings = [i.strip() for i in row.get("Findings", "").splitlines()]
-        self.findings.update(set(i for i in findings if i))
+        # If user reqests a recheck dont use the following fields
+        if not self.recheck:
+            # ports
+            ports = [i.strip() for i in row.get("Open Ports", "").split(",")]
+            self.ports.update(set(i for i in ports if i and is_port(i)))
+            # findings
+            findings = [i.strip() for i in row.get("Findings", "").splitlines()]
+            self.findings.update(set(i for i in findings if i))
+            # risk rating
+            risk_rating = row.get("Risk Rating", "").strip()
+            if risk_rating and risk_rating.isdigit() and int(risk_rating) > self.risk_rating:
+                self.risk_rating = int(risk_rating)
         # technologies
         technologies = [i.strip() for i in row.get("Technologies", "").splitlines()]
         self.technologies.update(set(i for i in technologies if i))
-        # risk rating
-        risk_rating = row.get("Risk Rating", "").strip()
-        if risk_rating and risk_rating.isdigit() and int(risk_rating) > self.risk_rating:
-            self.risk_rating = int(risk_rating)
         # provider
         provider = row.get("Provider", "").strip()
         if provider:

--- a/bbot/modules/output/asset_inventory.py
+++ b/bbot/modules/output/asset_inventory.py
@@ -38,7 +38,7 @@ class asset_inventory(CSV):
     options_desc = {
         "output_file": "Set a custom output file",
         "use_previous": "Emit previous asset inventory as new events (use in conjunction with -n <old_scan_name>)",
-        "recheck": "recheck the open ports and findings from the previous asset inventory (use in conjunction with use_previous)",
+        "recheck": "When use_previous=True, don't retain past details like open ports or findings. Instead, allow them to be rediscovered by the new scan",
         "summary_netmask": "Subnet mask to use when summarizing IP addresses at end of scan",
     }
 

--- a/bbot/modules/output/asset_inventory.py
+++ b/bbot/modules/output/asset_inventory.py
@@ -239,7 +239,7 @@ class Asset:
         # ips
         self.ip_addresses = set(_make_ip_list(row.get("IP (External)", "")))
         self.ip_addresses.update(set(_make_ip_list(row.get("IP (Internal)", ""))))
-        # If user reqests a recheck dont use the following fields
+        # If user reqests a recheck dont import the following fields to force them to be rechecked
         if not self.recheck:
             # ports
             ports = [i.strip() for i in row.get("Open Ports", "").split(",")]
@@ -247,17 +247,17 @@ class Asset:
             # findings
             findings = [i.strip() for i in row.get("Findings", "").splitlines()]
             self.findings.update(set(i for i in findings if i))
+            # technologies
+            technologies = [i.strip() for i in row.get("Technologies", "").splitlines()]
+            self.technologies.update(set(i for i in technologies if i))
             # risk rating
             risk_rating = row.get("Risk Rating", "").strip()
             if risk_rating and risk_rating.isdigit() and int(risk_rating) > self.risk_rating:
                 self.risk_rating = int(risk_rating)
-        # technologies
-        technologies = [i.strip() for i in row.get("Technologies", "").splitlines()]
-        self.technologies.update(set(i for i in technologies if i))
-        # provider
-        provider = row.get("Provider", "").strip()
-        if provider:
-            self.provider = provider
+            # provider
+            provider = row.get("Provider", "").strip()
+            if provider:
+                self.provider = provider
         # custom fields
         for k, v in row.items():
             v = str(v)

--- a/bbot/test/test_step_2/module_tests/test_module_asset_inventory.py
+++ b/bbot/test/test_step_2/module_tests/test_module_asset_inventory.py
@@ -49,3 +49,19 @@ class TestAsset_InventoryEmitPrevious(TestAsset_Inventory):
         with open(filename) as f:
             content = f.read()
             assert "bbottest.notreal" in content
+
+
+class TestAsset_InventoryRecheck(TestAsset_Inventory):
+    config_overrides = {
+        "dns_resolution": True,
+        "output_modules": {"asset_inventory": {"use_previous": True, "recheck": True}},
+    }
+    modules_overrides = ["asset_inventory"]
+
+    def check(self, module_test, events):
+        assert not any(e.type == "OPEN_TCP_PORT" for e in events), "Open port was emitted"
+        assert any(e.data == "www.bbottest.notreal" for e in events), "No DNS name found"
+        filename = next(module_test.scan.home.glob("asset-inventory.csv"))
+        with open(filename) as f:
+            content = f.read()
+            assert "www.bbottest.notreal,,,127.0.0.1" in content


### PR DESCRIPTION
This PR adds a boolean `recheck` option to the asset inventory output module.

Currently when using the `use_previous` option with the asset inventory output hosts that close ports in-between scans do not have this change reflected in the asset inventory.

This is because when `use_previous` is used `OPEN_TCP_PORT` events are emitted from the `finish()` function of the asset inventory even though those ports may no longer be open. Emitting the previously open ports can be beneficial in speeding up scans of large targets, however if a user wishes to view asset inventory across multiple scans and see what hosts have gone offline over time / closed ports this is currently not reflected.

If the user passes the recheck option on the command line only `DNS_NAMES` and `IP_ADDRESS` events will be emitted that where previously seen forcing the modules to recheck any open ports / findings etc. Hosts that no longer have open ports will leave that column blank now.