### PR TITLE
Process Timeouts

### DIFF
--- a/bbot/core/helpers/command.py
+++ b/bbot/core/helpers/command.py
@@ -53,7 +53,7 @@ async def run(self, *command, check=False, text=True, idle_timeout=None, **kwarg
                     stdout, stderr = await asyncio.wait_for(proc.communicate(_input), timeout=idle_timeout)
                 else:
                     stdout, stderr = await proc.communicate(_input)
-            except TimeoutError:
+            except asyncio.exceptions.TimeoutError:
                 proc.send_signal(SIGINT)
                 raise
 
@@ -117,7 +117,7 @@ async def run_live(self, *command, check=False, text=True, idle_timeout=None, **
                         line = await asyncio.wait_for(proc.stdout.readline(), timeout=idle_timeout)
                     else:
                         line = await proc.stdout.readline()
-                except TimeoutError:
+                except asyncio.exceptions.TimeoutError:
                     proc.send_signal(SIGINT)
                     raise
                 except ValueError as e:

--- a/bbot/core/helpers/command.py
+++ b/bbot/core/helpers/command.py
@@ -20,6 +20,7 @@ async def run(self, *command, check=False, text=True, idle_timeout=None, **kwarg
         check (bool, optional): If set to True, raises an error if the subprocess exits with a non-zero status.
                                 Defaults to False.
         text (bool, optional): If set to True, decodes the subprocess output to string. Defaults to True.
+        idle_timeout (int, optional): Sets a limit on the number of seconds the process can run before throwing a TimeoutError
         **kwargs (dict): Additional keyword arguments for the subprocess.
 
     Returns:
@@ -79,6 +80,7 @@ async def run_live(self, *command, check=False, text=True, idle_timeout=None, **
         check (bool, optional): If set to True, raises an error if the subprocess exits with a non-zero status.
                                 Defaults to False.
         text (bool, optional): If set to True, decodes the subprocess output to string. Defaults to True.
+        idle_timeout (int, optional): Sets a limit on the number of seconds the process can remain idle (no lines sent to stdout) before throwing a TimeoutError
         **kwargs (dict): Additional keyword arguments for the subprocess.
 
     Yields:

--- a/bbot/core/helpers/command.py
+++ b/bbot/core/helpers/command.py
@@ -117,7 +117,7 @@ async def run_live(self, *command, check=False, text=True, idle_timeout=None, **
                         line = await asyncio.wait_for(proc.stdout.readline(), timeout=idle_timeout)
                     else:
                         line = await proc.stdout.readline()
-                except TimeoutError as e:
+                except TimeoutError:
                     proc.send_signal(SIGINT)
                     raise
                 except ValueError as e:

--- a/bbot/modules/gowitness.py
+++ b/bbot/modules/gowitness.py
@@ -202,7 +202,6 @@ class gowitness(BaseModule):
             await self.emit_event(tech_data, "TECHNOLOGY", source=source_event)
 
     def construct_command(self):
-        return ["sleep", "999"]
         # base executable
         command = ["gowitness"]
         # chrome path

--- a/bbot/modules/gowitness.py
+++ b/bbot/modules/gowitness.py
@@ -1,3 +1,4 @@
+import asyncio
 import sqlite3
 import multiprocessing
 from pathlib import Path
@@ -164,7 +165,7 @@ class gowitness(BaseModule):
         try:
             async for line in self.run_process_live(self.command, input=stdin, idle_timeout=self.idle_timeout):
                 self.debug(line)
-        except TimeoutError:
+        except asyncio.exceptions.TimeoutError:
             urls_str = ",".join(event_dict)
             self.warning(f"Gowitness timed out while visiting the following URLs: {urls_str}", trace=False)
             return

--- a/bbot/modules/gowitness.py
+++ b/bbot/modules/gowitness.py
@@ -164,7 +164,7 @@ class gowitness(BaseModule):
         try:
             async for line in self.run_process_live(self.command, input=stdin, idle_timeout=self.idle_timeout):
                 self.debug(line)
-        except TimeoutError as e:
+        except TimeoutError:
             urls_str = ",".join(event_dict)
             self.warning(f"Gowitness timed out while visiting the following URLs: {urls_str}", trace=False)
             return

--- a/bbot/modules/gowitness.py
+++ b/bbot/modules/gowitness.py
@@ -1,4 +1,5 @@
 import sqlite3
+import multiprocessing
 from pathlib import Path
 from contextlib import suppress
 from shutil import copyfile, copymode
@@ -19,15 +20,17 @@ class gowitness(BaseModule):
         "resolution_y": 900,
         "output_path": "",
         "social": True,
+        "idle_timeout": 1800,
     }
     options_desc = {
-        "version": "gowitness version",
-        "threads": "threads used to run",
-        "timeout": "preflight check timeout",
-        "resolution_x": "screenshot resolution x",
-        "resolution_y": "screenshot resolution y",
-        "output_path": "where to save screenshots",
+        "version": "Gowitness version",
+        "threads": "How many gowitness threads to spawn - default is number of CPUs x 2",
+        "timeout": "Preflight check timeout",
+        "resolution_x": "Screenshot resolution x",
+        "resolution_y": "Screenshot resolution y",
+        "output_path": "Where to save screenshots",
         "social": "Whether to screenshot social media webpages",
+        "idle_timeout": "Skip the current gowitness batch if it stalls for longer than this many seconds",
     }
     deps_ansible = [
         {
@@ -82,8 +85,11 @@ class gowitness(BaseModule):
     scope_distance_modifier = 2
 
     async def setup(self):
+        num_cpus = multiprocessing.cpu_count()
+        default_thread_count = min(20, num_cpus * 2)
         self.timeout = self.config.get("timeout", 10)
-        self.threads = self.config.get("threads", 4)
+        self.idle_timeout = self.config.get("idle_timeout", 1800)
+        self.threads = self.config.get("threads", default_thread_count)
         self.proxy = self.scan.config.get("http_proxy", "")
         self.resolution_x = self.config.get("resolution_x")
         self.resolution_y = self.config.get("resolution_y")
@@ -155,8 +161,13 @@ class gowitness(BaseModule):
             event_dict[key] = e
         stdin = "\n".join(list(event_dict))
 
-        async for line in self.run_process_live(self.command, input=stdin):
-            self.debug(line)
+        try:
+            async for line in self.run_process_live(self.command, input=stdin, idle_timeout=self.idle_timeout):
+                self.debug(line)
+        except TimeoutError as e:
+            urls_str = ",".join(event_dict)
+            self.warning(f"Gowitness timed out while visiting the following URLs: {urls_str}", trace=False)
+            return
 
         # emit web screenshots
         for filename, screenshot in self.new_screenshots.items():
@@ -191,6 +202,7 @@ class gowitness(BaseModule):
             await self.emit_event(tech_data, "TECHNOLOGY", source=source_event)
 
     def construct_command(self):
+        return ["sleep", "999"]
         # base executable
         command = ["gowitness"]
         # chrome path
@@ -212,6 +224,8 @@ class gowitness(BaseModule):
         command += ["file", "-f", "-"]
         # threads
         command += ["--threads", str(self.threads)]
+        # timeout
+        command += ["--timeout", str(self.timeout)]
         return command
 
     @property

--- a/bbot/test/test_step_1/test_command.py
+++ b/bbot/test/test_step_1/test_command.py
@@ -1,3 +1,4 @@
+import time
 from ..bbot_fixtures import *
 from subprocess import CalledProcessError
 
@@ -5,6 +6,23 @@ from subprocess import CalledProcessError
 @pytest.mark.asyncio
 async def test_command(bbot_scanner, bbot_config):
     scan1 = bbot_scanner(config=bbot_config)
+
+    # test timeouts
+    command = ["sleep", "3"]
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        await scan1.helpers.run(command, idle_timeout=1)
+    end = time.time()
+    elapsed = end - start
+    assert 0 < elapsed < 2
+
+    start = time.time()
+    with pytest.raises(TimeoutError):
+        async for line in scan1.helpers.run_live(command, idle_timeout=1):
+            print(line)
+    end = time.time()
+    elapsed = end - start
+    assert 0 < elapsed < 2
 
     # run
     assert "plumbus\n" == (await scan1.helpers.run(["echo", "plumbus"])).stdout

--- a/bbot/test/test_step_1/test_command.py
+++ b/bbot/test/test_step_1/test_command.py
@@ -10,14 +10,14 @@ async def test_command(bbot_scanner, bbot_config):
     # test timeouts
     command = ["sleep", "3"]
     start = time.time()
-    with pytest.raises(TimeoutError):
+    with pytest.raises(asyncio.exceptions.TimeoutError):
         await scan1.helpers.run(command, idle_timeout=1)
     end = time.time()
     elapsed = end - start
     assert 0 < elapsed < 2
 
     start = time.time()
-    with pytest.raises(TimeoutError):
+    with pytest.raises(asyncio.exceptions.TimeoutError):
         async for line in scan1.helpers.run_live(command, idle_timeout=1):
             print(line)
     end = time.time()


### PR DESCRIPTION
This PR adds the ability to specify a timeout when executing a subprocess. This is useful in cases like gowitness, which can stall out and never finish (see https://github.com/blacklanternsecurity/bbot/issues/1378).