### PR TITLE
Include "host" as attribute in event JSON

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -608,11 +608,13 @@ class BaseEvent:
         Returns:
             dict: JSON-serializable dictionary representation of the event object.
         """
+        # type, ID, scope description
         j = dict()
         for i in ("type", "id", "scope_description"):
             v = getattr(self, i, "")
             if v:
                 j.update({i: v})
+        # event data
         data_attr = getattr(self, f"data_{mode}", None)
         if data_attr is not None:
             data = data_attr
@@ -622,23 +624,33 @@ class BaseEvent:
             j["data"] = {self.type: data}
         else:
             j["data"] = data
+        # host, dns children
+        if self.host:
+            j["host"] = str(self.host)
+            j["resolved_hosts"] = sorted(str(h) for h in self.resolved_hosts)
+            j["dns_children"] = {k: list(v) for k, v in self.dns_children.items()}
+        # web spider distance
         web_spider_distance = getattr(self, "web_spider_distance", None)
         if web_spider_distance is not None:
             j["web_spider_distance"] = web_spider_distance
+        # scope distance
         j["scope_distance"] = self.scope_distance
+        # scan
         if self.scan:
             j["scan"] = self.scan.id
+        # timestamp
         j["timestamp"] = self.timestamp.timestamp()
-        if self.host:
-            j["resolved_hosts"] = sorted(str(h) for h in self.resolved_hosts)
-            j["dns_children"] = {k: list(v) for k, v in self.dns_children.items()}
+        # parent event
         source_id = self.source_id
         if source_id:
             j["source"] = source_id
+        # tags
         if self.tags:
             j.update({"tags": list(self.tags)})
+        # source module
         if self.module:
             j.update({"module": str(self.module)})
+        # sequence of modules that led to discovery
         if self.module_sequence:
             j.update({"module_sequence": str(self.module_sequence)})
 

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -399,33 +399,40 @@ async def test_events(events, helpers):
     # test event serialization
     from bbot.core.event import event_from_json
 
-    db_event = scan.make_event("evilcorp.com", dummy=True)
+    db_event = scan.make_event("evilcorp.com:80", dummy=True)
     db_event._resolved_hosts = {"127.0.0.1"}
     db_event.scope_distance = 1
     timestamp = db_event.timestamp.timestamp()
     json_event = db_event.json()
     assert json_event["scope_distance"] == 1
-    assert json_event["data"] == "evilcorp.com"
-    assert json_event["type"] == "DNS_NAME"
+    assert json_event["data"] == "evilcorp.com:80"
+    assert json_event["type"] == "OPEN_TCP_PORT"
+    assert json_event["host"] == "evilcorp.com"
     assert json_event["timestamp"] == timestamp
     reconstituted_event = event_from_json(json_event)
     assert reconstituted_event.scope_distance == 1
     assert reconstituted_event.timestamp.timestamp() == timestamp
-    assert reconstituted_event.data == "evilcorp.com"
-    assert reconstituted_event.type == "DNS_NAME"
+    assert reconstituted_event.data == "evilcorp.com:80"
+    assert reconstituted_event.type == "OPEN_TCP_PORT"
     assert "127.0.0.1" in reconstituted_event.resolved_hosts
+    hostless_event = scan.make_event("asdf", "ASDF", dummy=True)
+    hostless_event_json = hostless_event.json()
+    assert hostless_event_json["type"] == "ASDF"
+    assert hostless_event_json["data"] == "asdf"
+    assert not "host" in hostless_event_json
 
     # SIEM-friendly serialize/deserialize
     json_event_siemfriendly = db_event.json(siem_friendly=True)
     assert json_event_siemfriendly["scope_distance"] == 1
-    assert json_event_siemfriendly["data"] == {"DNS_NAME": "evilcorp.com"}
-    assert json_event_siemfriendly["type"] == "DNS_NAME"
+    assert json_event_siemfriendly["data"] == {"OPEN_TCP_PORT": "evilcorp.com:80"}
+    assert json_event_siemfriendly["type"] == "OPEN_TCP_PORT"
+    assert json_event_siemfriendly["host"] == "evilcorp.com"
     assert json_event_siemfriendly["timestamp"] == timestamp
     reconstituted_event2 = event_from_json(json_event_siemfriendly, siem_friendly=True)
     assert reconstituted_event2.scope_distance == 1
     assert reconstituted_event2.timestamp.timestamp() == timestamp
-    assert reconstituted_event2.data == "evilcorp.com"
-    assert reconstituted_event2.type == "DNS_NAME"
+    assert reconstituted_event2.data == "evilcorp.com:80"
+    assert reconstituted_event2.type == "OPEN_TCP_PORT"
     assert "127.0.0.1" in reconstituted_event2.resolved_hosts
 
     http_response = scan.make_event(httpx_response, "HTTP_RESPONSE", source=scan.root_event)


### PR DESCRIPTION
I'm not sure why we haven't done this yet, but this PR adds a "host" attribute to each event in `output.json`.