### PR TITLE
Elastic-friendly Event JSON

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -388,10 +388,20 @@ class BaseEvent:
         """
         This event's full discovery context, including those of all its parents
         """
-        parent_path = []
+        discovery_path = []
         if self.parent is not None and self.parent is not self:
-            parent_path = self.parent.discovery_path
-        return parent_path + [[self.id, self.discovery_context]]
+            discovery_path = self.parent.discovery_path
+        return discovery_path + [self.discovery_context]
+
+    @property
+    def parent_chain(self):
+        """
+        This event's full discovery context, including those of all its parents
+        """
+        parent_chain = []
+        if self.parent is not None and self.parent is not self:
+            parent_chain = self.parent.parent_chain
+        return parent_chain + [self.id]
 
     @property
     def words(self):
@@ -775,6 +785,7 @@ class BaseEvent:
         # discovery context
         j["discovery_context"] = self.discovery_context
         j["discovery_path"] = self.discovery_path
+        j["parent_chain"] = self.parent_chain
 
         # normalize non-primitive python objects
         for k, v in list(j.items()):
@@ -912,6 +923,10 @@ class SCAN(BaseEvent):
 
     @property
     def discovery_path(self):
+        return []
+
+    @property
+    def parent_chain(self):
         return []
 
 

--- a/bbot/modules/output/csv.py
+++ b/bbot/modules/output/csv.py
@@ -55,7 +55,6 @@ class CSV(BaseOutputModule):
     async def handle_event(self, event):
         # ["Event type", "Event data", "IP Address", "Source Module", "Scope Distance", "Event Tags"]
         discovery_path = getattr(event, "discovery_path", [])
