### PR TITLE
turning off references baddns module by default

### DIFF
--- a/bbot/modules/baddns.py
+++ b/bbot/modules/baddns.py
@@ -15,18 +15,24 @@ class baddns(BaseModule):
         "created_date": "2024-01-18",
         "author": "@liquidsec",
     }
-    options = {"custom_nameservers": [], "only_high_confidence": False}
+    options = {"custom_nameservers": [], "only_high_confidence": False, "enable_references": False}
     options_desc = {
         "custom_nameservers": "Force BadDNS to use a list of custom nameservers",
         "only_high_confidence": "Do not emit low-confidence or generic detections",
+        "enable_references": "Enable the references module (off by default)",
     }
     max_event_handlers = 8
     deps_pip = ["baddns~=1.1.789"]
 
     def select_modules(self):
+
+        module_list = ["CNAME", "NS", "MX", "TXT"]
+        if self.config.get("enable_references", False):
+            module_list.append("references")
+
         selected_modules = []
         for m in get_all_modules():
-            if m.name in ["CNAME", "NS", "MX", "references", "TXT"]:
+            if m.name in module_list:
                 selected_modules.append(m)
         return selected_modules
 

--- a/bbot/presets/kitchen-sink.yml
+++ b/bbot/presets/kitchen-sink.yml
@@ -10,3 +10,10 @@ include:
   - paramminer
   - dirbust-light
   - web-screenshots
+
+config:
+  modules:
+    baddns:
+      enable_references: True
+
+


### PR DESCRIPTION
The references module is particularly resources expensive, so it will now be disabled by default, but can be re-enabled with the enable_references module option.