### PR TITLE
Fix omitted event types

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -449,7 +449,7 @@ class BaseEvent:
 
     def get_source(self):
         """
-        Takes into account events with the omit flag
+        Takes into account events with the _omit flag
         """
         if getattr(self.source, "_omit", False):
             return self.source.get_source()
@@ -665,7 +665,7 @@ class BaseEvent:
             str: The module sequence in human-friendly format.
         """
         module_name = getattr(self.module, "name", "")
-        if getattr(self.source, "omit", False):
+        if getattr(self.source, "_omit", False):
             module_name = f"{self.source.module_sequence}->{module_name}"
         return module_name
 

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -15,7 +15,6 @@ from .helpers import *
 from bbot.errors import *
 from bbot.core.helpers import (
     extract_words,
-    get_file_extension,
     is_domain,
     is_subdomain,
     is_ip,
@@ -99,8 +98,6 @@ class BaseEvent:
     _quick_emit = False
     # Whether this event has been retroactively marked as part of an important discovery chain
     _graph_important = False
-    # Exclude from output modules
-    _omit = False
     # Disables certain data validations
     _dummy = False
     # Data validation, if data is a dictionary
@@ -149,6 +146,7 @@ class BaseEvent:
         self._hash = None
         self.__host = None
         self._port = None
+        self._omit = False
         self.__words = None
         self._priority = None
         self._host_original = None
@@ -184,9 +182,6 @@ class BaseEvent:
             self.scans = scans
         if self.scan:
             self.scans = list(set([self.scan.id] + self.scans))
-
-        # check type blacklist
-        self._check_omit()
 
         self._scope_distance = -1
 
@@ -297,12 +292,12 @@ class BaseEvent:
     @property
     def port(self):
         self.host
-        if getattr(self, "parsed", None):
-            if self.parsed.port is not None:
-                return self.parsed.port
-            elif self.parsed.scheme == "https":
+        if getattr(self, "parsed_url", None):
+            if self.parsed_url.port is not None:
+                return self.parsed_url.port
+            elif self.parsed_url.scheme == "https":
                 return 443
-            elif self.parsed.scheme == "http":
+            elif self.parsed_url.scheme == "http":
                 return 80
         return self._port
 
@@ -453,9 +448,9 @@ class BaseEvent:
 
     def get_source(self):
         """
-        Takes into account events with the _omit flag
+        Takes into account events with the omit flag
         """
-        if getattr(self.source, "_omit", False):
+        if getattr(self.source, "omit", False):
             return self.source.get_source()
         return self.source
 
@@ -669,7 +664,7 @@ class BaseEvent:
             str: The module sequence in human-friendly format.
         """
         module_name = getattr(self.module, "name", "")
-        if getattr(self.source, "_omit", False):
+        if getattr(self.source, "omit", False):
             module_name = f"{self.source.module_sequence}->{module_name}"
         return module_name
 
@@ -704,13 +699,6 @@ class BaseEvent:
         self._type = val
         self._hash = None
         self._id = None
-        self._check_omit()
-
-    def _check_omit(self):
-        if self.scan is not None:
-            omit_event_types = self.scan.config.get("omit_event_types", [])
-            if omit_event_types and self.type in omit_event_types:
-                self._omit = True
 
     def __iter__(self):
         """
@@ -770,7 +758,7 @@ class DictEvent(BaseEvent):
     def sanitize_data(self, data):
         url = data.get("url", "")
         if url:
-            self.parsed = validators.validate_url_parsed(url)
+            self.parsed_url = validators.validate_url_parsed(url)
         return data
 
     def _data_load(self, data):
@@ -784,7 +772,7 @@ class DictHostEvent(DictEvent):
         if isinstance(self.data, dict) and "host" in self.data:
             return make_ip_type(self.data["host"])
         else:
-            parsed = getattr(self, "parsed")
+            parsed = getattr(self, "parsed_url", None)
             if parsed is not None:
                 return make_ip_type(parsed.hostname)
 
@@ -903,44 +891,29 @@ class URL_UNVERIFIED(BaseEvent):
         self.num_redirects = getattr(self.source, "num_redirects", 0)
 
     def sanitize_data(self, data):
-        self.parsed = validators.validate_url_parsed(data)
+        self.parsed_url = validators.validate_url_parsed(data)
 
         # tag as dir or endpoint
-        if str(self.parsed.path).endswith("/"):
+        if str(self.parsed_url.path).endswith("/"):
             self.add_tag("dir")
         else:
             self.add_tag("endpoint")
 
-        parsed_path_lower = str(self.parsed.path).lower()
-
-        scan = getattr(self, "scan", None)
-        url_extension_blacklist = getattr(scan, "url_extension_blacklist", [])
-        url_extension_httpx_only = getattr(scan, "url_extension_httpx_only", [])
-
-        extension = get_file_extension(parsed_path_lower)
-        if extension:
-            self.add_tag(f"extension-{extension}")
-            if extension in url_extension_blacklist:
-                self.add_tag("blacklisted")
-            if extension in url_extension_httpx_only:
-                self.add_tag("httpx-only")
-                self._omit = True
-
-        data = self.parsed.geturl()
+        data = self.parsed_url.geturl()
         return data
 
     def with_port(self):
         netloc_with_port = make_netloc(self.host, self.port)
-        return self.parsed._replace(netloc=netloc_with_port)
+        return self.parsed_url._replace(netloc=netloc_with_port)
 
     def _words(self):
-        first_elem = self.parsed.path.lstrip("/").split("/")[0]
+        first_elem = self.parsed_url.path.lstrip("/").split("/")[0]
         if not "." in first_elem:
             return extract_words(first_elem)
         return set()
 
     def _host(self):
-        return make_ip_type(self.parsed.hostname)
+        return make_ip_type(self.parsed_url.hostname)
 
     def _data_id(self):
         # consider spider-danger tag when deduping
@@ -1020,8 +993,8 @@ class HTTP_RESPONSE(URL_UNVERIFIED, DictEvent):
 
     def sanitize_data(self, data):
         url = data.get("url", "")
-        self.parsed = validators.validate_url_parsed(url)
-        data["url"] = self.parsed.geturl()
+        self.parsed_url = validators.validate_url_parsed(url)
+        data["url"] = self.parsed_url.geturl()
 
         header_dict = {}
         for i in data.get("raw_header", "").splitlines():

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -730,13 +730,6 @@ class BaseModule:
         if self._is_graph_important(event):
             return True, "event is critical to the graph"
 
-        # don't send out-of-scope targets to active modules (excluding portscanners, because they can handle it)
-        # this only takes effect if your target and whitelist are different
-        # TODO: the logic here seems incomplete, it could probably use some work.
-        if "active" in self.flags and "portscan" not in self.flags:
-            if "target" in event.tags and event not in self.scan.whitelist:
-                return False, "it is not in whitelist and module has active flag"
-
         # check scope distance
         filter_result, reason = self._scope_distance_check(event)
         if not filter_result:

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -684,6 +684,7 @@ class BaseModule:
         if self.target_only:
             if "target" not in event.tags:
                 return False, "it did not meet target_only filter criteria"
+
         # exclude certain URLs (e.g. javascript):
         # TODO: revisit this after httpx rework
         if event.type.startswith("URL") and self.name != "httpx" and "httpx-only" in event.tags:
@@ -952,7 +953,7 @@ class BaseModule:
             >>> event = self.make_event("https://example.com:8443")
             >>> self.get_per_hostport_hash(event)
         """
