### PR TITLE
Event dedupe rework

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1213,7 +1213,7 @@ class HTTP_RESPONSE(URL_UNVERIFIED, DictEvent):
             self.num_redirects += 1
 
     def _data_id(self):
-        return self.data["url"]
+        return self.data["method"] + "|" + self.data["url"]
 
     def sanitize_data(self, data):
         url = data.get("url", "")

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1045,15 +1045,15 @@ class URL_UNVERIFIED(BaseEvent):
     def _data_id(self):
 
         data = super()._data_id()
+
         # remove the querystring for URL/URL_UNVERIFIED events, because we will conditionally add it back in (based on settings)
-        if self.__class__.__name__.startswith("URL"):
-            data == data.split("?")[0]
+        if self.__class__.__name__.startswith("URL") and self.scan is not None:
+            prefix = data.split("?")[0]
 
-        # consider spider-danger tag when deduping
-        if "spider-danger" in self.tags:
-            data = "spider-danger" + data
+            # consider spider-danger tag when deduping
+            if "spider-danger" in self.tags:
+                prefix += "spider-danger"
 
-        if self.scan is not None:
             if not self.scan.config.get("url_querystring_remove", True) and self.parsed_url.query:
                 query_dict = parse_qs(self.parsed_url.query)
                 if self.scan.config.get("url_querystring_collapse", True):
@@ -1064,7 +1064,7 @@ class URL_UNVERIFIED(BaseEvent):
                     cleaned_query = "&".join(
                         f"{key}={','.join(sorted(values))}" for key, values in sorted(query_dict.items())
                     )
-                data += f":{self.parsed_url.scheme}:{self.parsed_url.netloc}:{self.parsed_url.path}:{cleaned_query}"
+                data = f"{prefix}:{self.parsed_url.scheme}:{self.parsed_url.netloc}:{self.parsed_url.path}:{cleaned_query}"
         return data
 
     def sanitize_data(self, data):

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1044,7 +1044,8 @@ class URL_UNVERIFIED(BaseEvent):
 
     def _data_id(self):
         # consider spider-danger tag when deduping
-        data = super()._data_id()
+        data = super()._data_id().split("?")[0]
+
         if "spider-danger" in self.tags:
             data = "spider-danger" + data
 

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1043,9 +1043,13 @@ class URL_UNVERIFIED(BaseEvent):
         self.num_redirects = getattr(self.parent, "num_redirects", 0)
 
     def _data_id(self):
-        # consider spider-danger tag when deduping
-        data = super()._data_id().split("?")[0]
 
+        data = super()._data_id()
+        # remove the querystring for URL/URL_UNVERIFIED events, because we will conditionally add it back in (based on settings)
+        if self.__class__.__name__.startswith("URL"):
+            data == data.split("?")[0]
+
+        # consider spider-danger tag when deduping
         if "spider-danger" in self.tags:
             data = "spider-danger" + data
 

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -242,20 +242,41 @@ class TestExcavateQuerystringRemoveTrue(TestExcavate):
         module_test.httpserver.expect_request("/").respond_with_data(self.lots_of_params)
 
     def check(self, module_test, events):
-        assert len([e for e in events if e.type == "URL_UNVERIFIED" and e.data == "http://127.0.0.1:8888/endpoint"]) == 1
+        assert (
+            len([e for e in events if e.type == "URL_UNVERIFIED" and e.data == "http://127.0.0.1:8888/endpoint"]) == 1
+        )
+
 
 class TestExcavateQuerystringRemoveFalse(TestExcavateQuerystringRemoveTrue):
     config_overrides = {"url_querystring_remove": False, "url_querystring_collapse": True}
 
     def check(self, module_test, events):
-        assert len([e for e in events if e.type == "URL_UNVERIFIED" and e.data.startswith("http://127.0.0.1:8888/endpoint?")]) == 1
+        assert (
+            len(
+                [
+                    e
+                    for e in events
+                    if e.type == "URL_UNVERIFIED" and e.data.startswith("http://127.0.0.1:8888/endpoint?")
+                ]
+            )
+            == 1
+        )
+
 
 class TestExcavateQuerystringCollapseFalse(TestExcavateQuerystringRemoveTrue):
     config_overrides = {"url_querystring_remove": False, "url_querystring_collapse": False}
 
     def check(self, module_test, events):
