### PR TITLE
Specify ORG in targets

### DIFF
--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -87,7 +87,10 @@ class Target:
         self.scan = scan
         self.strict_scope = strict_scope
         self.make_in_scope = make_in_scope
-        self.special_event_types = {"ORG_STUB": re.compile(r"^ORG:(.*)", re.IGNORECASE),"ASN": re.compile(r"^ASN:(.*)", re.IGNORECASE)}
+        self.special_event_types = {
+            "ORG_STUB": re.compile(r"^ORG:(.*)", re.IGNORECASE),
+            "ASN": re.compile(r"^ASN:(.*)", re.IGNORECASE),
+        }
 
         self._dummy_module = TargetDummyModule(scan)
         self._events = dict()
@@ -98,7 +101,13 @@ class Target:
                 match = regex.match(t)
                 if match:
                     target = match.groups()[0]
-                    t = self.scan.make_event(target, event_type=event_type, source=self.scan.root_event, module=self._dummy_module, tags=["target"])
+                    t = self.scan.make_event(
+                        target,
+                        event_type=event_type,
+                        source=self.scan.root_event,
+                        module=self._dummy_module,
+                        tags=["target"],
+                    )
                     break
             self.add_target(t)
 

--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -97,18 +97,6 @@ class Target:
         if len(targets) > 0:
             log.verbose(f"Creating events from {len(targets):,} targets")
         for t in targets:
-            for event_type, regex in self.special_event_types.items():
-                match = regex.match(t)
-                if match:
-                    target = match.groups()[0]
-                    t = self.scan.make_event(
-                        target,
-                        event_type=event_type,
-                        source=self.scan.root_event,
-                        module=self._dummy_module,
-                        tags=["target"],
-                    )
-                    break
             self.add_target(t)
 
         self._hash = None
@@ -141,6 +129,12 @@ class Target:
             if is_event(t):
                 event = t
             else:
+                for eventtype, regex in self.special_event_types.items():
+                    match = regex.match(t)
+                    if match:
+                        t = match.groups()[0]
+                        event_type = eventtype
+                        break
                 try:
                     event = self.scan.make_event(
                         t,

--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -92,7 +92,17 @@ class Target:
         if len(targets) > 0:
             log.verbose(f"Creating events from {len(targets):,} targets")
         for t in targets:
-            self.add_target(t)
+            event_type = None
+            if ":" in t and not t.startswith("http"):
+                target = t.split(":")[1]
+                type = t.split(":")[0].upper()
+                if type == "ORG":
+                    event_type = "ORG_STUB"
+                else:
+                    log.warning(f"Unknown target type: {type} for {target}, Valid types are: ORG")
+            else:
+                target = t
+            self.add_target(target, event_type=event_type)
 
         self._hash = None
 


### PR DESCRIPTION
This PR address's https://github.com/blacklanternsecurity/bbot/issues/1282.
Allows the user to specify an event type in the format `event_type`:`target` for now only org and asn are accepted (Case insensitive).
If it fails to detect a specified event it will default to the auto-detected event type

~~WIP currently `github_org` will not accept orgs raised this way because of the `validate_org()` function~~