### PR TITLE
Fix subdomain enum duplicate query bug

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -738,7 +738,12 @@ class BaseModule:
 
         # custom filtering
         async with self.scan._acatch(context=self.filter_event):
-            filter_result = await self.filter_event(event)
+            try:
+                filter_result = await self.filter_event(event)
+            except Exception as e:
+                msg = f"Unhandled exception in {self.name}.filter_event({event}): {e}"
+                self.error(msg)
+                return False, msg
             msg = str(self._custom_filter_criteria_msg)
             with suppress(ValueError, TypeError):
                 filter_result, reason = filter_result
@@ -886,7 +891,12 @@ class BaseModule:
         if event.type in ("FINISHED",):
             return False, ""
         reason = ""
-        event_hash = self._incoming_dedup_hash(event)
+        try:
+            event_hash = self._incoming_dedup_hash(event)
+        except Exception as e:
+            msg = f"Unhandled exception in {self.name}._incoming_dedup_hash({event}): {e}"
+            self.error(msg)
+            return True, msg
         with suppress(TypeError, ValueError):
             event_hash, reason = event_hash
         is_dup = event_hash in self._incoming_dup_tracker

--- a/bbot/modules/github_codesearch.py
+++ b/bbot/modules/github_codesearch.py
@@ -1,7 +1,8 @@
 from bbot.modules.templates.github import github
+from bbot.modules.templates.subdomain_enum import subdomain_enum
 
 
-class github_codesearch(github):
+class github_codesearch(github, subdomain_enum):
     watched_events = ["DNS_NAME"]
     produced_events = ["CODE_REPOSITORY", "URL_UNVERIFIED"]
     flags = ["passive", "subdomain-enum", "safe", "code-enum"]

