### PR TITLE
Add a version updater github action

### DIFF
--- a/.github/workflows/version_updater.yaml
+++ b/.github/workflows/version_updater.yaml
@@ -1,0 +1,92 @@
+name: Version Updater
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  update-nuclei-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+      - name: Get latest version
+        id: get-latest-version
+        run: |
+          import os, requests
+          response = requests.get('https://api.github.com/repos/projectdiscovery/nuclei/releases/latest')
+          version = response.json()['tag_name'].lstrip('v')
+          os.system(f"echo 'latest_version={version}' >> $GITHUB_ENV")
+        shell: python
+      - name: Get current version
+        id: get-current-version
+        run: |
+          version=$(grep -m 1 -oP '(?<=version": ")[^"]*' bbot/modules/deadly/nuclei.py)
+          echo "current_version=$version" >> $GITHUB_ENV
+      - name: Update version
+        id: update-version
+        if: env.latest_version != env.current_version
+        run: sed -i '0,/\"version\": \".*\",/ s/\"version\": \".*\",/\"version\": \"${{ env.latest_version }}\",/g' bbot/modules/deadly/nuclei.py
+      - name: Create pull request to update the version
+        if: steps.update-version.outcome == 'success'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update nuclei"
+          title: "Update nuclei to ${{ env.latest_version }}"
+          body: "This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."
+          branch: "dev"
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>
+          assignees: "TheTechromancer"
+  update-trufflehog-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+      - name: Get latest version
+        id: get-latest-version
+        run: |
+          import os, requests
+          response = requests.get('https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest')
+          version = response.json()['tag_name'].lstrip('v')
+          os.system(f"echo 'latest_version={version}' >> $GITHUB_ENV")
+        shell: python
+      - name: Get current version
+        id: get-current-version
+        run: |
+          version=$(grep -m 1 -oP '(?<=version": ")[^"]*' bbot/modules/trufflehog.py)
+          echo "current_version=$version" >> $GITHUB_ENV
+      - name: Update version
+        id: update-version
+        if: env.latest_version != env.current_version
+        run: sed -i '0,/\"version\": \".*\",/ s/\"version\": \".*\",/\"version\": \"${{ env.latest_version }}\",/g' bbot/modules/trufflehog.py
+      - name: Create pull request to update the version
+        if: steps.update-version.outcome == 'success'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update trufflehog"
+          title: "Update trufflehog to ${{ env.latest_version }}"
+          body: "This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py."
+          branch: "dev"
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>
+          assignees: "TheTechromancer"


### PR DESCRIPTION
This PR adds a github workflow to update the versions of nuclei and trufflehog.
Other modules that have set versions are
- [ ] ffuf / ffuf_shortnames
- [ ] fingerprintx
- [ ] gowitness
- [ ] httpx

I didn't know if they wanted updating though

It will make a request to the `/releases/latest` endpoint for the repository to obtain the latest version and store this in an environment variable. It then also grep's the current version out of the module file and compares them. If they do not match it uses `sed` to replace the version number and then opens a pull request.

I wasn't sure who would be the approve so let me know if it needs changing. Committer and author I have just added Github in there as a placeholder it can be changed to anything.