### PR TITLE
Better link extraction

### DIFF
--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -72,6 +72,7 @@ class URLExtractor(BaseExtractor):
         "fulluri": r"(?i)" + r"([a-z]\w{1,15})://" + url_path_regex,
         "fullurl": r"(?i)" + r"(https?)://" + url_path_regex,
         "a-tag": r"<a\s+(?:[^>]*?\s+)?href=([\"'])(.*?)\1",
+        "link-tag": r"<link\s+(?:[^>]*?\s+)?href=([\"'])(.*?)\1",
         "script-tag": r"<script\s+(?:[^>]*?\s+)?src=([\"'])(.*?)\1",
     }
 
@@ -129,7 +130,7 @@ class URLExtractor(BaseExtractor):
                     protocol, other = result
                     result = f"{protocol}://{other}"
 
-                elif name in ("a-tag", "script-tag") and parsed:
+                elif parsed and name.endswith("-tag"):
                     path = html.unescape(result[1])
 
                     for p in self.prefix_blacklist:

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -17,7 +17,12 @@ class TestExcavate(ModuleTestBase):
         \\x3dwww6.test.notreal
         %0awww7.test.notreal
         \\u000awww8.test.notreal
-        <a src="http://www9.test.notreal">
+        # these ones shouldn't get emitted because they're .js (url_extension_httpx_only)
+        <a href="/a_relative.js">
+        <link href="/link_relative.js">
+        # these ones should
+        <a href="/a_relative.txt">
+        <link href="/link_relative.txt">
         """
         expect_args = {"method": "GET", "uri": "/"}
         respond_args = {"response_data": response_data}
@@ -49,7 +54,10 @@ class TestExcavate(ModuleTestBase):
         assert "www6.test.notreal" in event_data
         assert "www7.test.notreal" in event_data
         assert "www8.test.notreal" in event_data
-        assert "http://www9.test.notreal/" in event_data
+        assert not "http://127.0.0.1:8888/a_relative.js" in event_data
+        assert not "http://127.0.0.1:8888/link_relative.js" in event_data
+        assert "http://127.0.0.1:8888/a_relative.txt" in event_data
+        assert "http://127.0.0.1:8888/link_relative.txt" in event_data
 
         assert "nhttps://www1.test.notreal/" not in event_data
         assert "x3dhttps://www2.test.notreal/" not in event_data


### PR DESCRIPTION
Addresses https://github.com/blacklanternsecurity/bbot/issues/1121:

> This is my command:
> 
> bbot -t react.dev -m httpx -c web_spider_distance=3 web_spider_depth=3 web_spider_links_per_page=500 omit_event_types=[]
> 
> And bbot can't detect any of these JS as links
> 
> ![image](https://private-user-images.githubusercontent.com/15929497/307865278-04aff98d-b749-4092-a687-8e2ac4a9cb74.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDg5OTEwMDIsIm5iZiI6MTcwODk5MDcwMiwicGF0aCI6Ii8xNTkyOTQ5Ny8zMDc4NjUyNzgtMDRhZmY5OGQtYjc0OS00MDkyLWE2ODctOGUyYWM0YTljYjc0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAyMjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMjI2VDIzMzgyMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTAwZTNjMTJmYTI1MTQ4MTFmM2NhNTQwZmY0M2ZmNDc0ZDlhZDFiYmNhOGVhNTQ4NDc5Mzg0OGIxMjhmMmQzYjQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.A86ydIqheC9olDfP_gguWf7f_HheisIVh8-ZkpBb2yw)
> 
> For example this link not exists in output file: https://react.dev/_next/static/chunks/webpack-8af07453075e2970.js

