### PR TITLE
Add 'path' attribute for FINDING and VULNERABILITY

### DIFF
--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -771,3 +771,31 @@ async def test_event_web_spider_distance(bbot_scanner):
     assert url_event_5.web_spider_distance == 1
     assert "spider-danger" in url_event_5.tags
     assert not "spider-max" in url_event_5.tags
+
+
+def test_event_closest_host():
+    scan = Scanner()
+    event1 = scan.make_event("evilcorp.com", "DNS_NAME", parent=scan.root_event)
+    assert event1.host == "evilcorp.com"
+    assert event1.closest_host == "evilcorp.com"
+    event2 = scan.make_event("wat", "ASDF", parent=event1)
+    assert event2.host == None
+    assert event2.closest_host == "evilcorp.com"
+    finding = scan.make_event({"path": "/tmp/asdf.txt", "description": "test"}, "FINDING", parent=event2)
+    assert finding.data["host"] == "evilcorp.com"
+    assert finding.host == "evilcorp.com"
+    vuln = scan.make_event(
+        {"path": "/tmp/asdf.txt", "description": "test", "severity": "HIGH"}, "VULNERABILITY", parent=event2
+    )
+    assert vuln.data["host"] == "evilcorp.com"
+    assert vuln.host == "evilcorp.com"
+
+    # no host
+    event3 = scan.make_event("wat", "ASDF", parent=scan.root_event)
+    assert event3.host == None
+    with pytest.raises(ValueError):
+        finding = scan.make_event({"path": "/tmp/asdf.txt", "description": "test"}, "FINDING", parent=event3)
+    with pytest.raises(ValueError):
+        vuln = scan.make_event(
+            {"path": "/tmp/asdf.txt", "description": "test", "severity": "HIGH"}, "VULNERABILITY", parent=event3
+        )

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -775,22 +775,26 @@ async def test_event_web_spider_distance(bbot_scanner):
 
 def test_event_closest_host():
     scan = Scanner()
+    # first event has a host
     event1 = scan.make_event("evilcorp.com", "DNS_NAME", parent=scan.root_event)
     assert event1.host == "evilcorp.com"
     assert event1.closest_host == "evilcorp.com"
+    # second event has no host
     event2 = scan.make_event("wat", "ASDF", parent=event1)
     assert event2.host == None
     assert event2.closest_host == "evilcorp.com"
+    # finding automatically uses the host from the first event
     finding = scan.make_event({"path": "/tmp/asdf.txt", "description": "test"}, "FINDING", parent=event2)
     assert finding.data["host"] == "evilcorp.com"
     assert finding.host == "evilcorp.com"
+    # same with vuln
     vuln = scan.make_event(
         {"path": "/tmp/asdf.txt", "description": "test", "severity": "HIGH"}, "VULNERABILITY", parent=event2
     )
     assert vuln.data["host"] == "evilcorp.com"
     assert vuln.host == "evilcorp.com"
 
-    # no host
+    # no host == not allowed
     event3 = scan.make_event("wat", "ASDF", parent=scan.root_event)
     assert event3.host == None
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds a `path` attribute to `FINDING` and `VULNERABILITY`, and also allows these events to skip specifying a host. When no host is specified, it will automatically walk up the chain of parents and use the closest available one. This will be more convenient for modules that are raising FINDINGs from events without hosts, like `FILESYSTEM`.

In response to https://github.com/blacklanternsecurity/bbot/pull/1636.