### PR TITLE
Dastardly: Handle `FileNotFoundError`

### DIFF
--- a/bbot/modules/deadly/dastardly.py
+++ b/bbot/modules/deadly/dastardly.py
@@ -107,7 +107,9 @@ class dastardly(BaseModule):
                 et = etree.parse(f)
                 for testsuite in et.iter("testsuite"):
                     yield TestSuite(testsuite)
-        except Exception as e:
+        except FileNotFoundError:
+            pass
+        except etree.ParseError as e:
             self.warning(f"Error parsing Dastardly XML at {xml_file}: {e}")
 
 


### PR DESCRIPTION
When dastardly fails to connect to a URL it will not output the xml file therefore the parser produces an incorrect error message
closes #1284.