### PR TITLE
Emit TECHNOLOGY Events from Nuclei Module

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -147,7 +147,9 @@ class nuclei(BaseModule):
 
             if severity == "INFO" and "tech" in tags:
                 await self.emit_event(
-                    {"technology": str(name).lower(), "url": url, "host": str(source_event.host)}, "TECHNOLOGY", source_event
+                    {"technology": str(name).lower(), "url": url, "host": str(source_event.host)},
+                    "TECHNOLOGY",
+                    source_event,
                 )
                 continue
 

--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -6,7 +6,7 @@ from bbot.modules.base import BaseModule
 
 class nuclei(BaseModule):
     watched_events = ["URL"]
-    produced_events = ["FINDING", "VULNERABILITY"]
+    produced_events = ["FINDING", "VULNERABILITY", "TECHNOLOGY"]
     flags = ["active", "aggressive"]
     meta = {"description": "Fast and customisable vulnerability scanner"}
 

--- a/bbot/test/test_step_2/module_tests/test_module_nuclei.py
+++ b/bbot/test/test_step_2/module_tests/test_module_nuclei.py
@@ -122,7 +122,7 @@ class TestNucleiBudget(TestNucleiManual):
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert any(e.type == "FINDING" and "SpiderFoot" in e.data["description"] for e in events)
+        assert any(e.type == "TECHNOLOGY" and "spider" in e.data["technology"] for e in events)
 
 
 class TestNucleiRetries(TestNucleiManual):

--- a/bbot/test/test_step_2/module_tests/test_module_nuclei.py
+++ b/bbot/test/test_step_2/module_tests/test_module_nuclei.py
@@ -97,7 +97,7 @@ class TestNucleiTechnology(TestNucleiManual):
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert any(e.type == "FINDING" and "apache" in e.data["description"] for e in events)
+        assert any(e.type == "TECHNOLOGY" and "apache" in e.data["technology"].lower() for e in events)
 
         with open(module_test.scan.home / "debug.log") as f:
             assert "Using Interactsh Server" not in f.read()


### PR DESCRIPTION
Adds `TECHNOLOGY` detection in Nuclei, as requested in https://github.com/blacklanternsecurity/bbot/issues/1178.