### PR TITLE
Better debugging during scan cancellation

### DIFF
--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -1145,6 +1145,7 @@ def kill_children(parent_pid=None, sig=signal.SIGTERM):
         parent = psutil.Process(parent_pid)
     except psutil.NoSuchProcess:
         log.debug(f"No such PID: {parent_pid}")
+        return
     log.debug(f"Killing children of process ID {parent.pid}")
     children = parent.children(recursive=True)
     for child in children:
@@ -1156,6 +1157,7 @@ def kill_children(parent_pid=None, sig=signal.SIGTERM):
                 log.debug(f"No such PID: {child.pid}")
             except psutil.AccessDenied:
                 log.debug(f"Error killing PID: {child.pid} - access denied")
+    log.debug(f"Finished killing children of process ID {parent.pid}")
 
 
 def str_or_file(s):

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -399,7 +399,13 @@ class Scanner:
                     self.critical(f"Unexpected error during scan:\n{traceback.format_exc()}")
 
         finally:
-            self._cancel_tasks()
+            tasks = self._cancel_tasks()
+            self.debug(f"Awaiting {len(tasks):,} tasks")
+            for task in tasks:
+                self.debug(f"Awaiting {task}")
+                with contextlib.suppress(BaseException):
+                    await task
+            self.debug(f"Awaited {len(tasks):,} tasks")
             await self._report()
             await self._cleanup()
 
@@ -565,13 +571,14 @@ class Scanner:
         if not self._stopping:
             self._stopping = True
             self.status = "ABORTING"
-            self.hugewarning(f"Aborting scan")
+            self.hugewarning("Aborting scan")
             self.trace()
             self._cancel_tasks()
             self._drain_queues()
             self.helpers.kill_children()
             self._drain_queues()
             self.helpers.kill_children()
+            self.debug("Finished aborting scan")
 
     async def finish(self):
         """Finalizes the scan by invoking the `finished()` method on all active modules if new activity is detected.
@@ -634,6 +641,7 @@ class Scanner:
         Returns:
             None
         """
+        self.debug("Cancelling all scan tasks")
         tasks = []
         # module workers
         for m in self.modules.values():
@@ -651,6 +659,8 @@ class Scanner:
         self.helpers.cancel_tasks_sync(tasks)
         # process pool
         self.process_pool.shutdown(cancel_futures=True)
+        self.debug("Finished cancelling all scan tasks")
+        return tasks
 
     async def _report(self):
         """Asynchronously executes the `report()` method for each module in the scan.


### PR DESCRIPTION
This PR ensures that all tasks are awaited when a scan is cancelled via CTRL+C. It also adds some debugging statements to assist in troubleshooting cancellation-related issues.

Addressing https://github.com/blacklanternsecurity/bbot/issues/1268.