### PR TITLE
Tagged modules with `code-enum`

### DIFF
--- a/bbot/modules/docker_pull.py
+++ b/bbot/modules/docker_pull.py
@@ -8,7 +8,7 @@ from bbot.modules.base import BaseModule
 class docker_pull(BaseModule):
     watched_events = ["CODE_REPOSITORY"]
     produced_events = ["FILESYSTEM"]
-    flags = ["passive", "safe", "slow"]
+    flags = ["passive", "safe", "slow", "code-enum"]
     meta = {
         "description": "Download images from a docker repository",
         "created_date": "2024-03-24",

--- a/bbot/modules/git_clone.py
+++ b/bbot/modules/git_clone.py
@@ -6,7 +6,7 @@ from bbot.modules.templates.github import github
 class git_clone(github):
     watched_events = ["CODE_REPOSITORY"]
     produced_events = ["FILESYSTEM"]
-    flags = ["passive", "safe", "slow"]
+    flags = ["passive", "safe", "slow", "code-enum"]
     meta = {
         "description": "Clone code github repositories",
         "created_date": "2024-03-08",

--- a/bbot/modules/github_workflows.py
+++ b/bbot/modules/github_workflows.py
@@ -7,7 +7,7 @@ from bbot.modules.templates.github import github
 class github_workflows(github):
     watched_events = ["CODE_REPOSITORY"]
     produced_events = ["FILESYSTEM"]
-    flags = ["passive", "safe"]
+    flags = ["passive", "safe", "code-enum"]
     meta = {
         "description": "Download a github repositories workflow logs",
         "created_date": "2024-04-29",


### PR DESCRIPTION
This PR adds the `code-enum` flag to the `git_clone`, `docker_pull` and `github_workflows` modules. This is so these modules will get enabled in the code-enum preset along with the truffle hog module which consumes their events

Closes #1658 