### PR TITLE
Presets: Rename output.ndjson back to .json

### DIFF
--- a/bbot/modules/output/json.py
+++ b/bbot/modules/output/json.py
@@ -16,7 +16,7 @@ class JSON(BaseOutputModule):
     _preserve_graph = True
 
     async def setup(self):
-        self._prep_output_dir("output.ndjson")
+        self._prep_output_dir("output.json")
         self.siem_friendly = self.config.get("siem_friendly", False)
         return True
 

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -24,7 +24,7 @@ async def test_cli_scan(monkeypatch):
     assert (scan_home / "wordcloud.tsv").is_file(), "wordcloud.tsv not found"
     assert (scan_home / "output.txt").is_file(), "output.txt not found"
     assert (scan_home / "output.csv").is_file(), "output.csv not found"
-    assert (scan_home / "output.ndjson").is_file(), "output.ndjson not found"
+    assert (scan_home / "output.json").is_file(), "output.json not found"
 
     with open(scan_home / "preset.yml") as f:
         text = f.read()

--- a/bbot/test/test_step_1/test_python_api.py
+++ b/bbot/test/test_step_1/test_python_api.py
@@ -15,7 +15,7 @@ async def test_python_api():
     scan2 = Scanner("127.0.0.1", output_modules=["json"], scan_name="python_api_test")
     await scan2.async_start_without_generator()
     scan_home = scan2.helpers.scans_dir / "python_api_test"
-    out_file = scan_home / "output.ndjson"
+    out_file = scan_home / "output.json"
     assert list(scan2.helpers.read_file(out_file))
     scan_log = scan_home / "scan.log"
     debug_log = scan_home / "debug.log"
@@ -31,7 +31,7 @@ async def test_python_api():
     assert "scan_logging_test" not in open(debug_log).read()
 
     scan_home = scan3.helpers.scans_dir / "scan_logging_test"
-    out_file = scan_home / "output.ndjson"
+    out_file = scan_home / "output.json"
     assert list(scan3.helpers.read_file(out_file))
     scan_log = scan_home / "scan.log"
     debug_log = scan_home / "debug.log"
@@ -58,7 +58,7 @@ def test_python_api_sync():
     # make sure output files work
     scan2 = Scanner("127.0.0.1", output_modules=["json"], scan_name="python_api_test")
     scan2.start_without_generator()
-    out_file = scan2.helpers.scans_dir / "python_api_test" / "output.ndjson"
+    out_file = scan2.helpers.scans_dir / "python_api_test" / "output.json"
     assert list(scan2.helpers.read_file(out_file))
     # make sure config loads properly
     bbot_home = "/tmp/.bbot_python_api_test"

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -6,7 +6,7 @@ from bbot.core.event.base import event_from_json
 
 class TestJSON(ModuleTestBase):
     def check(self, module_test, events):
-        txt_file = module_test.scan.home / "output.ndjson"
+        txt_file = module_test.scan.home / "output.json"
         lines = list(module_test.scan.helpers.read_file(txt_file))
         assert lines
         e = event_from_json(json.loads(lines[0]))
@@ -19,7 +19,7 @@ class TestJSONSIEMFriendly(ModuleTestBase):
     config_overrides = {"modules": {"json": {"siem_friendly": True}}}
 
     def check(self, module_test, events):
-        txt_file = module_test.scan.home / "output.ndjson"
+        txt_file = module_test.scan.home / "output.json"
         lines = list(module_test.scan.helpers.read_file(txt_file))
         passed = False
         for line in lines:

--- a/docs/scanning/output.md
+++ b/docs/scanning/output.md
@@ -64,7 +64,7 @@ You can filter on the JSON output with `jq`:
 
 ```bash
 # pull out only the .data attribute of every DNS_NAME
-$ jq -r 'select(.type=="DNS_NAME") | .data' ~/.bbot/scans/extreme_johnny/output.ndjson
+$ jq -r 'select(.type=="DNS_NAME") | .data' ~/.bbot/scans/extreme_johnny/output.json
 evilcorp.com
 www.evilcorp.com
 mail.evilcorp.com


### PR DESCRIPTION
Multiple people have expressed confusion about why the json output is called `output.ndjson`, so I am renaming it back to its original, simpler `output.json`.

It _is_ technically "newline-delimited JSON" and not one huge JSON object, but the `ndjson` file extension is not well-known and is causing the json output to be overlooked by new users.