### PR TITLE
Shorten ingress queue

### DIFF
--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -19,6 +19,9 @@ class ScanIngress(InterceptModule):
     scope_distance_modifier = None
     _name = "_scan_ingress"
 
+    # small queue size so we don't drain modules' outgoing queues
+    _qsize = 10
+
     @property
     def priority(self):
         # we are the highest priority

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -241,12 +241,12 @@ class Scanner:
 
             # intercept modules get sewn together like human centipede
             self.intercept_modules = [m for m in self.modules.values() if m._intercept]
-            for i, intercept_module in enumerate(self.intercept_modules[:-1]):
-                next_intercept_module = self.intercept_modules[i + 1]
+            for i, intercept_module in enumerate(self.intercept_modules[1:]):
+                prev_intercept_module = self.intercept_modules[i]
                 self.debug(
-                    f"Setting intercept module {intercept_module.name}.outgoing_event_queue to next intercept module {next_intercept_module.name}.incoming_event_queue"
+                    f"Setting intercept module {intercept_module.name}._incoming_event_queue to previous intercept module {prev_intercept_module.name}.outgoing_event_queue"
                 )
-                intercept_module._outgoing_event_queue = next_intercept_module.incoming_event_queue
+                intercept_module._incoming_event_queue = prev_intercept_module.outgoing_event_queue
 
             # abort if there are no output modules
             num_output_modules = len([m for m in self.modules.values() if m._type == "output"])

--- a/bbot/test/test_step_1/test_manager_deduplication.py
+++ b/bbot/test/test_step_1/test_manager_deduplication.py
@@ -75,6 +75,7 @@ async def test_manager_deduplication(bbot_scanner):
         )
 
     dns_mock_chain = {
+        "test.notreal": {"A": ["127.0.0.3"]},
         "default_module.test.notreal": {"A": ["127.0.0.3"]},
         "everything_module.test.notreal": {"A": ["127.0.0.4"]},
         "no_suppress_dupes.test.notreal": {"A": ["127.0.0.5"]},
@@ -116,7 +117,7 @@ async def test_manager_deduplication(bbot_scanner):
     assert 1 == len([e for e in default_events if e.type == "DNS_NAME" and e.data == "per_hostport_only.test.notreal" and str(e.module) == "per_hostport_only"])
     assert 1 == len([e for e in default_events if e.type == "DNS_NAME" and e.data == "test.notreal" and str(e.module) == "TARGET" and "SCAN:" in e.source.data])
 
-    assert len(all_events) == 26
+    assert len(all_events) == 27
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "accept_dupes.test.notreal" and str(e.module) == "accept_dupes"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "default_module.test.notreal" and str(e.module) == "default_module"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "no_suppress_dupes.test.notreal" and str(e.module) == "no_suppress_dupes" and e.source.data == "accept_dupes.test.notreal"])
@@ -127,6 +128,7 @@ async def test_manager_deduplication(bbot_scanner):
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "per_domain_only.test.notreal" and str(e.module) == "per_domain_only"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "per_hostport_only.test.notreal" and str(e.module) == "per_hostport_only"])
     assert 1 == len([e for e in all_events if e.type == "DNS_NAME" and e.data == "test.notreal" and str(e.module) == "TARGET" and "SCAN:" in e.source.data])
+    assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.3" and str(e.module) == "A" and e.source.data == "test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.3" and str(e.module) == "A" and e.source.data == "default_module.test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.5" and str(e.module) == "A" and e.source.data == "no_suppress_dupes.test.notreal"])
     assert 1 == len([e for e in all_events if e.type == "IP_ADDRESS" and e.data == "127.0.0.6" and str(e.module) == "A" and e.source.data == "accept_dupes.test.notreal"])


### PR DESCRIPTION
This small PR shortens the outgoing queue for the internal module `_scan_ingress`, to prevent premature draining of the modules' outgoing queues.