-        parsed = getattr(event, "parsed", None)
+        parsed = getattr(event, "parsed_url", None)
         if parsed is None:
             to_hash = self.helpers.make_netloc(event.host, event.port)
         else:

--- a/bbot/modules/bypass403.py
+++ b/bbot/modules/bypass403.py
@@ -164,10 +164,10 @@ class bypass403(BaseModule):
 
     def format_signature(self, sig, event):
         if sig[3] == True:
-            cleaned_path = event.parsed.path.strip("/")
+            cleaned_path = event.parsed_url.path.strip("/")
         else:
-            cleaned_path = event.parsed.path.lstrip("/")
-        kwargs = {"scheme": event.parsed.scheme, "netloc": event.parsed.netloc, "path": cleaned_path}
+            cleaned_path = event.parsed_url.path.lstrip("/")
+        kwargs = {"scheme": event.parsed_url.scheme, "netloc": event.parsed_url.netloc, "path": cleaned_path}
         formatted_url = sig[1].format(**kwargs)
         if sig[2] != None:
             formatted_headers = {k: v.format(**kwargs) for k, v in sig[2].items()}

--- a/bbot/modules/deadly/dastardly.py
+++ b/bbot/modules/deadly/dastardly.py
@@ -27,7 +27,7 @@ class dastardly(BaseModule):
         return True
 
     async def handle_event(self, event):
-        host = event.parsed._replace(path="/").geturl()
+        host = event.parsed_url._replace(path="/").geturl()
         self.verbose(f"Running Dastardly scan against {host}")
         command, output_file = self.construct_command(host)
         finished_proc = await self.run_process(command, sudo=True)

--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -57,7 +57,7 @@ class ffuf(BaseModule):
             return
 
         # only FFUF against a directory
-        if "." in event.parsed.path.split("/")[-1]:
+        if "." in event.parsed_url.path.split("/")[-1]:
             self.debug("Aborting FFUF as period was detected in right-most path segment (likely a file)")
             return
         else:

--- a/bbot/modules/deadly/vhost.py
+++ b/bbot/modules/deadly/vhost.py
@@ -33,7 +33,7 @@ class vhost(ffuf):
 
     async def handle_event(self, event):
         if not self.helpers.is_ip(event.host) or self.config.get("force_basehost"):
-            host = f"{event.parsed.scheme}://{event.parsed.netloc}"
+            host = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}"
             if host in self.scanned_hosts.keys():
                 return
             else:
@@ -44,7 +44,7 @@ class vhost(ffuf):
             if self.config.get("force_basehost"):
                 basehost = self.config.get("force_basehost")
             else:
-                basehost = self.helpers.parent_domain(event.parsed.netloc)
+                basehost = self.helpers.parent_domain(event.parsed_url.netloc)
 
             self.debug(f"Using basehost: {basehost}")
             async for vhost in self.ffuf_vhost(host, f".{basehost}", event):
@@ -55,7 +55,7 @@ class vhost(ffuf):
             # check existing host for mutations
             self.verbose("Checking for vhost mutations on main host")
             async for vhost in self.ffuf_vhost(
-                host, f".{basehost}", event, wordlist=self.mutations_check(event.parsed.netloc.split(".")[0])
+                host, f".{basehost}", event, wordlist=self.mutations_check(event.parsed_url.netloc.split(".")[0])
             ):
                 pass
 
@@ -81,7 +81,7 @@ class vhost(ffuf):
         ):
             found_vhost_b64 = r["input"]["FUZZ"]
             vhost_dict = {"host": str(event.host), "url": host, "vhost": base64.b64decode(found_vhost_b64).decode()}
