### PR TITLE
Fix: wpscan

### DIFF
--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -48,7 +48,8 @@ class wpscan(BaseModule):
         },
         {
             "name": "Install wpscan gem",
-            "gem": {"name": "wpscan", "state": "latest"},
+            "gem": {"name": "wpscan", "state": "latest", "user_install": False},
+            "become": True,
         },
     ]
 


### PR DESCRIPTION
Address's #1441 

This PR adds `user_install=False` to the ansible command as even with `become` it still installs to `~/.local/share/` instead of a directory in the systemwide path