### PR TITLE
Iis shortnames abort fix

### DIFF
--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -52,7 +52,7 @@ class iis_shortnames(BaseModule):
                 results[method] = {url: response}
         for method, result in results.items():
             confirmations = 0
-            iterations = 4 # one failed detection is tolerated, as long as its not the first run
+            iterations = 4  # one failed detection is tolerated, as long as its not the first run
             while iterations > 0:
                 control = results[method].get(control_url, None)
                 test = results[method].get(test_url, None)


### PR DESCRIPTION
Lowered abort threshold, and made initial detection require 3 confirmations (the extra 2 confirmations only happen after initial detection), made warnings verbose instead of warnings