-            if f"{vhost_dict['vhost']}{basehost}" != event.parsed.netloc:
+            if f"{vhost_dict['vhost']}{basehost}" != event.parsed_url.netloc:
                 await self.emit_event(vhost_dict, "VHOST", source=event)
                 if skip_dns_host == False:
                     await self.emit_event(f"{vhost_dict['vhost']}{basehost}", "DNS_NAME", source=event, tags=["vhost"])
@@ -102,13 +102,13 @@ class vhost(ffuf):
 
         for host, event in self.scanned_hosts.items():
             if host not in self.wordcloud_tried_hosts:
-                event.parsed = urlparse(host)
+                event.parsed_url = urlparse(host)
 
                 self.verbose("Checking main host with wordcloud")
                 if self.config.get("force_basehost"):
                     basehost = self.config.get("force_basehost")
                 else:
-                    basehost = self.helpers.parent_domain(event.parsed.netloc)
+                    basehost = self.helpers.parent_domain(event.parsed_url.netloc)
 
                 async for vhost in self.ffuf_vhost(host, f".{basehost}", event, wordlist=tempfile):
                     pass

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -92,7 +92,7 @@ class ffuf_shortnames(ffuf):
 
     def build_extension_list(self, event):
         used_extensions = []
-        extension_hint = event.parsed.path.rsplit(".", 1)[1].lower().strip()
+        extension_hint = event.parsed_url.path.rsplit(".", 1)[1].lower().strip()
         if len(extension_hint) == 3:
             with open(self.wordlist_extensions) as f:
                 for l in f:
@@ -117,9 +117,9 @@ class ffuf_shortnames(ffuf):
         return True
 
     async def handle_event(self, event):
-        filename_hint = re.sub(r"~\d", "", event.parsed.path.rsplit(".", 1)[0].split("/")[-1]).lower()
+        filename_hint = re.sub(r"~\d", "", event.parsed_url.path.rsplit(".", 1)[0].split("/")[-1]).lower()
 
-        host = f"{event.source.parsed.scheme}://{event.source.parsed.netloc}/"
+        host = f"{event.source.parsed_url.scheme}://{event.source.parsed_url.netloc}/"
         if host not in self.per_host_collection.keys():
             self.per_host_collection[host] = [(filename_hint, event.source.data)]
 
@@ -128,8 +128,8 @@ class ffuf_shortnames(ffuf):
 
         self.shortname_to_event[filename_hint] = event
 
-        root_stub = "/".join(event.parsed.path.split("/")[:-1])
-        root_url = f"{event.parsed.scheme}://{event.parsed.netloc}{root_stub}/"
+        root_stub = "/".join(event.parsed_url.path.split("/")[:-1])
+        root_url = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}{root_stub}/"
 
         if "shortname-file" in event.tags:
             used_extensions = self.build_extension_list(event)

--- a/bbot/modules/generic_ssrf.py
+++ b/bbot/modules/generic_ssrf.py
@@ -44,7 +44,7 @@ class BaseSubmodule:
         self.test_paths = self.create_paths()
 
     def set_base_url(self, event):
-        return f"{event.parsed.scheme}://{event.parsed.netloc}"
+        return f"{event.parsed_url.scheme}://{event.parsed_url.netloc}"
 
     def create_paths(self):
         return self.paths
