### PR TITLE
Add Option to Disable Target DNS Regex

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -141,3 +141,7 @@ dns_omit_queries:
   - SRV:mail.protection.outlook.com
   - CNAME:mail.protection.outlook.com
   - TXT:mail.protection.outlook.com
+
+# temporary fix to boost scan performance
+# TODO: remove this when https://github.com/blacklanternsecurity/bbot/issues/1252 is merged
+target_dns_regex_disable: false

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -269,6 +269,10 @@ class Scanner:
         self._stopping = False
 
         self._dns_regexes = None
+        # temporary fix to boost scan performance
+        # TODO: remove this when https://github.com/blacklanternsecurity/bbot/issues/1252 is merged
+        self._target_dns_regex_disable = self.config.get("target_dns_regex_disable", False)
+
         self.__log_handlers = None
         self._log_handler_backup = []
 
@@ -849,6 +853,8 @@ class Scanner:
             ...     for match in regex.finditer(response.text):
             ...         hostname = match.group().lower()
         """
+        if self._target_dns_regex_disable:
+            return []
         if self._dns_regexes is None:
             dns_targets = set(t.host for t in self.target if t.host and isinstance(t.host, str))
             dns_whitelist = set(t.host for t in self.whitelist if t.host and isinstance(t.host, str))


### PR DESCRIPTION
In scans with a lot of targets, `excavate` is taking up a lot of CPU time and slowing down scans significantly. This is because a regex is generated for every target in order to extract matching subdomains from `HTTP_RESPONSE`, etc. 

Because this is preventing ASM scans from finishing in a timely manner, I've added this option which allows that regex feature to be disabled. 

This is a temporary fix and will be removed again once @liquidsec finishes his [excavate overhual](https://github.com/blacklanternsecurity/bbot/issues/1252).