### PR TITLE
Fix release notes not displaying correctly in version updater

### DIFF
--- a/.github/workflows/version_updater.yaml
+++ b/.github/workflows/version_updater.yaml
@@ -28,8 +28,9 @@ jobs:
           response = requests.get('https://api.github.com/repos/projectdiscovery/nuclei/releases/latest')
           version = response.json()['tag_name'].lstrip('v')
           release_notes = response.json()['body']
-          os.system(f"echo 'latest_version={version}' >> $GITHUB_ENV")
-          os.system(f"echo 'release_notes={release_notes}' >> $GITHUB_ENV")
+          with open(os.getenv('GITHUB_ENV'), 'a') as env_file:
+            env_file.write(f"latest_version={version}\n")
+            env_file.write(f"release_notes<<EOF\n{release_notes}\nEOF\n")
         shell: python
       - name: Get current version
         id: get-current-version
@@ -78,8 +79,9 @@ jobs:
           response = requests.get('https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest')
           version = response.json()['tag_name'].lstrip('v')
           release_notes = response.json()['body']
-          os.system(f"echo 'latest_version={version}' >> $GITHUB_ENV")
-          os.system(f"echo 'release_notes={release_notes}' >> $GITHUB_ENV")
+          with open(os.getenv('GITHUB_ENV'), 'a') as env_file:
+            env_file.write(f"latest_version={version}\n")
+            env_file.write(f"release_notes<<EOF\n{release_notes}\nEOF\n")
         shell: python
       - name: Get current version
         id: get-current-version

--- a/.github/workflows/version_updater.yaml
+++ b/.github/workflows/version_updater.yaml
@@ -51,7 +51,7 @@ jobs:
           body: |
             This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."
 
-            Release notes:
+            # Release notes:
             ${{ env.release_notes }}
           branch: "update-nuclei"
           committer: GitHub <noreply@github.com>
@@ -102,7 +102,7 @@ jobs:
           body: |
             This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.
 
-            Release notes:
+            # Release notes:
             ${{ env.release_notes }}
           branch: "update-trufflehog"
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
The release notes were not displaying in the opened Pull Request by the workflow.

The release notes often contained new lines which meant they were not being handled correctly by `os.system` this PR uses open to append to the github environment file.

It is using the correct syntax for multiline environment variables: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings