### PR TITLE
Improve --brief stdout

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -407,6 +407,19 @@ class BaseEvent:
                 self.source.scope_distance = scope_distance + 1
 
     @property
+    def scope_description(self):
+        """
+        Returns a single word describing the scope of the event.
+
+        "in-scope" if the event is in scope, "affiliate" if it's an affiliate, otherwise "distance-{scope_distance}"
+        """
+        if self.scope_distance == 0:
+            return "in-scope"
+        elif "affiliate" in self.tags:
+            return "affiliate"
+        return f"distance-{self.scope_distance}"
+
+    @property
     def source(self):
         return self._source
 
@@ -600,7 +613,7 @@ class BaseEvent:
             dict: JSON-serializable dictionary representation of the event object.
         """
         j = dict()
-        for i in ("type", "id"):
+        for i in ("type", "id", "scope_description"):
             v = getattr(self, i, "")
             if v:
                 j.update({i: v})

--- a/bbot/scanner/preset/args.py
+++ b/bbot/scanner/preset/args.py
@@ -126,7 +126,7 @@ class BBOTArgs:
             args_preset.core.merge_custom({"modules": {"stdout": {"format": "json"}}})
         if self.parsed.brief:
             args_preset.core.merge_custom(
-                {"modules": {"stdout": {"event_fields": ["type", "scope_distance", "data"]}}}
+                {"modules": {"stdout": {"event_fields": ["type", "scope_description", "data"]}}}
             )
         if self.parsed.event_types:
             args_preset.core.merge_custom({"modules": {"stdout": {"event_types": self.parsed.event_types}}})


### PR DESCRIPTION
This PR adds a `scope_description` attribute to events, and uses it in the `--brief` CLI option. It's meant to summarize the scope of an event: `in-scope` or `affiliate`, or if it's neither of those, its scope distance.