-        assert len([e for e in events if e.type == "URL_UNVERIFIED" and e.data.startswith("http://127.0.0.1:8888/endpoint?")]) == 10
-
+        assert (
+            len(
+                [
+                    e
+                    for e in events
+                    if e.type == "URL_UNVERIFIED" and e.data.startswith("http://127.0.0.1:8888/endpoint?")
+                ]
+            )
+            == 10
+        )
 
 
 class TestExcavateMaxLinksPerPage(TestExcavate):

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -224,7 +224,7 @@ class TestExcavateRedirect(TestExcavate):
 
 class TestExcavateQuerystringRemoveTrue(TestExcavate):
     targets = ["http://127.0.0.1:8888/"]
-    config_overrides = {"url_querystring_remove": True}
+    config_overrides = {"url_querystring_remove": True, "url_querystring_collapse": True}
     lots_of_params = """
     <a href="http://127.0.0.1:8888/endpoint?foo=1"/>
     <a href="http://127.0.0.1:8888/endpoint?foo=2"/>

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -699,8 +699,7 @@ class TestExcavateSpiderDedupe(ModuleTestBase):
 
         assert sorted(self.dummy_module.events_seen) == [
             "http://127.0.0.1:8888/",
-            "http://127.0.0.1:8888/spider",
-            "http://127.0.0.1:8888/spider",
+            "http://127.0.0.1:8888/spider"
         ]
 
         for e in events:

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -242,9 +242,7 @@ class TestExcavateQuerystringRemoveTrue(TestExcavate):
         module_test.httpserver.expect_request("/").respond_with_data(self.lots_of_params)
 
     def check(self, module_test, events):
-        assert (
-            len([e for e in events if e.type == "URL_UNVERIFIED"]) == 2
-        )
+        assert len([e for e in events if e.type == "URL_UNVERIFIED"]) == 2
         assert (
             len([e for e in events if e.type == "URL_UNVERIFIED" and e.data == "http://127.0.0.1:8888/endpoint"]) == 1
         )

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -697,10 +697,7 @@ class TestExcavateSpiderDedupe(ModuleTestBase):
         found_url_unverified_dummy = False
         found_url_event = False
 
-        assert sorted(self.dummy_module.events_seen) == [
-            "http://127.0.0.1:8888/",
-            "http://127.0.0.1:8888/spider"
-        ]
+        assert sorted(self.dummy_module.events_seen) == ["http://127.0.0.1:8888/", "http://127.0.0.1:8888/spider"]
 
         for e in events:
             if e.type == "URL_UNVERIFIED":

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -640,9 +640,14 @@ class TestExcavateSpiderDedupe(ModuleTestBase):
         found_url_unverified_dummy = False
         found_url_event = False
 
-        assert self.dummy_module.events_seen == ["http://127.0.0.1:8888/", "http://127.0.0.1:8888/spider"]
+        assert sorted(self.dummy_module.events_seen) == [
+            "http://127.0.0.1:8888/",
+            "http://127.0.0.1:8888/spider",
+            "http://127.0.0.1:8888/spider",
+        ]
 
         for e in events:
+
             if e.type == "URL_UNVERIFIED":
 
                 if e.data == "http://127.0.0.1:8888/spider":

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -243,6 +243,9 @@ class TestExcavateQuerystringRemoveTrue(TestExcavate):
 
     def check(self, module_test, events):
         assert (
+            len([e for e in events if e.type == "URL_UNVERIFIED"]) == 2
+        )
+        assert (
             len([e for e in events if e.type == "URL_UNVERIFIED" and e.data == "http://127.0.0.1:8888/endpoint"]) == 1
         )
 

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -647,9 +647,7 @@ class TestExcavateSpiderDedupe(ModuleTestBase):
         ]
 
         for e in events:
-
             if e.type == "URL_UNVERIFIED":
-
                 if e.data == "http://127.0.0.1:8888/spider":
                     if str(e.module) == "excavate" and "spider-danger" in e.tags and "spider-max" in e.tags:
                         found_url_unverified_spider_max = True


### PR DESCRIPTION
Several changes were necessary to the URL_UNVERIFIED (and events which inherit from it) deduping logic, to account for the url_querystring_remove and url_querystring_collapse options being introduced in the yara-excavate branch. Logic was also tweaked for a few other events.