### PR TITLE
InternetDB: option to display open ports

### DIFF
--- a/bbot/modules/internetdb.py
+++ b/bbot/modules/internetdb.py
@@ -43,24 +43,21 @@ class internetdb(BaseModule):
         "created_date": "2023-12-22",
         "author": "@TheTechromancer",
     }
+    options = {"show_open_ports": False}
+    options_desc = {
+        "show_open_ports": "Display OPEN_TCP_PORT events in output, even if they didn't lead to an interesting discovery"
+    }
 
     _qsize = 500
 
     base_url = "https://internetdb.shodan.io"
 
     async def setup(self):
-        self.processed = set()
+        self.show_open_ports = self.config.get("show_open_ports", False)
         return True
 
-    async def filter_event(self, event):
-        ip = self.get_ip(event)
-        if ip:
-            ip_hash = hash(ip)
-            if ip_hash in self.processed:
-                return False, "IP was already processed"
-            self.processed.add(ip_hash)
-            return True
-        return False, "event had no valid IP addresses"
+    def _incoming_dedup_hash(self, event):
+        return hash(self.get_ip(event))
 
     async def handle_event(self, event):
         ip = self.get_ip(event)
@@ -99,7 +96,11 @@ class internetdb(BaseModule):
             await self.emit_event({"technology": cpe, "host": str(event.host)}, "TECHNOLOGY", source=event)
         for port in data.get("ports", []):
             await self.emit_event(
-                self.helpers.make_netloc(event.data, port), "OPEN_TCP_PORT", source=event, internal=True, quick=True
+                self.helpers.make_netloc(event.data, port),
+                "OPEN_TCP_PORT",
+                source=event,
+                internal=(not self.show_open_ports),
+                quick=True,
             )
         vulns = data.get("vulns", [])
         if vulns:


### PR DESCRIPTION
Adds an option to display `OPEN_TCP_PORT` events from `internetdb`:

```bash
bbot -t evilcorp.com -m internetdb -c modules.internetdb.show_open_ports=true
```