### PR TITLE
New Module: Unstructured

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -122,7 +122,7 @@ url_extension_httpx_only:
 # Don't output these types of events (they are still distributed to modules)
 omit_event_types:
     - HTTP_RESPONSE
-    - RAW_DATA
+    - RAW_TEXT
     - URL_UNVERIFIED
     - DNS_NAME_UNRESOLVED
     - FILESYSTEM

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -122,8 +122,10 @@ url_extension_httpx_only:
 # Don't output these types of events (they are still distributed to modules)
 omit_event_types:
     - HTTP_RESPONSE
+    - RAW_DATA
     - URL_UNVERIFIED
     - DNS_NAME_UNRESOLVED
+    - FILESYSTEM
     # - IP_ADDRESS
 # URL of BBOT server
 agent_url: ''

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -335,7 +335,7 @@ class JavascriptExtractor(BaseExtractor):
 
 
 class excavate(BaseInternalModule):
-    watched_events = ["HTTP_RESPONSE"]
+    watched_events = ["HTTP_RESPONSE", "RAW_DATA"]
     produced_events = ["URL_UNVERIFIED"]
     flags = ["passive"]
     meta = {

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -114,8 +114,13 @@ class URLExtractor(BaseExtractor):
                         )
                     self.excavate.debug(f"Tagging {url_event} as spider-danger because {reason}")
                     url_event.add_tag("spider-danger")
-
-                self.excavate.debug(f"Found URL [{result}] from parsing [{event.data.get('url')}] with regex [{name}]")
+                if "url" in event.data:
+                    message = f"Found URL [{result}] from parsing [{event.data.get('url')}] with regex [{name}]"
+                else:
+                    message = (
+                        f"Found URL [{result}] from parsing [{event.source.data.get('path')}] with regex [{name}]"
+                    )
+                self.excavate.debug(message)
                 await self.excavate.emit_event(url_event)
                 if url_in_scope:
                     urls_found += 1
@@ -197,7 +202,11 @@ class EmailExtractor(BaseExtractor):
         result = result.lower()
         tld = result.split(".")[-1]
         if tld not in self.tld_blacklist:
-            self.excavate.debug(f"Found email address [{result}] from parsing [{event.data.get('url')}]")
+            if "url" in event.data:
+                message = f"Found email address [{result}] from parsing [{event.data.get('url')}]"
+            else:
+                message = f"Found email address [{result}] from parsing [{event.source.data.get('path')}]"
+            self.excavate.debug(message)
             await self.excavate.emit_event(result, "EMAIL_ADDRESS", source=event)
 
 

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -344,7 +344,7 @@ class JavascriptExtractor(BaseExtractor):
 
 
 class excavate(BaseInternalModule):
-    watched_events = ["HTTP_RESPONSE", "RAW_DATA"]
+    watched_events = ["HTTP_RESPONSE", "RAW_TEXT"]
     produced_events = ["URL_UNVERIFIED"]
     flags = ["passive"]
     meta = {

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -66,7 +66,7 @@ class unstructured(BaseModule):
         "ignore_folders": "Subfolders to ignore when crawling downloaded folders",
     }
 
-    # deps_apt = ["libmagic-dev", "poppler-utils", "tesseract-ocr", "libreoffice", "pandoc"]
+    deps_apt = ["libmagic-dev", "poppler-utils", "tesseract-ocr", "libreoffice", "pandoc"]
     deps_python = ["unstructured[all-docs]"]
 
     async def setup(self):

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -74,7 +74,7 @@ class unstructured(BaseModule):
         self.extensions = list(set([e.lower().strip(".") for e in self.config.get("extensions", [])]))
         self.ignored_folders = self.config.get("ignore_folders", [])
         # Do not send user statistics to the unstructured library
-        os.environ['SCARF_NO_ANALYTICS'] = 'true'
+        os.environ["SCARF_NO_ANALYTICS"] = "true"
         return True
 
     async def filter_event(self, event):
@@ -148,7 +148,7 @@ class unstructured(BaseModule):
         else:
             with open(file_path, "rb") as file:
                 return file.read().decode("utf-8", errors="ignore")
-    
+
     async def finish(self):
