### PR TITLE
Social - Extract Docker Profiles

### DIFF
--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -33,9 +33,9 @@ class dockerhub(BaseModule):
             api_result = await self.helpers.request(profile_url)
             status_code = getattr(api_result, "status_code", 0)
             if status_code == 200:
-                url = "https://hub.docker.com/u/" + profile_name
+                url = "https://hub.docker.com/u/" + p
                 await self.emit_event(
-                    {"platform": "docker", "url": url, "profile_name": profile_name}, "SOCIAL", source=event
+                    {"platform": "docker", "url": url, "profile_name": p}, "SOCIAL", source=event
                 )
 
     async def handle_social(self, event):

--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -38,13 +38,13 @@ class dockerhub(BaseModule):
                 await self.emit_event(
                     {"platform": "docker", "url": site_url, "profile_name": p}, "SOCIAL", source=event
                 )
-                # emit API endpoint to be visited by httpx (for url/email extraction, etc.)
-                await self.emit_event(api_url, "URL_UNVERIFIED", source=event, tags="httpx-safe")
 
     async def handle_social(self, event):
         username = event.data.get("profile_name", "")
         if not username:
             return
+        # emit API endpoint to be visited by httpx (for url/email extraction, etc.)
+        await self.emit_event(f"{self.api_url}/users/{p}", "URL_UNVERIFIED", source=event, tags="httpx-safe")
         self.verbose(f"Searching for docker images belonging to {username}")
         repos = await self.get_repos(username)
         for repo in repos:

--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -44,7 +44,7 @@ class dockerhub(BaseModule):
         if not username:
             return
         # emit API endpoint to be visited by httpx (for url/email extraction, etc.)
-        await self.emit_event(f"{self.api_url}/users/{p}", "URL_UNVERIFIED", source=event, tags="httpx-safe")
+        await self.emit_event(f"{self.api_url}/users/{username}", "URL_UNVERIFIED", source=event, tags="httpx-safe")
         self.verbose(f"Searching for docker images belonging to {username}")
         repos = await self.get_repos(username)
         for repo in repos:

--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -29,7 +29,6 @@ class dockerhub(BaseModule):
         profiles_to_check = set([profile_name, profile_name.lower()])
         for p in profiles_to_check:
             profile_url = f"{self.base_url}/users/{p}"
-            self.critical(profile_url)
             api_result = await self.helpers.request(profile_url)
             status_code = getattr(api_result, "status_code", 0)
             if status_code == 200:

--- a/bbot/modules/social.py
+++ b/bbot/modules/social.py
@@ -18,6 +18,7 @@ class social(BaseModule):
         "bitbucket": r"(?:https?://)?(?:www.)?bitbucket.org/([a-zA-Z0-9_-]+)/?",
         "gitlab": r"(?:https?://)?(?:www.)?gitlab.com/([a-zA-Z0-9_-]+)/?",
         "discord": r"(?:https?://)?(?:www.)?discord.gg/([a-zA-Z0-9_-]+)/?",
+        "docker": r"(?:https?://)?hub.docker.com/[ur]/([a-zA-Z0-9_-]+)/?",
     }
 
     scope_distance_modifier = 1

--- a/bbot/test/test_step_2/module_tests/test_module_dockerhub.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dockerhub.py
@@ -6,6 +6,22 @@ class TestDockerhub(ModuleTestBase):
 
     async def setup_before_prep(self, module_test):
         module_test.httpx_mock.add_response(
+            url="https://hub.docker.com/v2/users/blacklanternsecurity",
+            json={
+                "id": "f90895d9cf484d9182c6dbbef2632329",
+                "uuid": "f90895d9-cf48-4d91-82c6-dbbef2632329",
+                "username": "blacklanternsecurity",
+                "full_name": "",
+                "location": "",
+                "company": "Black Lantern Security",
+                "profile_url": "https://github.com/blacklanternsecurity",
+                "date_joined": "2022-08-29T15:27:10.227081Z",
+                "gravatar_url": "",
+                "gravatar_email": "",
+                "type": "User",
+            },
+        )
+        module_test.httpx_mock.add_response(
             url="https://hub.docker.com/v2/repositories/blacklanternsecurity?page_size=25&page=1",
             json={
                 "count": 2,

--- a/bbot/test/test_step_2/module_tests/test_module_social.py
+++ b/bbot/test/test_step_2/module_tests/test_module_social.py
@@ -8,12 +8,23 @@ class TestSocial(ModuleTestBase):
     async def setup_after_prep(self, module_test):
         expect_args = {"method": "GET", "uri": "/"}
         respond_args = {
-            "response_data": '<html><a href="https://discord.gg/asdf"/><a href="https://github.com/blacklanternsecurity/bbot"/></html>'
+            "response_data": """
+            <html>
+                <a href="https://discord.gg/asdf"/><a href="https://github.com/blacklanternsecurity/bbot"/>
+                <a href="https://hub.docker.com/r/blacklanternsecurity/bbot"/>
+            </html>
+            """
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert any(e.type == "SOCIAL" and e.data["platform"] == "discord" for e in events)
+        assert any(
+            e.type == "SOCIAL" and e.data["platform"] == "discord" and e.data["profile_name"] == "asdf" for e in events
+        )
+        assert any(
+            e.type == "SOCIAL" and e.data["platform"] == "docker" and e.data["profile_name"] == "blacklanternsecurity"
+            for e in events
+        )
         assert any(
             e.type == "SOCIAL" and e.data["platform"] == "github" and e.data["profile_name"] == "blacklanternsecurity"
             for e in events


### PR DESCRIPTION
Adds Docker to `social.py`'s list of profiles to extract from `HTTP_RESPONSE`s. Also tweaks the `dockerhub` module to check whether a profile exists before emitting its `SOCIAL` event.

@domwhewell-sage if you please, look this over and let me know if you have any objections.