### PR TITLE
Added RawV2 to trufflehog output

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -90,17 +90,25 @@ class trufflehog(BaseModule):
             host = event.host
         else:
             host = str(event.parent.host)
-        async for decoder_name, detector_name, raw_result, verified, source_metadata in self.execute_trufflehog(
-            module, path
-        ):
+        async for (
+            decoder_name,
+            detector_name,
+            raw_result,
+            rawv2_result,
+            verified,
+            source_metadata,
+        ) in self.execute_trufflehog(module, path):
             if verified:
                 data = {
                     "severity": "High",
-                    "description": f"Verified Secret Found. Detector Type: [{detector_name}] Decoder Type: [{decoder_name}] Secret: [{raw_result}] Details: [{source_metadata}]",
+                    "description": f"Verified Secret Found. Detector Type: [{detector_name}] Decoder Type: [{decoder_name}] Details: [{source_metadata}]",
                     "host": host,
                 }
                 if description:
                     data["description"] += f" Description: [{description}]"
+                data["description"] += f" Raw result: [{raw_result}]"
+                if rawv2_result:
+                    data["description"] += f" RawV2 result: [{rawv2_result}]"
                 await self.emit_event(
                     data,
                     "VULNERABILITY",
@@ -109,11 +117,14 @@ class trufflehog(BaseModule):
                 )
             else:
                 data = {
-                    "description": f"Potential Secret Found. Detector Type: [{detector_name}] Decoder Type: [{decoder_name}] Secret: [{raw_result}] Details: [{source_metadata}]",
+                    "description": f"Potential Secret Found. Detector Type: [{detector_name}] Decoder Type: [{decoder_name}] Details: [{source_metadata}]",
                     "host": host,
                 }
                 if description:
                     data["description"] += f" Description: [{description}]"
+                data["description"] += f" Raw result: [{raw_result}]"
+                if rawv2_result:
+                    data["description"] += f" RawV2 result: [{rawv2_result}]"
                 await self.emit_event(
                     data,
                     "FINDING",
@@ -162,11 +173,13 @@ class trufflehog(BaseModule):
 
                     raw_result = j.get("Raw", "")
 
+                    rawv2_result = j.get("RawV2", "")
+
                     verified = j.get("Verified", False)
 
                     source_metadata = j.get("SourceMetadata", {})
 
-                    yield (decoder_name, detector_name, raw_result, verified, source_metadata)
+                    yield (decoder_name, detector_name, raw_result, rawv2_result, verified, source_metadata)
         finally:
             stats_file.unlink()
 

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -851,7 +851,7 @@ class TestTrufflehog(ModuleTestBase):
             if e.type == "VULNERABILITY"
             and (e.data["host"] == "hub.docker.com" or e.data["host"] == "github.com")
             and "Verified Secret Found." in e.data["description"]
-            and "Secret: [https://admin:admin@the-internet.herokuapp.com]" in e.data["description"]
+            and "Raw result: [https://admin:admin@the-internet.herokuapp.com]" in e.data["description"]
         ]
         assert 3 == len(vuln_events), "Failed to find secret in events"
         github_repo_event = [e for e in vuln_events if "test_keys" in e.data["description"]][0].parent
@@ -898,7 +898,7 @@ class TestTrufflehog_NonVerified(TestTrufflehog):
             if e.type == e.type == "FINDING"
             and (e.data["host"] == "hub.docker.com" or e.data["host"] == "github.com")
             and "Potential Secret Found." in e.data["description"]
-            and "Secret: [https://admin:admin@internal.host.com]" in e.data["description"]
+            and "Raw result: [https://admin:admin@internal.host.com]" in e.data["description"]
         ]
         assert 3 == len(finding_events), "Failed to find secret in events"
         github_repo_event = [e for e in finding_events if "test_keys" in e.data["description"]][0].parent

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -852,7 +852,7 @@ class TestTrufflehog(ModuleTestBase):
             and (e.data["host"] == "hub.docker.com" or e.data["host"] == "github.com")
             and "Verified Secret Found." in e.data["description"]
             and "Raw result: [https://admin:admin@the-internet.herokuapp.com]" in e.data["description"]
-            and "RawV2 result: [https://admin:admin@the-internet.herokuapp.com/basic_auth]"
+            and "RawV2 result: [https://admin:admin@the-internet.herokuapp.com/basic_auth]" in e.data["description"]
         ]
         assert 3 == len(vuln_events), "Failed to find secret in events"
         github_repo_event = [e for e in vuln_events if "test_keys" in e.data["description"]][0].parent

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -852,6 +852,7 @@ class TestTrufflehog(ModuleTestBase):
             and (e.data["host"] == "hub.docker.com" or e.data["host"] == "github.com")
             and "Verified Secret Found." in e.data["description"]
             and "Raw result: [https://admin:admin@the-internet.herokuapp.com]" in e.data["description"]
+            and "RawV2 result: [https://admin:admin@the-internet.herokuapp.com/basic_auth]"
         ]
         assert 3 == len(vuln_events), "Failed to find secret in events"
         github_repo_event = [e for e in vuln_events if "test_keys" in e.data["description"]][0].parent


### PR DESCRIPTION
This PR adds "RawV2" output if it exists from truffle hog to the module output.
I have changed the "Secret:" wording to "Raw result" and "RawV2 result" to better align with trufflehog.

This is how it looks:
```python
[VULNERABILITY]         {"description": "Verified Secret Found. Detector Type: [AWS] Decoder Type: [PLAIN] Details: [{'Data': {'Git': {'commit': 'fbc14303ffbf8fb1c2c1914e8dda7d0121633aca', 'file': 'keys', 'email': 'counter <counter@counters-MacBook-Air.local>', 'repository': 'https://github.com/trufflesecurity/test_keys', 'timestamp': '2022-06-16 17:17:40 +0000', 'line': 4}}}] Raw result: [AKIAYVP4CIPPERUVIFXG] RawV2 result: [AKIAYVP4CIPPERUVIFXGZt2U1h267eViPnuSA+JO5ABhiu4T7XUMSZ+Y2Oth]", "host": "github.com", "severity": "HIGH"}git_clone->trufflehog   (high, in-scope)
```

Closes #1686 