### PR TITLE
URL excavation bugfixes

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -100,6 +100,7 @@ url_extension_blacklist:
     - woff
     - woff2
     - ttf
+    - eot
     - sass
     - scss
     # audio

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -67,7 +67,7 @@ class HostnameExtractor(BaseExtractor):
 
 
 class URLExtractor(BaseExtractor):
-    url_path_regex = r"((?:\w|\d)(?:[\d\w-]+\.?)+(?::\d{1,5})?(?:/[-\w\.\(\)]+)*/?)"
+    url_path_regex = r"((?:\w|\d)(?:[\d\w-]+\.?)+(?::\d{1,5})?(?:/[-\w\.\(\)]*[-\w\.]+)*/?)"
     regexes = {
         "fulluri": r"(?i)" + r"([a-z]\w{1,15})://" + url_path_regex,
         "fullurl": r"(?i)" + r"(https?)://" + url_path_regex,


### PR DESCRIPTION
Fixes https://github.com/blacklanternsecurity/bbot/issues/1307.

Also introduces a test for URL extension blacklisting, and adds `.eot` (Embedded OpenType font) to the default URL extension blacklist.