--- a/bbot/modules/templates/github.py
+++ b/bbot/modules/templates/github.py
@@ -1,7 +1,7 @@
-from bbot.modules.templates.subdomain_enum import subdomain_enum
+from bbot.modules.base import BaseModule
 
 
-class github(subdomain_enum):
+class github(BaseModule):
     """
     A template module for use of the GitHub API
     Inherited by several other github modules.

--- a/bbot/modules/templates/subdomain_enum.py
+++ b/bbot/modules/templates/subdomain_enum.py
@@ -67,7 +67,11 @@ class subdomain_enum(BaseModule):
             if self.scan.in_scope(p):
                 query = p
                 break
-        return ".".join([s for s in query.split(".") if s != "_wildcard"])
+        try:
+            return ".".join([s for s in query.split(".") if s != "_wildcard"])
+        except Exception:
+            self.critical(query)
+            raise
 
     def parse_results(self, r, query=None):
         json = r.json()

--- a/bbot/modules/templates/subdomain_enum.py
+++ b/bbot/modules/templates/subdomain_enum.py
@@ -30,6 +30,12 @@ class subdomain_enum(BaseModule):
     #   "lowest_parent": dedupe by lowest parent (lowest parent of www.api.test.evilcorp.com is api.test.evilcorp.com)
     dedup_strategy = "highest_parent"
 
+    def _incoming_dedup_hash(self, event):
+        """
+        Determines the criteria for what is considered to be a duplicate event if `accept_dupes` is False.
+        """
+        return hash(self.make_query(event)), f"dedup_strategy={self.dedup_strategy}"
+
     async def handle_event(self, event):
         query = self.make_query(event)
         results = await self.query(query)

--- a/bbot/test/test_step_2/module_tests/base.py
+++ b/bbot/test/test_step_2/module_tests/base.py
@@ -43,7 +43,7 @@ class ModuleTestBase:
     whitelist = None
     module_name = None
     config_overrides = {}
-    modules_overrides = []
+    modules_overrides = None
     log = logging.getLogger("bbot")
 
     class ModuleTest:
@@ -147,7 +147,7 @@ class ModuleTestBase:
 
     @property
     def modules(self):
-        if self.modules_overrides:
+        if self.modules_overrides is not None:
             return self.modules_overrides
         return [self.name]
 

--- a/bbot/test/test_step_2/template_tests/test_template_subdomain_enum.py
+++ b/bbot/test/test_step_2/template_tests/test_template_subdomain_enum.py
@@ -1,0 +1,85 @@
+from ..module_tests.base import ModuleTestBase
+
+
+class TestSubdomainEnum(ModuleTestBase):
+    targets = ["blacklanternsecurity.com"]
+    modules_overrides = []
+    config_overrides = {"dns_resolution": True, "scope_report_distance": 10}
+    dedup_strategy = "highest_parent"
+
+    txt = [
+        "www.blacklanternsecurity.com",
+        "asdf.www.blacklanternsecurity.com",
+        "test.asdf.www.blacklanternsecurity.com",
+        "api.test.asdf.www.blacklanternsecurity.com",
+    ]
+
+    async def setup_after_prep(self, module_test):
+        dns_mock = {
+            "evilcorp.com": {"A": ["127.0.0.6"]},
+            "blacklanternsecurity.com": {"A": ["127.0.0.5"]},
+            "www.blacklanternsecurity.com": {"A": ["127.0.0.5"]},
+            "asdf.www.blacklanternsecurity.com": {"A": ["127.0.0.5"]},
+            "test.asdf.www.blacklanternsecurity.com": {"A": ["127.0.0.5"]},
+            "api.test.asdf.www.blacklanternsecurity.com": {"A": ["127.0.0.5"]},
+        }
+        if self.txt:
+            dns_mock["blacklanternsecurity.com"]["TXT"] = self.txt
+        await module_test.mock_dns(dns_mock)
+
+        # load subdomain enum template as module
+        from bbot.modules.templates.subdomain_enum import subdomain_enum
+
+        subdomain_enum_module = subdomain_enum(module_test.scan)
+
+        self.queries = []
+
+        async def mock_query(query):
+            self.queries.append(query)
+
+        subdomain_enum_module.query = mock_query
+        subdomain_enum_module.dedup_strategy = self.dedup_strategy
+        module_test.scan.modules["subdomain_enum"] = subdomain_enum_module
+
+    def check(self, module_test, events):
+        in_scope_dns_names = [e for e in events if e.type == "DNS_NAME" and e.scope_distance == 0]
+        assert len(in_scope_dns_names) == 5
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "asdf.www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "test.asdf.www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "api.test.asdf.www.blacklanternsecurity.com"])
+        assert len(self.queries) == 1
+        assert self.queries[0] == "blacklanternsecurity.com"
+
+
+class TestSubdomainEnumHighestParent(TestSubdomainEnum):
+    targets = ["api.test.asdf.www.blacklanternsecurity.com", "evilcorp.com"]
+    whitelist = ["www.blacklanternsecurity.com"]
+    modules_overrides = ["speculate"]
+    dedup_strategy = "highest_parent"
+    txt = None
+
+    def check(self, module_test, events):
+        in_scope_dns_names = [e for e in events if e.type == "DNS_NAME" and e.scope_distance == 0]
+        distance_1_dns_names = [e for e in events if e.type == "DNS_NAME" and e.scope_distance == 1]
+        assert len(in_scope_dns_names) == 4
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "asdf.www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "test.asdf.www.blacklanternsecurity.com"])
+        assert 1 == len([e for e in in_scope_dns_names if e.data == "api.test.asdf.www.blacklanternsecurity.com"])
+        assert len(distance_1_dns_names) == 1
+        assert 1 == len([e for e in distance_1_dns_names if e.data == "evilcorp.com"])
+        assert len(self.queries) == 1
+        assert self.queries[0] == "www.blacklanternsecurity.com"
+
+
+class TestSubdomainEnumLowestParent(TestSubdomainEnumHighestParent):
+    dedup_strategy = "lowest_parent"
+
+    def check(self, module_test, events):
+        assert set(self.queries) == {
+            "test.asdf.www.blacklanternsecurity.com",
+            "asdf.www.blacklanternsecurity.com",
+            "www.blacklanternsecurity.com",
+        }


### PR DESCRIPTION
A bug in bbot 2.0 was causing multiple of the same query to be made in the subdomain enum modules. This PR fixes the bug and creates tests for it.

TODO:
- [x] Fix this:
```
2024-05-13T14:32:14.8936865Z CRITICAL bbot.scanner:scanner.py:1142 Error in BaseModule._worker(): /home/runner/work/bbot/bbot/bbot/modules/templates/subdomain_enum.py:70:make_query(): 'dict' object has no attribute 'split'
2024-05-13T14:32:14.8943505Z CRITICAL bbot.scanner:scanner.py:1143 Traceback (most recent call last):
2024-05-13T14:32:14.8944638Z   File "/home/runner/work/bbot/bbot/bbot/scanner/scanner.py", line 1125, in _acatch
2024-05-13T14:32:14.8945265Z     yield
2024-05-13T14:32:14.8945918Z   File "/home/runner/work/bbot/bbot/bbot/modules/base.py", line 620, in _worker
2024-05-13T14:32:14.8946890Z     acceptable, reason = await self._event_postcheck(event)
2024-05-13T14:32:14.8947344Z                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-13T14:32:14.8947978Z   File "/home/runner/work/bbot/bbot/bbot/modules/base.py", line 706, in _event_postcheck
2024-05-13T14:32:14.8949178Z     is_incoming_duplicate, reason = self.is_incoming_duplicate(event, add=True)
2024-05-13T14:32:14.8950060Z                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-13T14:32:14.8950757Z   File "/home/runner/work/bbot/bbot/bbot/modules/base.py", line 889, in is_incoming_duplicate
2024-05-13T14:32:14.8951929Z     event_hash = self._incoming_dedup_hash(event)
2024-05-13T14:32:14.8952639Z                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-13T14:32:14.8954033Z   File "/home/runner/work/bbot/bbot/bbot/modules/templates/subdomain_enum.py", line 37, in _incoming_dedup_hash
2024-05-13T14:32:14.8955224Z     return hash(self.make_query(event)), f"dedup_strategy={self.dedup_strategy}"
2024-05-13T14:32:14.8955735Z                 ^^^^^^^^^^^^^^^^^^^^^^
2024-05-13T14:32:14.8956413Z   File "/home/runner/work/bbot/bbot/bbot/modules/templates/subdomain_enum.py", line 70, in make_query
2024-05-13T14:32:14.8957193Z     return ".".join([s for s in query.split(".") if s != "_wildcard"])
2024-05-13T14:32:14.8957657Z                                 ^^^^^^^^^^^
2024-05-13T14:32:14.8958177Z AttributeError: 'dict' object has no attribute 'split'
```