### PR TITLE
Fix wpscan again!

### DIFF
--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -33,16 +33,22 @@ class wpscan(BaseModule):
     deps_apt = ["curl", "make", "gcc"]
     deps_ansible = [
         {
-            "name": "Install Ruby Deps (Non-Debian)",
-            "package": {"name": ["rubygems", "ruby-devel"], "state": "present"},
-            "become": True,
-            "when": "ansible_facts['os_family'] != 'Debian'",
-        },
-        {
-            "name": "Install Ruby Deps (Debian)",
+            "name": "Install Ruby Deps (Debian/Ubuntu)",
             "package": {"name": ["ruby-rubygems", "ruby-dev"], "state": "present"},
             "become": True,
             "when": "ansible_facts['os_family'] == 'Debian'",
+        },
+        {
+            "name": "Install Ruby Deps (Arch)",
+            "package": {"name": ["rubygems"], "state": "present"},
+            "become": True,
+            "when": "ansible_facts['os_family'] == 'Archlinux'",
+        },
+        {
+            "name": "Install Ruby Deps (Fedora)",
+            "package": {"name": ["rubygems", "ruby-devel"], "state": "present"},
+            "become": True,
+            "when": "ansible_facts['os_family'] == 'Fedora'",
         },
         {
             "name": "Install wpscan gem",

--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -30,32 +30,17 @@ class wpscan(BaseModule):
         "disable_tls_checks": "Disables the SSL/TLS certificate verification (Default True)",
         "force": "Do not check if the target is running WordPress or returns a 403",
     }
-    deps_apt = ["curl", "build-essential"]
+    deps_apt = ["curl", "make", "gcc"]
     deps_ansible = [
         {
-            "name": "Install Rubygems (Non-Debian)",
-            "package": {"name": "rubygems", "state": "present"},
+            "name": "Install Ruby Deps (Non-Debian)",
+            "package": {"name": ["rubygems", "ruby-devel"], "state": "present"},
             "become": True,
             "when": "ansible_facts['os_family'] != 'Debian'",
         },
         {
-            "name": "Install Ruby Development Environment (Non-Debian)",
-            "package": {"name": "ruby-devel", "state": "present"},
-            "become": True,
-            "when": "ansible_facts['os_family'] != 'Debian'",
-        },
-        {
-            "name": "Install Rubygems (Debian)",
-            "package": {
-                "name": "ruby-rubygems",
-                "state": "present",
-            },
-            "become": True,
-            "when": "ansible_facts['os_family'] == 'Debian'",
-        },
-        {
-            "name": "Install Ruby Development Environment (Debian)",
-            "package": {"name": "ruby-dev", "state": "present"},
+            "name": "Install Ruby Deps (Debian)",
+            "package": {"name": ["ruby-rubygems", "ruby-dev"], "state": "present"},
             "become": True,
             "when": "ansible_facts['os_family'] == 'Debian'",
         },

--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -30,6 +30,7 @@ class wpscan(BaseModule):
         "disable_tls_checks": "Disables the SSL/TLS certificate verification (Default True)",
         "force": "Do not check if the target is running WordPress or returns a 403",
     }
+    deps_apt = ["curl", "build-essential"]
     deps_ansible = [
         {
             "name": "Install Rubygems (Non-Debian)",

--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -38,11 +38,23 @@ class wpscan(BaseModule):
             "when": "ansible_facts['os_family'] != 'Debian'",
         },
         {
+            "name": "Install Ruby Development Environment (Non-Debian)",
+            "package": {"name": "ruby-devel", "state": "present"},
+            "become": True,
+            "when": "ansible_facts['os_family'] != 'Debian'",
+        },
+        {
             "name": "Install Rubygems (Debian)",
             "package": {
                 "name": "ruby-rubygems",
                 "state": "present",
             },
+            "become": True,
+            "when": "ansible_facts['os_family'] == 'Debian'",
+        },
+        {
+            "name": "Install Ruby Development Environment (Debian)",
+            "package": {"name": "ruby-dev", "state": "present"},
             "become": True,
             "when": "ansible_facts['os_family'] == 'Debian'",
         },


### PR DESCRIPTION
I have added the ruby development environment to the wpscan module and `gcc`,`make` as they are required to build the gem
`curl` is also required in order to run the gem
Should fix #1441