### PR TITLE
Add RAW_DNS_RECORD Event Type

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1424,6 +1424,10 @@ class FILESYSTEM(DictPathEvent):
     pass
 
 
+class RAW_DNS_RECORD(DictHostEvent):
+    pass
+
+
 def make_event(
     data,
     event_type=None,

--- a/bbot/core/helpers/dns/helpers.py
+++ b/bbot/core/helpers/dns/helpers.py
@@ -1,0 +1,61 @@
+import logging
+
+from bbot.core.helpers.regexes import dns_name_regex
+from bbot.core.helpers.misc import clean_dns_record, smart_decode
+
+log = logging.getLogger("bbot.core.helpers.dns")
+
+
+def extract_targets(record):
+    """
+    Extracts hostnames or IP addresses from a given DNS record.
+
+    This method reads the DNS record's type and based on that, extracts the target
+    hostnames or IP addresses it points to. The type of DNS record
+    (e.g., "A", "MX", "CNAME", etc.) determines which fields are used for extraction.
+
+    Args:
+        record (dns.rdata.Rdata): The DNS record to extract information from.
+
+    Returns:
+        set: A set of tuples, each containing the DNS record type and the extracted value.
+
+    Examples:
+        >>> from dns.rrset import from_text
+        >>> record = from_text('www.example.com', 3600, 'IN', 'A', '192.0.2.1')
+        >>> extract_targets(record[0])
+        {('A', '192.0.2.1')}
+
+        >>> record = from_text('example.com', 3600, 'IN', 'MX', '10 mail.example.com.')
+        >>> extract_targets(record[0])
+        {('MX', 'mail.example.com')}
+
+    """
+    results = set()
+
+    def add_result(rdtype, _record):
+        cleaned = clean_dns_record(_record)
+        if cleaned:
+            results.add((rdtype, cleaned))
+
+    rdtype = str(record.rdtype.name).upper()
+    if rdtype in ("A", "AAAA", "NS", "CNAME", "PTR"):
+        add_result(rdtype, record)
+    elif rdtype == "SOA":
+        add_result(rdtype, record.mname)
+    elif rdtype == "MX":
+        add_result(rdtype, record.exchange)
+    elif rdtype == "SRV":
+        add_result(rdtype, record.target)
+    elif rdtype == "TXT":
+        for s in record.strings:
+            s = smart_decode(s)
+            for match in dns_name_regex.finditer(s):
+                start, end = match.span()
+                host = s[start:end]
+                add_result(rdtype, host)
+    elif rdtype == "NSEC":
+        add_result(rdtype, record.next)
+    else:
+        log.warning(f'Unknown DNS record type "{rdtype}"')
+    return results

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -174,6 +174,7 @@ omit_event_types:
   - DNS_NAME_UNRESOLVED
   - FILESYSTEM
   - WEB_PARAMETER
+  - RAW_DNS_RECORD
   # - IP_ADDRESS
 
 # Custom interactsh server settings


### PR DESCRIPTION
This PR adds a `RAW_DNS_RECORD` type to BBOT, as requested by @colin-stubbs and @amiremami. This will allow us to do better analysis of SPF, DMARC, etc.

![image](https://github.com/blacklanternsecurity/bbot/assets/20261699/35672fd6-adb9-4a76-a6e5-bbe4ea13cfb1)