### PR TITLE
Another dastardly fix

### DIFF
--- a/bbot/modules/deadly/dastardly.py
+++ b/bbot/modules/deadly/dastardly.py
@@ -104,7 +104,7 @@ class dastardly(BaseModule):
     def parse_dastardly_xml(self, xml_file):
         try:
             with open(xml_file, "rb") as f:
-                et = etree.parse(f)
+                et = etree.parse(f, parser=etree.XMLParser(recover=True))
                 for testsuite in et.iter("testsuite"):
                     yield TestSuite(testsuite)
         except FileNotFoundError:


### PR DESCRIPTION
This PR addresses #1284. Where binary data is supplied in the XML file caused the parser to error-out. This fixes that by using a custom parser which is more relaxed :)