### PR TITLE
Enhancement: Git Clone repos into their own containing folders

### DIFF
--- a/bbot/modules/git_clone.py
+++ b/bbot/modules/git_clone.py
@@ -46,11 +46,14 @@ class git_clone(github):
             )
 
     async def clone_git_repository(self, repository_url):
+        owner = repository_url.split("/")[-2]
+        folder = self.output_dir / owner
+        self.helpers.mkdir(folder)
         if self.api_key:
             url = repository_url.replace("https://github.com", f"https://user:{self.api_key}@github.com")
         else:
             url = repository_url
-        command = ["git", "-C", self.output_dir, "clone", url]
+        command = ["git", "-C", folder, "clone", url]
         try:
             output = await self.run_process(command, env={"GIT_TERMINAL_PROMPT": "0"}, check=True)
         except CalledProcessError as e:
@@ -58,4 +61,4 @@ class git_clone(github):
             return
 
         folder_name = output.stderr.split("Cloning into '")[1].split("'")[0]
-        return self.output_dir / folder_name
+        return self.output_dir / folder / folder_name

--- a/bbot/modules/git_clone.py
+++ b/bbot/modules/git_clone.py
@@ -61,4 +61,4 @@ class git_clone(github):
             return
 
         folder_name = output.stderr.split("Cloning into '")[1].split("'")[0]
-        return self.output_dir / folder / folder_name
+        return folder / folder_name

--- a/bbot/test/test_step_2/module_tests/test_module_git_clone.py
+++ b/bbot/test/test_step_2/module_tests/test_module_git_clone.py
@@ -196,7 +196,7 @@ class TestGit_Clone(ModuleTestBase):
             e
             for e in events
             if e.type == "FILESYSTEM"
-            and "git_repos/test_keys" in e.data["path"]
+            and "git_repos/.bbot_test/test_keys" in e.data["path"]
             and "git" in e.tags
             and e.scope_distance == 1
         ]

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -868,7 +868,7 @@ class TestTrufflehog(ModuleTestBase):
             [
                 e
                 for e in filesystem_events
-                if e.data["path"].endswith("/git_repos/test_keys") and Path(e.data["path"]).is_dir()
+                if e.data["path"].endswith("/git_repos/.bbot_test/test_keys") and Path(e.data["path"]).is_dir()
             ]
         ), "Test keys repo dir does not exist"
         assert 1 == len(
@@ -915,7 +915,7 @@ class TestTrufflehog_NonVerified(TestTrufflehog):
             [
                 e
                 for e in filesystem_events
-                if e.data["path"].endswith("/git_repos/test_keys") and Path(e.data["path"]).is_dir()
+                if e.data["path"].endswith("/git_repos/.bbot_test/test_keys") and Path(e.data["path"]).is_dir()
             ]
         ), "Test keys repo dir does not exist"
         assert 1 == len(


### PR DESCRIPTION
I have made a small patch to the git_clone module so that it will obtain the owner name from the repository URL and use that to create a containing folder to hold all of their cloned github repos. Similar to the way the github workflows module does it.