### PR TITLE
Filedownload - only download in-scope files

### DIFF
--- a/bbot/modules/bucket_file_enum.py
+++ b/bbot/modules/bucket_file_enum.py
@@ -4,13 +4,15 @@ import xml.etree.ElementTree as ET
 
 class bucket_file_enum(BaseModule):
     """
-    Enumerate files in a public bucket
+    Enumerate files in public storage buckets
+
+    Currently only supports AWS and DigitalOcean
     """
 
     watched_events = ["STORAGE_BUCKET"]
     produced_events = ["URL_UNVERIFIED"]
     meta = {
-        "description": "Works in conjunction with the filedownload module to download files from open storage buckets. Currently supported cloud providers: AWS",
+        "description": "Works in conjunction with the filedownload module to download files from open storage buckets. Currently supported cloud providers: AWS, DigitalOcean",
         "created_date": "2023-11-14",
         "author": "@TheTechromancer",
     }

--- a/bbot/modules/filedownload.py
+++ b/bbot/modules/filedownload.py
@@ -105,7 +105,7 @@ class filedownload(BaseModule):
         if "filedownload" in event.tags:
             return True
         else:
-            if event.scope_distance > 1:
+            if event.scope_distance > 0:
                 return False, f"{event} not within scope distance"
             elif self.hash_event(event) in self.urls_downloaded:
                 return False, f"Already processed {event}"


### PR DESCRIPTION
Addresses https://github.com/blacklanternsecurity/bbot/issues/1141. Note that files tagged with `filedownload` (e.g. storage bucket files from `bucket_file_enum`) are still downloaded up to a distance of `3`.