### PR TITLE
Module killing/status tweaks

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -640,6 +640,12 @@ class BaseModule:
                 # this trace was used for debugging leaked CancelledErrors from inside httpx
                 # self.log.trace("Worker cancelled")
                 raise
+            except BaseException as e:
+                if self.helpers.in_exception_chain(e, (KeyboardInterrupt,)):
+                    self.scan.stop()
+                else:
+                    self.error(f"Critical failure in module {self.name}: {e}")
+                    self.error(traceback.format_exc())
         self.log.trace(f"Worker stopped")
 
     @property
@@ -1487,9 +1493,11 @@ class InterceptModule(BaseModule):
                 # self.log.trace("Worker cancelled")
                 raise
             except BaseException as e:
-                self.critical(f"Critical failure in intercept module {self.name}: {e}")
-                self.critical(traceback.format_exc())
-                self.scan.stop()
+                if self.helpers.in_exception_chain(e, (KeyboardInterrupt,)):
+                    self.scan.stop()
+                else:
+                    self.critical(f"Critical failure in intercept module {self.name}: {e}")
+                    self.critical(traceback.format_exc())
         self.log.trace(f"Worker stopped")
 
     async def get_incoming_event(self):

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -53,7 +53,7 @@ class iis_shortnames(BaseModule):
         for method, result in results.items():
             control = results[method].get(control_url, None)
             test = results[method].get(test_url, None)
-            if (result != None) and (test != None):
+            if (result != None) and (test != None) and (control != None):
                 if control.status_code != test.status_code:
                     technique = f"{str(control.status_code)}/{str(test.status_code)} HTTP Code"
                     detections.append((method, test.status_code, technique))

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -133,7 +133,8 @@ class ScanIngress(InterceptModule):
 
     @property
     def incoming_queues(self):
-        return [self.incoming_event_queue] + [m.outgoing_event_queue for m in self.non_intercept_modules]
+        queues = [self.incoming_event_queue] + [m.outgoing_event_queue for m in self.non_intercept_modules]
+        return [q for q in queues if q is not False]
 
     @property
     def module_priority_weights(self):

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -619,9 +619,13 @@ class Scanner:
 
             num_queued_events = self.num_queued_events
             if num_queued_events:
-                self.info(f"{self.name}: {num_queued_events:,} events in queue")
+                self.info(
+                    f"{self.name}: {num_queued_events:,} events in queue ({self.stats.speedometer.speed:,} processed in the past minute)"
+                )
             else:
-                self.info(f"{self.name}: No events in queue")
+                self.info(
+                    f"{self.name}: No events in queue ({self.stats.speedometer.speed:,} processed in the past minute)"
+                )
 
             if self.log_level <= logging.DEBUG:
                 # status debugging

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -537,6 +537,9 @@ class Scanner:
         from signal import SIGINT
 
         module = self.modules[module_name]
+        if module._intercept:
+            self.warning(f'Cannot kill module "{module_name}" because it is critical to the scan')
+            return
         module.set_error_state(message=message, clear_outgoing_queue=True)
         for proc in module._proc_tracker:
             with contextlib.suppress(Exception):
@@ -560,8 +563,8 @@ class Scanner:
 
         sorted_modules = []
         for module_name, module in self.modules.items():
-            # if module_name.startswith("_"):
-            #     continue
+            if module_name.startswith("_"):
+                continue
             sorted_modules.append(module)
             mod_status = module.status
             if mod_status["running"]:

--- a/bbot/test/test_step_1/test_scan.py
+++ b/bbot/test/test_step_1/test_scan.py
@@ -106,7 +106,7 @@ async def test_speed_counter():
     counter = SpeedCounter(1)
     # 10 events spread across 2 seconds
     for i in range(10):
-        counter.add_timestamp()
+        counter.tick()
         await asyncio.sleep(0.2)
     # only 5 should show
     assert 4 <= counter.speed <= 5

--- a/bbot/test/test_step_1/test_scan.py
+++ b/bbot/test/test_step_1/test_scan.py
@@ -96,3 +96,17 @@ async def test_url_extension_handling(bbot_scanner):
     result = await scan.ingress_module.handle_event(httpx_event, {})
     assert result == None
     assert "httpx-only" in httpx_event.tags
+
+
+@pytest.mark.asyncio
+async def test_speed_counter():
+    from bbot.scanner.stats import SpeedCounter
+
+    # counter with 1-second window
+    counter = SpeedCounter(1)
+    # 10 events spread across 2 seconds
+    for i in range(10):
+        counter.add_timestamp()
+        await asyncio.sleep(0.2)
+    # only 5 should show
+    assert 4 <= counter.speed <= 5


### PR DESCRIPTION
Prevents killing of critical scan modules by the user, adds speed counter as suggested in https://github.com/blacklanternsecurity/bbot/discussions/1529.

![image](https://github.com/blacklanternsecurity/bbot/assets/20261699/722417db-f40b-4c96-8feb-81de28a59585)
