### PR TITLE
Filter out already processed events from trufflehog

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -1,5 +1,5 @@
-import os
 import json
+from pathlib import Path
 from bbot.modules.base import BaseModule
 
 
@@ -74,8 +74,10 @@ class trufflehog(BaseModule):
                 return False, "Deleted forks is not enabled"
         else:
             path = event.data["path"]
-            for processed_path in self.processed:
-                if os.path.commonpath([path, processed_path]) == processed_path:
+            for processed in self.processed:
+                processed_path = Path(processed)
+                new_path = Path(path)
+                if new_path.is_relative_to(processed_path):
                     return False, "Parent folder has already been processed"
         return True
 

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -13,6 +13,7 @@ class TestTrufflehog(ModuleTestBase):
         "github_org",
         "speculate",
         "git_clone",
+        "unstructured",
         "github_workflows",
         "dockerhub",
         "docker_pull",
@@ -854,6 +855,7 @@ class TestTrufflehog(ModuleTestBase):
             and "Raw result: [https://admin:admin@the-internet.herokuapp.com]" in e.data["description"]
             and "RawV2 result: [https://admin:admin@the-internet.herokuapp.com/basic_auth]" in e.data["description"]
         ]
+        # Trufflehog should find 3 verifiable secrets, 1 from the github, 1 from the workflow log and 1 from the docker image. Unstructured will extract the text file but trufflehog should reject it as its already scanned the containing folder
         assert 3 == len(vuln_events), "Failed to find secret in events"
         github_repo_event = [e for e in vuln_events if "test_keys" in e.data["description"]][0].parent
         folder = Path(github_repo_event.data["path"])
@@ -901,6 +903,7 @@ class TestTrufflehog_NonVerified(TestTrufflehog):
             and "Potential Secret Found." in e.data["description"]
             and "Raw result: [https://admin:admin@internal.host.com]" in e.data["description"]
         ]
+        # Trufflehog should find 3 unverifiable secrets, 1 from the github, 1 from the workflow log and 1 from the docker image. Unstructured will extract the text file but trufflehog should reject it as its already scanned the containing folder
         assert 3 == len(finding_events), "Failed to find secret in events"
         github_repo_event = [e for e in finding_events if "test_keys" in e.data["description"]][0].parent
         folder = Path(github_repo_event.data["path"])


### PR DESCRIPTION
Add a filter to trufflehog to check if the `FILESYSTEM` path has already been processed.

This fixes #1719 where when unstructured parses a folder and re-raises events they would get processed by trufflehog and duplicates would be raised