### PR TITLE
bump baddns, lower dnswalk timeout settings

### DIFF
--- a/bbot/modules/baddns.py
+++ b/bbot/modules/baddns.py
@@ -58,7 +58,7 @@ class baddns(BaseModule):
 
             if ModuleClass.name == "NS":
                 kwargs["raw_query_max_retries"] = 1
-                kwargs["raw_query_timeout"] = 4.0
+                kwargs["raw_query_timeout"] = 5.0
                 kwargs["raw_query_retry_wait"] = 0
 
             module_instance = ModuleClass(event.data, **kwargs)

--- a/bbot/modules/baddns_zone.py
+++ b/bbot/modules/baddns_zone.py
@@ -17,7 +17,7 @@ class baddns_zone(baddns_module):
         "only_high_confidence": "Do not emit low-confidence or generic detections",
     }
     module_threads = 8
-    deps_pip = ["baddns~=1.1.798"]
+    deps_pip = ["baddns~=1.1.815"]
 
     def select_modules(self):
         selected_modules = []


### PR DESCRIPTION
Upgrading to baddns 1.1.815, and significantly lowering settings regarding the NS module's DNSWalk(). This should significantly speed baddns up in situations where one or more nameservers aren't responding.