-        discovery_path = [e[-1] for e in discovery_path]
         self.writerow(
             {
                 "Event type": getattr(event, "type", ""),

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -38,8 +38,9 @@ class TestJSON(ModuleTestBase):
         assert dns_reconstructed.data == dns_data
         assert dns_reconstructed.discovery_context == context_data
         assert dns_reconstructed.discovery_path == [
-            ["DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc", context_data]
+            context_data
         ]
+        assert dns_reconstructed.parent_chain == ["DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc"]
 
 
 class TestJSONSIEMFriendly(ModuleTestBase):

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -26,7 +26,8 @@ class TestJSON(ModuleTestBase):
         assert scan_json["data"]["target"]["whitelist"] == ["blacklanternsecurity.com"]
         assert dns_json["data"] == dns_data
         assert dns_json["discovery_context"] == context_data
-        assert dns_json["discovery_path"] == [["DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc", context_data]]
+        assert dns_json["discovery_path"] == [context_data]
+        assert dns_json["parent_chain"] == ["DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc"]
 
         # event objects reconstructed from json
         scan_reconstructed = event_from_json(scan_json)

--- a/bbot/test/test_step_2/module_tests/test_module_json.py
+++ b/bbot/test/test_step_2/module_tests/test_module_json.py
@@ -37,9 +37,7 @@ class TestJSON(ModuleTestBase):
         assert scan_reconstructed.data["target"]["whitelist"] == ["blacklanternsecurity.com"]
         assert dns_reconstructed.data == dns_data
         assert dns_reconstructed.discovery_context == context_data
-        assert dns_reconstructed.discovery_path == [
-            context_data
-        ]
+        assert dns_reconstructed.discovery_path == [context_data]
         assert dns_reconstructed.parent_chain == ["DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc"]
 
 

--- a/docs/scanning/events.md
+++ b/docs/scanning/events.md
@@ -54,7 +54,6 @@ These attributes allow us to construct a visual graph of events (e.g. in [Neo4j]
     "DNS_NAME:879e47564ff0ed7711b707d3dbecb706ad6af1a3"
   ]
 }
-
 ```
 
 For a more detailed description of BBOT events, see [Developer Documentation - Event](../../dev/event).

--- a/docs/scanning/events.md
+++ b/docs/scanning/events.md
@@ -21,43 +21,40 @@ These attributes allow us to construct a visual graph of events (e.g. in [Neo4j]
 
 ```json
 {
-  "type": "URL",
-  "id": "URL:c9962277277393f8895d2a4fa9b7f70b15f3af3e",
+  "type": "DNS_NAME",
+  "id": "DNS_NAME:879e47564ff0ed7711b707d3dbecb706ad6af1a3",
   "scope_description": "in-scope",
-  "data": "https://blog.blacklanternsecurity.com/",
-  "host": "blog.blacklanternsecurity.com",
+  "data": "www.blacklanternsecurity.com",
+  "host": "www.blacklanternsecurity.com",
   "resolved_hosts": [
-    "104.18.40.87"
+    "185.199.108.153",
+    "2606:50c0:8003::153",
+    "blacklanternsecurity.github.io"
   ],
-  "dns_children": {
-    "A": [
-      "104.18.40.87",
-      "172.64.147.169"
-    ]
-  },
+  "dns_children": {},
   "web_spider_distance": 0,
   "scope_distance": 0,
-  "scan": "SCAN:9224b49405e6d1607fd615243577d9ca86c7d206",
-  "timestamp": 1717260760.157012,
-  "parent": "OPEN_TCP_PORT:ebe3d6c10b41f60e3590ce6436ab62510b91c758",
+  "scan": "SCAN:477d1e6b94be928bf85c554b0845985189cfc81d",
+  "timestamp": "2024-08-17T03:49:47.906017+00:00",
+  "parent": "DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc",
   "tags": [
-    "in-scope",
-    "http-title-black-lantern-security-blsops",
-    "dir",
-    "ip-104-18-40-87",
-    "cdn-cloudflare",
-    "status-200"
+    "cdn-github",
+    "subdomain",
+    "in-scope"
   ],
-  "module": "httpx",
-  "module_sequence": "httpx",
-  "discovery_context": "httpx visited blog.blacklanternsecurity.com:443 and got status code 200 at https://blog.blacklanternsecurity.com/",
+  "module": "otx",
+  "module_sequence": "otx",
+  "discovery_context": "otx searched otx API for \"blacklanternsecurity.com\" and found DNS_NAME: www.blacklanternsecurity.com",
   "discovery_path": [
-    "Scan difficult_arthur seeded with DNS_NAME: blacklanternsecurity.com",
-    "certspotter searched certspotter API for \"blacklanternsecurity.com\" and found DNS_NAME: blog.blacklanternsecurity.com",
-    "speculated OPEN_TCP_PORT: blog.blacklanternsecurity.com:443",
-    "httpx visited blog.blacklanternsecurity.com:443 and got status code 200 at https://blog.blacklanternsecurity.com/"
+    "Scan demonic_jimmy seeded with DNS_NAME: blacklanternsecurity.com",
+    "otx searched otx API for \"blacklanternsecurity.com\" and found DNS_NAME: www.blacklanternsecurity.com"
+  ],
+  "parent_chain": [
+    "DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc",
+    "DNS_NAME:879e47564ff0ed7711b707d3dbecb706ad6af1a3"
   ]
 }
+
 ```
 
 For a more detailed description of BBOT events, see [Developer Documentation - Event](../../dev/event).


### PR DESCRIPTION
This PR separates the event IDs from the `discovery_chain` and puts them in their own list:

```json
{
  "type": "DNS_NAME",
  "id": "DNS_NAME:879e47564ff0ed7711b707d3dbecb706ad6af1a3",
  "scope_description": "in-scope",
  "data": "www.blacklanternsecurity.com",
  "host": "www.blacklanternsecurity.com",
  "resolved_hosts": [
    "185.199.108.153",
    "2606:50c0:8003::153",
    "blacklanternsecurity.github.io"
  ],
  "dns_children": {},
  "web_spider_distance": 0,
  "scope_distance": 0,
  "scan": "SCAN:477d1e6b94be928bf85c554b0845985189cfc81d",
  "timestamp": "2024-08-17T03:49:47.906017+00:00",
  "parent": "DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc",
  "tags": [
    "cdn-github",
    "subdomain",
    "in-scope"
  ],
  "module": "otx",
  "module_sequence": "otx",
  "discovery_context": "otx searched otx API for \"blacklanternsecurity.com\" and found DNS_NAME: www.blacklanternsecurity.com",
  "discovery_path": [ <-----
    "Scan demonic_jimmy seeded with DNS_NAME: blacklanternsecurity.com",
    "otx searched otx API for \"blacklanternsecurity.com\" and found DNS_NAME: www.blacklanternsecurity.com"
  ],
  "parent_chain": [ <-----
    "DNS_NAME:1e57014aa7b0715bca68e4f597204fc4e1e851fc",
    "DNS_NAME:879e47564ff0ed7711b707d3dbecb706ad6af1a3"
  ]
}
```