@@ -140,7 +140,7 @@ class Generic_XXE(BaseSubmodule):
 <!ENTITY % {rand_entity} SYSTEM "http://{subdomain_tag}.{self.parent_module.interactsh_domain}" >
 ]>
 <foo>&{rand_entity};</foo>"""
-        test_url = f"{event.parsed.scheme}://{event.parsed.netloc}/"
+        test_url = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/"
         r = await self.parent_module.helpers.curl(
             url=test_url, method="POST", raw_body=post_body, headers={"Content-type": "application/xml"}
         )

--- a/bbot/modules/gitlab.py
+++ b/bbot/modules/gitlab.py
@@ -47,7 +47,7 @@ class gitlab(BaseModule):
         # HTTP_RESPONSE --> FINDING
         headers = event.data.get("header", {})
         if "x_gitlab_meta" in headers:
-            url = event.parsed._replace(path="/").geturl()
+            url = event.parsed_url._replace(path="/").geturl()
             await self.emit_event(
                 {"host": str(event.host), "technology": "GitLab", "url": url}, "TECHNOLOGY", source=event
             )

--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -84,7 +84,7 @@ class httpx(BaseModule):
             if e.type.startswith("URL"):
                 # we NEED the port, otherwise httpx will try HTTPS even for HTTP URLs
                 url = e.with_port().geturl()
-                if e.parsed.path == "/":
+                if e.parsed_url.path == "/":
                     url_hash = hash((e.host, e.port))
             else:
                 url = str(e.data)

--- a/bbot/modules/internal/dns.py
+++ b/bbot/modules/internal/dns.py
@@ -164,7 +164,7 @@ class DNS(InterceptModule):
                 event.add_tag(tag)
 
         # If the event is unresolved, change its type to DNS_NAME_UNRESOLVED
-        if event.type == "DNS_NAME" and "unresolved" in event.tags and not "target" in event.tags:
+        if event.type == "DNS_NAME" and "unresolved" in event.tags:
             event.type = "DNS_NAME_UNRESOLVED"
 
         # speculate DNS_NAMES and IP_ADDRESSes from other event types

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -122,7 +122,7 @@ class URLExtractor(BaseExtractor):
                     urls_found += 1
 
     async def _search(self, content, event, **kwargs):
-        parsed = getattr(event, "parsed", None)
+        parsed = getattr(event, "parsed_url", None)
         for name, regex in self.compiled_regexes.items():
             # yield to event loop
             await self.excavate.helpers.sleep(0)
@@ -142,7 +142,7 @@ class URLExtractor(BaseExtractor):
                             continue
 
                     if not self.compiled_regexes["fullurl"].match(path):
-                        source_url = event.parsed.geturl()
+                        source_url = event.parsed_url.geturl()
                         result = urljoin(source_url, path)
                         # this is necessary to weed out mailto: and such
                         if not self.compiled_regexes["fullurl"].match(result):
@@ -167,7 +167,7 @@ class URLExtractor(BaseExtractor):
             # these findings are pretty mundane so don't bother with them if they aren't in scope
             abort_if = lambda e: e.scope_distance > 0
             event_data = {"host": str(host), "description": f"Non-HTTP URI: {result}"}
-            parsed_url = getattr(event, "parsed", None)
+            parsed_url = getattr(event, "parsed_url", None)
             if parsed_url:
                 event_data["url"] = parsed_url.geturl()
             await self.excavate.emit_event(

--- a/bbot/modules/ntlm.py
+++ b/bbot/modules/ntlm.py
@@ -122,7 +122,7 @@ class ntlm(BaseModule):
             }
         if self.try_all:
             for endpoint in ntlm_discovery_endpoints:
-                urls.add(f"{event.parsed.scheme}://{event.parsed.netloc}/{endpoint}")
+                urls.add(f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/{endpoint}")
 
         tasks = []
         for url in urls:

--- a/bbot/modules/output/base.py
+++ b/bbot/modules/output/base.py
@@ -33,10 +33,14 @@ class BaseOutputModule(BaseModule):
         if event.type.startswith("URL") and self.name != "httpx" and "httpx-only" in event.tags:
             return False, "its extension was listed in url_extension_httpx_only"
 
-        # output module specific stuff
-        # omitted events such as HTTP_RESPONSE etc.
-        if event._omit and not event.type in self.get_watched_events():
-            return False, "_omit is True"
+        ### begin output-module specific ###
+
+        # events from omit_event_types, e.g. HTTP_RESPONSE, DNS_NAME_UNRESOLVED, etc.
+        # if the output module specifically requests a certain event type, we let it through anyway
+        # always_emit overrides _omit.
+        if event._omit:
+            if not event.always_emit and not event.type in self.get_watched_events():
+                return False, "_omit is True"
 
         # force-output certain events to the graph
         if self._is_graph_important(event):

--- a/bbot/modules/output/base.py
+++ b/bbot/modules/output/base.py
@@ -37,9 +37,9 @@ class BaseOutputModule(BaseModule):
 
         # events from omit_event_types, e.g. HTTP_RESPONSE, DNS_NAME_UNRESOLVED, etc.
         # if the output module specifically requests a certain event type, we let it through anyway
-        # always_emit overrides _omit.
+        # an exception is also made for targets
         if event._omit:
-            if not event.always_emit and not event.type in self.get_watched_events():
+            if not "target" in event.tags and not event.type in self.get_watched_events():
                 return False, "_omit is True"
 
         # force-output certain events to the graph

--- a/bbot/modules/output/base.py
+++ b/bbot/modules/output/base.py
@@ -41,6 +41,9 @@ class BaseOutputModule(BaseModule):
         if event.type.startswith("URL") and self.name != "httpx" and "httpx-only" in event.tags:
             return False, (f"Omitting {event} from output because it's marked as httpx-only")
 
+        if event._omit:
+            return False, "_omit is True"
+
         # omit certain event types
         if event.type in self.scan.omitted_event_types:
             if "target" in event.tags:
@@ -48,7 +51,7 @@ class BaseOutputModule(BaseModule):
             elif event.type in self.get_watched_events():
                 self.debug(f"Allowing omitted event: {event} because its type is explicitly in watched_events")
             else:
-                return False, f"its type is omitted in the config"
+                return False, "its type is omitted in the config"
 
         # internal events like those from speculate, ipneighbor
         # or events that are over our report distance

--- a/bbot/modules/output/web_report.py
+++ b/bbot/modules/output/web_report.py
@@ -34,7 +34,7 @@ class web_report(BaseOutputModule):
 
     async def handle_event(self, event):
         if event.type == "URL":
-            parsed = event.parsed
+            parsed = event.parsed_url
             host = f"{parsed.scheme}://{parsed.netloc}/"
             if host not in self.web_assets.keys():
                 self.web_assets[host] = {"URL": []}
@@ -60,7 +60,7 @@ class web_report(BaseOutputModule):
             parsed = None
             while 1:
                 if current_parent.type == "URL":
-                    parsed = current_parent.parsed
+                    parsed = current_parent.parsed_url
                     break
                 current_parent = current_parent.source
                 if current_parent.source.type == "SCAN":

--- a/bbot/modules/robots.py
+++ b/bbot/modules/robots.py
@@ -21,7 +21,7 @@ class robots(BaseModule):
         return True
 
     async def handle_event(self, event):
-        host = f"{event.parsed.scheme}://{event.parsed.netloc}/"
+        host = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/"
         result = None
         url = f"{host}robots.txt"
         result = await self.helpers.request(url)

--- a/bbot/modules/secretsdb.py
+++ b/bbot/modules/secretsdb.py
@@ -51,7 +51,7 @@ class secretsdb(BaseModule):
             matches = [m.string[m.start() : m.end()] for m in matches]
             description = f"Possible secret ({name}): {matches}"
             event_data = {"host": str(event.host), "description": description}
-            parsed_url = getattr(event, "parsed", None)
+            parsed_url = getattr(event, "parsed_url", None)
             if parsed_url:
                 event_data["url"] = parsed_url.geturl()
             await self.emit_event(

--- a/bbot/modules/url_manipulation.py
+++ b/bbot/modules/url_manipulation.py
@@ -94,10 +94,10 @@ class url_manipulation(BaseModule):
 
     def format_signature(self, sig, event):
         if sig[2] == True:
-            cleaned_path = event.parsed.path.strip("/")
+            cleaned_path = event.parsed_url.path.strip("/")
         else:
-            cleaned_path = event.parsed.path.lstrip("/")
+            cleaned_path = event.parsed_url.path.lstrip("/")
 
-        kwargs = {"scheme": event.parsed.scheme, "netloc": event.parsed.netloc, "path": cleaned_path}
+        kwargs = {"scheme": event.parsed_url.scheme, "netloc": event.parsed_url.netloc, "path": cleaned_path}
         formatted_url = sig[1].format(**kwargs)
         return (sig[0], formatted_url)

--- a/bbot/modules/wafw00f.py
+++ b/bbot/modules/wafw00f.py
@@ -33,7 +33,7 @@ class wafw00f(BaseModule):
         return True, ""
 
     async def handle_event(self, event):
-        url = f"{event.parsed.scheme}://{event.parsed.netloc}/"
+        url = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/"
         WW = await self.helpers.run_in_executor(wafw00f_main.WAFW00F, url, followredirect=False)
         waf_detections = await self.helpers.run_in_executor(WW.identwaf)
         if waf_detections:

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -73,20 +73,15 @@ class ScanIngress(InterceptModule):
         event.scope_distance = event.source.scope_distance + 1
 
         # special handling of URL extensions
-        parsed_url = getattr(event, "parsed_url", None)
-        if parsed_url is not None:
-            url_path = parsed_url.path
-            if url_path:
-                parsed_path_lower = str(url_path).lower()
-                extension = self.helpers.get_file_extension(parsed_path_lower)
-                if extension:
-                    event.add_tag(f"extension-{extension}")
-                if extension in self.scan.url_extension_httpx_only:
-                    event.add_tag("httpx-only")
-                    event._omit = True
+        url_extension = getattr(event, "url_extension", None)
+        self.critical(f"{url_extension} in {self.scan.url_extension_httpx_only}?")
+        if url_extension is not None:
+            if url_extension in self.scan.url_extension_httpx_only:
+                event.add_tag("httpx-only")
+                event._omit = True
 
             # blacklist by extension
-            if extension in self.scan.url_extension_blacklist:
+            if url_extension in self.scan.url_extension_blacklist:
                 event.add_tag("blacklisted")
 
         # main scan blacklist

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -74,7 +74,6 @@ class ScanIngress(InterceptModule):
 
         # special handling of URL extensions
         url_extension = getattr(event, "url_extension", None)
-        self.critical(f"{url_extension} in {self.scan.url_extension_httpx_only}?")
         if url_extension is not None:
             if url_extension in self.scan.url_extension_httpx_only:
                 event.add_tag("httpx-only")
@@ -82,6 +81,9 @@ class ScanIngress(InterceptModule):
 
             # blacklist by extension
             if url_extension in self.scan.url_extension_blacklist:
+                self.debug(
+                    f"Blacklisting {event} because its extension (.{url_extension}) is blacklisted in the config"
+                )
                 event.add_tag("blacklisted")
 
         # main scan blacklist
@@ -89,7 +91,7 @@ class ScanIngress(InterceptModule):
 
         # reject all blacklisted events
         if event_blacklisted or "blacklisted" in event.tags:
-            return False, f"Omitting blacklisted event: {event}"
+            return False, "event is blacklisted"
 
         # Scope shepherding
         # here is where we make sure in-scope events are set to their proper scope distance

--- a/bbot/scanner/preset/args.py
+++ b/bbot/scanner/preset/args.py
@@ -338,4 +338,4 @@ class BBOTArgs:
                 if self.exclude_from_validation.match(c):
                     continue
                 # otherwise, ensure it exists as a module option
-                raise ValidationError(get_closest_match(c, all_options, msg="module option"))
+                raise ValidationError(get_closest_match(c, all_options, msg="config option"))

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -197,6 +197,7 @@ class Scanner:
         self._finished_init = False
         self._new_activity = False
         self._cleanedup = False
+        self._omitted_event_types = None
 
         self.__loop = None
         self._manager_worker_loop_tasks = []
@@ -860,6 +861,12 @@ class Scanner:
     @property
     def status(self):
         return self._status
+
+    @property
+    def omitted_event_types(self):
+        if self._omitted_event_types is None:
+            self._omitted_event_types = self.config.get("omit_event_types", [])
+        return self._omitted_event_types
 
     @status.setter
     def status(self, status):

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -325,7 +325,7 @@ def test_cli_config_validation(monkeypatch, caplog):
     assert not caplog.text
     monkeypatch.setattr("sys.argv", ["bbot", "-c", "modules.ipnegibhor.num_bits=4"])
     cli.main()
-    assert 'Could not find module option "modules.ipnegibhor.num_bits"' in caplog.text
+    assert 'Could not find config option "modules.ipnegibhor.num_bits"' in caplog.text
     assert 'Did you mean "modules.ipneighbor.num_bits"?' in caplog.text
 
     # incorrect global option
@@ -333,7 +333,7 @@ def test_cli_config_validation(monkeypatch, caplog):
     assert not caplog.text
     monkeypatch.setattr("sys.argv", ["bbot", "-c", "web_spier_distance=4"])
     cli.main()
-    assert 'Could not find module option "web_spier_distance"' in caplog.text
+    assert 'Could not find config option "web_spier_distance"' in caplog.text
     assert 'Did you mean "web_spider_distance"?' in caplog.text
 
 

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -100,7 +100,7 @@ async def test_events(events, scan, helpers):
     # http response
     assert events.http_response.host == "example.com"
     assert events.http_response.port == 80
-    assert events.http_response.parsed.scheme == "http"
+    assert events.http_response.parsed_url.scheme == "http"
     assert events.http_response.with_port().geturl() == "http://example.com:80/"
 
     http_response = scan.make_event(

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -6,7 +6,13 @@ from ..bbot_fixtures import *
 
 
 @pytest.mark.asyncio
-async def test_events(events, scan, helpers):
+async def test_events(events, helpers):
+
+    from bbot.scanner import Scanner
+
+    scan = Scanner()
+    await scan._prep()
+
     assert events.ipv4.type == "IP_ADDRESS"
     assert events.ipv6.type == "IP_ADDRESS"
     assert events.netv4.type == "IP_RANGE"
@@ -159,8 +165,9 @@ async def test_events(events, scan, helpers):
     assert events.ipv6_url_unverified.host == ipaddress.ip_address("2001:4860:4860::8888")
     assert events.ipv6_url_unverified.port == 443
 
-    javascript_event = scan.make_event("http://evilcorp.com/asdf/a.js?b=c#d", "URL_UNVERIFIED", dummy=True)
+    javascript_event = scan.make_event("http://evilcorp.com/asdf/a.js?b=c#d", "URL_UNVERIFIED", source=scan.root_event)
     assert "extension-js" in javascript_event.tags
+    await scan.ingress_module.handle_event(javascript_event, {})
     assert "httpx-only" in javascript_event.tags
 
     # scope distance

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -467,3 +467,28 @@ async def test_events(events, helpers):
     )
     assert bucket_event.data["name"] == "asdf.s3.amazonaws.com"
     assert bucket_event.data["url"] == "https://asdf.s3.amazonaws.com/"
+
+    # test module sequence
+    module = scan._make_dummy_module("mymodule")
+    source_event_1 = scan.make_event("127.0.0.1", module=module, source=scan.root_event)
+    assert str(source_event_1.module) == "mymodule"
+    assert str(source_event_1.module_sequence) == "mymodule"
+    source_event_2 = scan.make_event("127.0.0.2", module=module, source=source_event_1)
+    assert str(source_event_2.module) == "mymodule"
+    assert str(source_event_2.module_sequence) == "mymodule"
+    source_event_3 = scan.make_event("127.0.0.3", module=module, source=source_event_2)
+    assert str(source_event_3.module) == "mymodule"
+    assert str(source_event_3.module_sequence) == "mymodule"
+
+    module = scan._make_dummy_module("mymodule")
+    source_event_1 = scan.make_event("127.0.0.1", module=module, source=scan.root_event)
+    source_event_1._omit = True
+    assert str(source_event_1.module) == "mymodule"
+    assert str(source_event_1.module_sequence) == "mymodule"
+    source_event_2 = scan.make_event("127.0.0.2", module=module, source=source_event_1)
+    source_event_2._omit = True
+    assert str(source_event_2.module) == "mymodule"
+    assert str(source_event_2.module_sequence) == "mymodule->mymodule"
+    source_event_3 = scan.make_event("127.0.0.3", module=module, source=source_event_2)
+    assert str(source_event_3.module) == "mymodule"
+    assert str(source_event_3.module_sequence) == "mymodule->mymodule->mymodule"

--- a/bbot/test/test_step_1/test_manager_deduplication.py
+++ b/bbot/test/test_step_1/test_manager_deduplication.py
@@ -75,6 +75,7 @@ async def test_manager_deduplication(bbot_scanner):
         )
 
     dns_mock_chain = {
+        "test.notreal": {"A": ["127.0.0.3"]},
         "default_module.test.notreal": {"A": ["127.0.0.3"]},
         "everything_module.test.notreal": {"A": ["127.0.0.4"]},
         "no_suppress_dupes.test.notreal": {"A": ["127.0.0.5"]},
@@ -116,7 +117,7 @@ async def test_manager_deduplication(bbot_scanner):
     assert 1 == len([e for e in default_events if e.type == "DNS_NAME" and e.data == "per_hostport_only.test.notreal" and str(e.module) == "per_hostport_only"])
     assert 1 == len([e for e in default_events if e.type == "DNS_NAME" and e.data == "test.notreal" and str(e.module) == "TARGET" and "SCAN:" in e.source.data])
 
-    assert len(all_events) == 26
+    assert len(all_events) == 27
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "accept_dupes.test.notreal" and str(e.module) == "accept_dupes"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "default_module.test.notreal" and str(e.module) == "default_module"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "no_suppress_dupes.test.notreal" and str(e.module) == "no_suppress_dupes" and e.source.data == "accept_dupes.test.notreal"])
@@ -127,6 +128,7 @@ async def test_manager_deduplication(bbot_scanner):
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "per_domain_only.test.notreal" and str(e.module) == "per_domain_only"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "per_hostport_only.test.notreal" and str(e.module) == "per_hostport_only"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "test.notreal" and str(e.module) == "TARGET" and "SCAN:" in e.source.data])
+    assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.3" and str(e.module) == "A" and e.source.data == "test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.3" and str(e.module) == "A" and e.source.data == "default_module.test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.5" and str(e.module) == "A" and e.source.data == "no_suppress_dupes.test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.6" and str(e.module) == "A" and e.source.data == "accept_dupes.test.notreal"])

--- a/bbot/test/test_step_1/test_modules_basic.py
+++ b/bbot/test/test_step_1/test_modules_basic.py
@@ -9,32 +9,75 @@ from bbot.modules.internal.base import BaseInternalModule
 
 
 @pytest.mark.asyncio
-async def test_modules_basic(scan, helpers, events, bbot_scanner, httpx_mock):
+async def test_modules_basic(helpers, events, bbot_scanner, httpx_mock):
     for http_method in ("GET", "CONNECT", "HEAD", "POST", "PUT", "TRACE", "DEBUG", "PATCH", "DELETE", "OPTIONS"):
         httpx_mock.add_response(method=http_method, url=re.compile(r".*"), json={"test": "test"})
 
+    from bbot.scanner import Scanner
+
+    scan = Scanner(config={"omit_event_types": ["URL_UNVERIFIED"]})
+    assert "URL_UNVERIFIED" in scan.omitted_event_types
+
     # output module specific event filtering tests
     base_output_module_1 = BaseOutputModule(scan)
-    base_output_module_1.watched_events = ["IP_ADDRESS"]
+    base_output_module_1.watched_events = ["IP_ADDRESS", "URL_UNVERIFIED"]
     localhost = scan.make_event("127.0.0.1", source=scan.root_event)
-    assert base_output_module_1._event_precheck(localhost)[0] == True
+    # ip addresses should be accepted
+    result, reason = base_output_module_1._event_precheck(localhost)
+    assert result == True
+    assert reason == "precheck succeeded"
+    # internal events should be rejected
     localhost._internal = True
-    assert base_output_module_1._event_precheck(localhost)[0] == False
+    result, reason = base_output_module_1._event_precheck(localhost)
+    assert result == False
+    assert reason == "_internal is True"
     localhost._internal = False
-    assert base_output_module_1._event_precheck(localhost)[0] == True
+    result, reason = base_output_module_1._event_precheck(localhost)
+    assert result == True
+    assert reason == "precheck succeeded"
+    # omitted events should be rejected
     localhost._omit = True
-    assert base_output_module_1._event_precheck(localhost)[0] == True
+    result, reason = base_output_module_1._event_precheck(localhost)
+    assert result == False
+    assert reason == "_omit is True"
+    # unwatched event types should be rejected
+    dns_name = scan.make_event("evilcorp.com", "DNS_NAME", source=scan.root_event)
+    result, reason = base_output_module_1._event_precheck(dns_name)
+    assert result == False
+    assert reason == "its type is not in watched_events"
+    # omitted event types matching watched events should be accepted
+    url_unverified = scan.make_event("http://127.0.0.1", "URL_UNVERIFIED", source=scan.root_event)
+    result, reason = base_output_module_1._event_precheck(url_unverified)
+    assert result == True
+    assert reason == "precheck succeeded"
 
     base_output_module_2 = BaseOutputModule(scan)
     base_output_module_2.watched_events = ["*"]
+    # normal events should be accepted
     localhost = scan.make_event("127.0.0.1", source=scan.root_event)
-    assert base_output_module_2._event_precheck(localhost)[0] == True
+    result, reason = base_output_module_2._event_precheck(localhost)
+    assert result == True
+    assert reason == "precheck succeeded"
+    # internal events should be rejected
     localhost._internal = True
-    assert base_output_module_2._event_precheck(localhost)[0] == False
+    result, reason = base_output_module_2._event_precheck(localhost)
+    assert result == False
+    assert reason == "_internal is True"
     localhost._internal = False
-    assert base_output_module_2._event_precheck(localhost)[0] == True
+    result, reason = base_output_module_2._event_precheck(localhost)
+    assert result == True
+    assert reason == "precheck succeeded"
+    # omitted events should be rejected
     localhost._omit = True
-    assert base_output_module_2._event_precheck(localhost)[0] == False
+    result, reason = base_output_module_2._event_precheck(localhost)
+    assert result == False
+    assert reason == "_omit is True"
+    # omitted event types should be rejected
+    url_unverified = scan.make_event("http://127.0.0.1", "URL_UNVERIFIED", source=scan.root_event)
+    result, reason = base_output_module_2._event_precheck(url_unverified)
+    log.critical(f"{url_unverified} / {result} / {reason}")
+    assert result == False
+    assert reason == "its type is omitted in the config"
 
     # common event filtering tests
     for module_class in (BaseModule, BaseOutputModule, BaseReportModule, BaseInternalModule):

--- a/bbot/test/test_step_2/module_tests/test_module_azure_realm.py
+++ b/bbot/test/test_step_2/module_tests/test_module_azure_realm.py
@@ -20,6 +20,7 @@ class TestAzure_Realm(ModuleTestBase):
     }
 
     async def setup_after_prep(self, module_test):
+        await module_test.mock_dns({"evilcorp.com": {"A": ["127.0.0.5"]}})
         module_test.httpx_mock.add_response(
             url=f"https://login.microsoftonline.com/getuserrealm.srf?login=test@evilcorp.com",
             json=self.response_json,

--- a/bbot/test/test_step_2/module_tests/test_module_baddns_zone.py
+++ b/bbot/test/test_step_2/module_tests/test_module_baddns_zone.py
@@ -48,7 +48,7 @@ class TestBaddns_zone_nsec(BaseTestBaddns_zone):
 
         await module_test.mock_dns(
             {
-                "bad.dns": {"NSEC": ["asdf.bad.dns"]},
+                "bad.dns": {"A": ["127.0.0.5"], "NSEC": ["asdf.bad.dns"]},
                 "asdf.bad.dns": {"NSEC": ["zzzz.bad.dns"]},
                 "zzzz.bad.dns": {"NSEC": ["xyz.bad.dns"]},
             }

--- a/bbot/test/test_step_2/module_tests/test_module_csv.py
+++ b/bbot/test/test_step_2/module_tests/test_module_csv.py
@@ -3,7 +3,7 @@ from .base import ModuleTestBase
 
 class TestCSV(ModuleTestBase):
     async def setup_after_prep(self, module_test):
-        await module_test.mock_dns({})
+        await module_test.mock_dns({"blacklanternsecurity.com": {"A": ["127.0.0.5"]}})
 
     def check(self, module_test, events):
         csv_file = module_test.scan.home / "output.csv"

--- a/bbot/test/test_step_2/module_tests/test_module_csv.py
+++ b/bbot/test/test_step_2/module_tests/test_module_csv.py
@@ -8,4 +8,4 @@ class TestCSV(ModuleTestBase):
     def check(self, module_test, events):
         csv_file = module_test.scan.home / "output.csv"
         with open(csv_file) as f:
-            assert "DNS_NAME,blacklanternsecurity.com,,TARGET" in f.read()
+            assert "blacklanternsecurity.com,127.0.0.5,TARGET" in f.read()

--- a/bbot/test/test_step_2/module_tests/test_module_dastardly.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dastardly.py
@@ -52,7 +52,7 @@ class TestDastardly(ModuleTestBase):
         def new_filter_event(event):
             self.new_url = f"http://{docker_ip}:5556/"
             event.data["url"] = self.new_url
-            event.parsed = module_test.scan.helpers.urlparse(self.new_url)
+            event.parsed_url = module_test.scan.helpers.urlparse(self.new_url)
             return old_filter_event(event)
 
         module_test.monkeypatch.setattr(module_test.module, "filter_event", new_filter_event)

--- a/bbot/test/test_step_2/module_tests/test_module_dnscommonsrv.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dnscommonsrv.py
@@ -8,6 +8,7 @@ class TestDNSCommonSRV(ModuleTestBase):
     async def setup_after_prep(self, module_test):
         await module_test.mock_dns(
             {
+                "blacklanternsecurity.notreal": {"A": ["127.0.0.5"]},
                 "_ldap._tcp.gc._msdcs.blacklanternsecurity.notreal": {
                     "SRV": ["0 100 3268 asdf.blacklanternsecurity.notreal"]
                 },

--- a/bbot/test/test_step_2/module_tests/test_module_oauth.py
+++ b/bbot/test/test_step_2/module_tests/test_module_oauth.py
@@ -165,6 +165,7 @@ class TestOAUTH(ModuleTestBase):
     }
 
     async def setup_after_prep(self, module_test):
+        await module_test.mock_dns({"evilcorp.com": {"A": ["127.0.0.1"]}})
         module_test.httpx_mock.add_response(
             url=f"https://login.microsoftonline.com/getuserrealm.srf?login=test@evilcorp.com",
             json=Azure_Realm.response_json,

--- a/bbot/test/test_step_2/module_tests/test_module_postman.py
+++ b/bbot/test/test_step_2/module_tests/test_module_postman.py
@@ -235,7 +235,9 @@ class TestPostman(ModuleTestBase):
             await old_emit_event(event_data, event_type, **kwargs)
 
         module_test.monkeypatch.setattr(module_test.module, "emit_event", new_emit_event)
-        await module_test.mock_dns({"asdf.blacklanternsecurity.com": {"A": ["127.0.0.1"]}})
+        await module_test.mock_dns(
+            {"blacklanternsecurity.com": {"A": ["127.0.0.1"]}, "asdf.blacklanternsecurity.com": {"A": ["127.0.0.1"]}}
+        )
 
         request_args = dict(uri="/_api/request/28129865-987c8ac8-bfa9-4bab-ade9-88ccf0597862")
         respond_args = dict(response_data="https://asdf.blacklanternsecurity.com")

--- a/bbot/test/test_step_2/module_tests/test_module_sitedossier.py
+++ b/bbot/test/test_step_2/module_tests/test_module_sitedossier.py
@@ -126,6 +126,15 @@ class TestSitedossier(ModuleTestBase):
     targets = ["evilcorp.com"]
 
     async def setup_after_prep(self, module_test):
+        await module_test.mock_dns(
+            {
+                "evilcorp.com": {"A": ["127.0.0.1"]},
+                "asdf.evilcorp.com": {"A": ["127.0.0.1"]},
+                "zzzz.evilcorp.com": {"A": ["127.0.0.1"]},
+                "xxxx.evilcorp.com": {"A": ["127.0.0.1"]},
+                "ffff.evilcorp.com": {"A": ["127.0.0.1"]},
+            }
+        )
         module_test.httpx_mock.add_response(
             url=f"http://www.sitedossier.com/parentdomain/evilcorp.com",
             text=page1,


### PR DESCRIPTION
This PR fixes a bug that was causing omitted event types to be displayed. Now, all omitted event types are suppressed from output, with the one exception of targets.

It also includes some new tests around the `_omit` attribute, and a rename of `event.parsed` to `event.parsed_url` for clarity.