### PR TITLE
Change dockerhub from active to passive flag

### DIFF
--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -4,7 +4,7 @@ from bbot.modules.base import BaseModule
 class dockerhub(BaseModule):
     watched_events = ["SOCIAL", "ORG_STUB"]
     produced_events = ["SOCIAL", "CODE_REPOSITORY", "URL_UNVERIFIED"]
-    flags = ["active", "safe"]
+    flags = ["passive", "safe"]
     meta = {"description": "Search for docker repositories of discovered orgs/usernames"}
 
     site_url = "https://hub.docker.com"


### PR DESCRIPTION
When orgs are specified as targets dockerhub wouldn't consume some of these as it was flagged as ACTIVE (for some reason) so this PR changes it to PASSIVE

Fixes https://github.com/blacklanternsecurity/bbot/issues/1347