-        del os.environ['SCARF_NO_ANALYTICS']
+        del os.environ["SCARF_NO_ANALYTICS"]
         return

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from unstructured.partition.auto import partition
 
 from bbot.modules.base import BaseModule
 
@@ -143,7 +142,7 @@ class unstructured(BaseModule):
 
         # If the file can be extracted with unstructured use its partition function or try and read it
         if any(file_path.lower().endswith(file_type) for file_type in unstructured_file_types):
-            elements = partition(filename=file_path)
+            elements = await self.scan.run_in_executor_mp(auto_partition, file_path)
             return "\n\n".join(element.text for element in elements)
         else:
             with open(file_path, "rb") as file:
@@ -152,3 +151,10 @@ class unstructured(BaseModule):
     async def finish(self):
         del os.environ["SCARF_NO_ANALYTICS"]
         return
+
+
+def auto_partition(filename):
+    from unstructured.partition.auto import partition
+
+    elements = partition(filename=filename)
+    return elements

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unstructured.partition.auto import partition
 
@@ -72,6 +73,8 @@ class unstructured(BaseModule):
     async def setup(self):
         self.extensions = list(set([e.lower().strip(".") for e in self.config.get("extensions", [])]))
         self.ignored_folders = self.config.get("ignore_folders", [])
+        # Do not send user statistics to the unstructured library
+        os.environ['SCARF_NO_ANALYTICS'] = 'true'
         return True
 
     async def filter_event(self, event):
@@ -145,3 +148,7 @@ class unstructured(BaseModule):
         else:
             with open(file_path, "rb") as file:
                 return file.read().decode("utf-8", errors="ignore")
+    
+    async def finish(self):
+        del os.environ['SCARF_NO_ANALYTICS']
+        return

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -8,7 +8,7 @@ from bbot.modules.base import BaseModule
 class unstructured(BaseModule):
     watched_events = ["FILESYSTEM"]
     produced_events = ["FILESYSTEM", "RAW_DATA"]
-    flags = ["passive"]
+    flags = ["passive", "safe"]
     meta = {
         "description": "Module to extract data from files",
         "created_date": "2024-06-03",

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -59,14 +59,14 @@ class unstructured(BaseModule):
             "yml",  #  YAML Ain't Markup Language
             "yaml",  #  YAML Ain't Markup Language
         ],
-        "ignore_folders": ["."],
+        "ignore_folders": [".git"],
     }
     options_desc = {
         "extensions": "File extensions to parse",
         "ignore_folders": "Subfolders to ignore when crawling downloaded folders",
     }
 
-    deps_apt = ["libmagic-dev", "poppler-utils", "tesseract-ocr", "libreoffice", "pandoc"]
+    # deps_apt = ["libmagic-dev", "poppler-utils", "tesseract-ocr", "libreoffice", "pandoc"]
     deps_python = ["unstructured[all-docs]"]
 
     async def setup(self):
@@ -87,7 +87,7 @@ class unstructured(BaseModule):
             folder_path = Path(event.data["path"])
             for file_path in folder_path.rglob("*"):
                 # If the file is not in an ignored folder and if it has an allowed extension raise it as a FILESYSTEM event
