### PR TITLE
Improve usability of run_tests.sh

### DIFF
--- a/bbot/test/run_tests.sh
+++ b/bbot/test/run_tests.sh
@@ -13,5 +13,13 @@ echo "======================="
 flake8 --select F,E722 --ignore F403,F405,F541 --per-file-ignores="*/__init__.py:F401,F403" "$bbot_dir" || exit 1
 echo
 
-echo "[+] Testing with pytest"
-pytest --exitfirst --disable-warnings --log-cli-level=ERROR "$bbot_dir" --cov=bbot/test/test_step_2/test_cli.py --cov-report="term-missing" --cov-config="$bbot_dir/test/coverage.cfg"
+if [ "${1}x" != "x" ] ; then
+  MODULES=`echo ${1} | sed -e 's/,/ /g'`
+  for MODULE in ${MODULES} ; do
+    echo "[+] Testing ${MODULE} with pytest"
+    pytest --exitfirst --disable-warnings --log-cli-level=ERROR "$bbot_dir" --cov=bbot/test/test_step_2/test_cli.py --cov-report="term-missing" --cov-config="$bbot_dir/test/coverage.cfg" -k ${MODULE}
+  done
+else
+  echo "[+] Testing all modules with pytest"
+  pytest --exitfirst --disable-warnings --log-cli-level=ERROR "$bbot_dir" --cov=bbot/test/test_step_2/test_cli.py --cov-report="term-missing" --cov-config="$bbot_dir/test/coverage.cfg"
+fi


### PR DESCRIPTION
Adds ability to pass a single module name, or a subset of modules as a CSV format list, to run tests against.

This resolves issue #1637