### PR TITLE
Lock the trufflehog version

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -75,9 +75,10 @@ class trufflehog(BaseModule):
         command = [
             "trufflehog",
             "--json",
+            "--no-update",
         ]
         if self.verified:
-            command.append("--only_verified")
+            command.append("--only-verified")
         command.append("--concurrency=" + str(self.concurrency))
         if module == "git":
             command.append("git")


### PR DESCRIPTION
This PR adds a `--no-update` option to trufflehog so it does not update to the latest version when it is called. This way we can ensure we are on a stable version that has been tested within bbot before pushing it out

Also made a slight change to the only_verified option as it must have been a typo

Closes #1458 