-                if not any(ignored_folder in file_path for ignored_folder in self.ignored_folders):
+                if not any(ignored_folder in str(file_path) for ignored_folder in self.ignored_folders):
                     if any(file_path.name.endswith(f".{ext}") for ext in self.extensions):
                         file_event = self.make_event(
                             {"path": str(file_path)}, "FILESYSTEM", tags=["parsed_folder", "file"], source=event

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+from unstructured.partition.auto import partition
+
+from bbot.modules.base import BaseModule
+
+
+class unstructured(BaseModule):
+    watched_events = ["FILESYSTEM"]
+    produced_events = ["FILESYSTEM", "RAW_DATA"]
+    flags = ["passive"]
+    meta = {
+        "description": "Module to extract data from files",
+        "created_date": "2024-06-03",
+        "author": "@domwhewell-sage",
+    }
+    options = {
+        "extensions": [
+            "bak",  #  Backup File
+            "bash",  #  Bash Script or Configuration
+            "bashrc",  #  Bash Script or Configuration
+            "conf",  #  Configuration File
+            "cfg",  #  Configuration File
+            "crt",  #  Certificate File
+            "csv",  #  Comma Separated Values File
+            "db",  #  SQLite Database File
+            "sqlite",  #  SQLite Database File
+            "doc",  #  Microsoft Word Document (Old Format)
+            "docx",  #  Microsoft Word Document
+            "exe",  #  Windows PE executable
+            "ica",  #  Citrix Independent Computing Architecture File
+            "indd",  #  Adobe InDesign Document
+            "ini",  #  Initialization File
+            "jar",  #  Java Archive
+            "key",  #  Private Key File
+            "pub",  #  Public Key File
+            "log",  #  Log File
+            "markdown",  #  Markdown File
+            "md",  #  Markdown File
+            "msi",  # Windows setup file
+            "odg",  #  OpenDocument Graphics (LibreOffice, OpenOffice)
+            "odp",  #  OpenDocument Presentation (LibreOffice, OpenOffice)
+            "ods",  #  OpenDocument Spreadsheet (LibreOffice, OpenOffice)
+            "odt",  #  OpenDocument Text (LibreOffice, OpenOffice)
+            "pdf",  #  Adobe Portable Document Format
+            "pem",  #  Privacy Enhanced Mail (SSL certificate)
+            "pps",  #  Microsoft PowerPoint Slideshow (Old Format)
+            "ppsx",  #  Microsoft PowerPoint Slideshow
+            "ppt",  #  Microsoft PowerPoint Presentation (Old Format)
+            "pptx",  #  Microsoft PowerPoint Presentation
+            "ps1",  #  PowerShell Script
+            "raw",  #  Raw Image File Format
+            "rdp",  #  Remote Desktop Protocol File
+            "sh",  #  Shell Script
+            "sql",  #  SQL Database Dump
+            "swp",  #  Swap File (temporary file, often Vim)
+            "sxw",  #  OpenOffice.org Writer document
+            "tar",  #  Tar Archive
+            "tar.gz",  # Gzip-Compressed Tar Archive
+            "zip",  #  Zip Archive
+            "txt",  #  Plain Text Document
+            "vbs",  #  Visual Basic Script
+            "wpd",  #  WordPerfect Document
+            "xls",  #  Microsoft Excel Spreadsheet (Old Format)
+            "xlsx",  #  Microsoft Excel Spreadsheet
+            "xml",  #  eXtensible Markup Language File
+            "yml",  #  YAML Ain't Markup Language
+            "yaml",  #  YAML Ain't Markup Language
+        ],
+    }
+    options_desc = {
+        "extensions": "File extensions to parse",
+    }
+
+    deps_python = ["unstructured[all-docs]"]
+
+    async def setup(self):
+        self.extensions = list(set([e.lower().strip(".") for e in self.config.get("extensions", [])]))
+        return True
+
+    async def filter_event(self, event):
+        if "file" not in event.tags and "folder" not in event.tags:
+            return False, "Event is not a file or folder"
+        if "file" in event.tags:
+            if not any(event.data["path"].endswith(f".{ext}") for ext in self.extensions):
+                return False, "File extension not in the allowed list"
+        return True
+
+    async def handle_event(self, event):
+        if "folder" in event.tags:
+            folder_path = Path(event.data["path"])
+            for file_path in folder_path.rglob("*"):
+                if any(file_path.name.endswith(f".{ext}") for ext in self.extensions):
+                    file_event = self.make_event(
+                        {"path": str(file_path)}, "FILESYSTEM", tags=["parsed_folder", "file"], source=event
+                    )
+                    file_event.scope_distance = event.scope_distance
+                    await self.emit_event(file_event)
+        elif "file" in event.tags:
+            file_path = event.data["path"]
+            content = await self.extract_text(file_path)
+            if content:
+                raw_data_event = self.make_event(
+                    content,
+                    "RAW_DATA",
+                    source=event,
+                )
+                await self.emit_event(raw_data_event)
+
+    async def extract_text(self, file_path):
+        """
+        extract_text Extracts plaintext from a document path using Tika.
+
+        :param file_path: The path of the file to extract text from.
+        :return: ASCII-encoded plaintext extracted from the document.
+        """
+
+        elements = partition(filename=file_path)
+        return "\n\n".join(element.text for element in elements)

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -6,7 +6,7 @@ from bbot.modules.base import BaseModule
 
 class unstructured(BaseModule):
     watched_events = ["FILESYSTEM"]
-    produced_events = ["FILESYSTEM", "RAW_DATA"]
+    produced_events = ["FILESYSTEM", "RAW_TEXT"]
     flags = ["passive", "safe"]
     meta = {
         "description": "Module to extract data from files",
@@ -100,12 +100,12 @@ class unstructured(BaseModule):
             file_path = event.data["path"]
             content = await self.scan.run_in_executor_mp(extract_text, file_path)
             if content:
-                raw_data_event = self.make_event(
+                raw_text_event = self.make_event(
                     content,
-                    "RAW_DATA",
+                    "RAW_TEXT",
                     source=event,
                 )
-                await self.emit_event(raw_data_event)
+                await self.emit_event(raw_text_event)
 
     async def finish(self):
         del os.environ["SCARF_NO_ANALYTICS"]

--- a/bbot/modules/unstructured.py
+++ b/bbot/modules/unstructured.py
@@ -68,7 +68,7 @@ class unstructured(BaseModule):
     }
 
     deps_apt = ["libmagic-dev", "poppler-utils", "tesseract-ocr", "libreoffice", "pandoc"]
-    deps_python = ["unstructured[all-docs]"]
+    deps_pip = ["unstructured[all-docs]"]
 
     async def setup(self):
         self.extensions = list(set([e.lower().strip(".") for e in self.config.get("extensions", [])]))

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -329,3 +329,96 @@ class TestExcavateSerializationPositive(TestExcavate):
             assert any(
                 e.type == "FINDING" and serialize_type in e.data["description"] for e in events
             ), f"Did not find {serialize_type} Serialized Object"
+
+
+class TestExcavateRawData(TestExcavate):
+    targets = ["http://127.0.0.1:8888/"]
+    modules_overrides = ["unstructured", "filedownload", "httpx", "excavate"]
+    config_overrides = {"web_spider_distance": 2, "web_spider_depth": 2}
+
+    pdf_data = """%PDF-1.3
+%���� ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20240605141216+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20240605141216+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 132
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<RAf8.4MLLf/GNAf/!Cn6RrNecqhb7/kO8[:,UJC.*9`]<!^TD#gi^AU;-p49&LT2~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<4ec66ff265d6f71192a8280f8a3a00ac><4ec66ff265d6f71192a8280f8a3a00ac>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1059
+%%EOF"""
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            dict(uri="/"),
+            dict(response_data='<a href="/Test_PDF"/>'),
+        )
+        module_test.set_expect_requests(
+            dict(uri="/Test_PDF"),
+            dict(response_data=self.pdf_data, headers={"Content-Type": "application/pdf"}),
+        )
+
+    def check(self, module_test, events):
+        assert any(
+            e.type == "URL_UNVERIFIED"
+            and e.data == "http://127.0.0.1:8888/distance2.html"
+            and "spider-danger" in e.tags
+            for e in events
+        )

--- a/bbot/test/test_step_2/module_tests/test_module_unstructured.py
+++ b/bbot/test/test_step_2/module_tests/test_module_unstructured.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from .base import ModuleTestBase
+
+
+class TestUnstructured(ModuleTestBase):
+    targets = ["http://127.0.0.1:8888"]
+    modules_overrides = ["unstructured", "filedownload", "httpx", "excavate", "speculate"]
+    config_overrides = {"web_spider_distance": 2, "web_spider_depth": 2}
+
+    pdf_data = """%PDF-1.3
+%���� ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/Contents 7 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 6 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+4 0 obj
+<<
+/PageMode /UseNone /Pages 6 0 R /Type /Catalog
+>>
+endobj
+5 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20240603185816+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20240603185816+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+6 0 obj
+<<
+/Count 1 /Kids [ 3 0 R ] /Type /Pages
+>>
+endobj
+7 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 107
+>>
+stream
+GapQh0E=F,0U\H3T\pNYT^QKk?tc>IP,;W#U1^23ihPEM_?CW4KISi90MjG^2,FS#<RC5+c,n)Z;$bK$b"5I[<!^TD#gi]&=5X,[5@Y@V~>endstream
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000073 00000 n 
+0000000104 00000 n 
+0000000211 00000 n 
+0000000414 00000 n 
+0000000482 00000 n 
+0000000778 00000 n 
+0000000837 00000 n 
+trailer
+<<
+/ID 
+[<80d9f5b964fc99284501deb7a6a637f7><80d9f5b964fc99284501deb7a6a637f7>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 5 0 R
+/Root 4 0 R
+/Size 8
+>>
+startxref
+1034
+%%EOF"""
+
+    unstructured_response = "Hello, World!"
+
+    async def setup_after_prep(self, module_test):
+        module_test.set_expect_requests(
+            dict(uri="/"),
+            dict(response_data='<a href="/Test_PDF"/>'),
+        )
+        module_test.set_expect_requests(
+            dict(uri="/Test_PDF"),
+            dict(response_data=self.pdf_data, headers={"Content-Type": "application/pdf"}),
+        )
+
+    def check(self, module_test, events):
+        filesystem_events = [e for e in events if e.type == "FILESYSTEM"]
+        assert 1 == len(filesystem_events), filesystem_events
+        filesystem_event = filesystem_events[0]
+        file = Path(filesystem_event.data["path"])
+        assert file.is_file(), "Destination file doesn't exist"
+        assert open(file).read() == self.pdf_data, f"File at {file} does not contain the correct content"
+        raw_data_events = [e for e in events if e.type == "RAW_DATA"]
+        assert 1 == len(raw_data_events), "Failed to emmit RAW_DATA event"
+        assert (
+            raw_data_events[0].data == self.unstructured_response
+        ), f"Text extracted from PDF is incorrect, got {raw_data_events[0].data}"

--- a/bbot/test/test_step_2/module_tests/test_module_unstructured.py
+++ b/bbot/test/test_step_2/module_tests/test_module_unstructured.py
@@ -95,8 +95,8 @@ startxref
         file = Path(filesystem_event.data["path"])
         assert file.is_file(), "Destination file doesn't exist"
         assert open(file).read() == self.pdf_data, f"File at {file} does not contain the correct content"
-        raw_data_events = [e for e in events if e.type == "RAW_DATA"]
-        assert 1 == len(raw_data_events), "Failed to emmit RAW_DATA event"
+        raw_text_events = [e for e in events if e.type == "RAW_TEXT"]
+        assert 1 == len(raw_text_events), "Failed to emmit RAW_TEXT event"
         assert (
-            raw_data_events[0].data == self.unstructured_response
-        ), f"Text extracted from PDF is incorrect, got {raw_data_events[0].data}"
+            raw_text_events[0].data == self.unstructured_response
+        ), f"Text extracted from PDF is incorrect, got {raw_text_events[0].data}"

--- a/docs/scanning/configuration.md
+++ b/docs/scanning/configuration.md
@@ -179,8 +179,10 @@ url_extension_httpx_only:
 # Don't output these types of events (they are still distributed to modules)
 omit_event_types:
     - HTTP_RESPONSE
+    - RAW_TEXT
     - URL_UNVERIFIED
     - DNS_NAME_UNRESOLVED
+    - FILESYSTEM
     # - IP_ADDRESS
 # URL of BBOT server
 agent_url: ''


### PR DESCRIPTION
Add unstructured as a module to extract text contents from many different file types and raise them as `RAW_DATA` events.

I have added `FILESYSTEM` and `RAW_DATA` to `omit_event_types` as alot of data can be raised this way and can flood your output files and are not particularly interesting events in by themselves.

The unstructured module will consume `FILESYSTEM` events tagged with either `file` or `folder`. Ones tagged as `file` will go straight to the extraction function and the `RAW_DATA` will be raised. Events tagged as `folder` will be crawled and interesting files (`extensions`) will be re-raised as files to be extracted. There is a list of `ignore_folders` as crawling this folder can raise a lot of links that linkback to the git_repo. (More can probably be added)

I have also added `RAW_DATA` to excavate so it will extract useful tidbits from files