### PR TITLE
Add an option to trufflehog to allow users to specify their own custom config file

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -21,7 +21,7 @@ class trufflehog(BaseModule):
     }
     options_desc = {
         "version": "trufflehog version",
-        "config": "File path to YAML trufflehog config",
+        "config": "File path or URL to YAML trufflehog config",
         "only_verified": "Only report credentials that have been verified",
         "concurrency": "Number of concurrent workers",
         "deleted_forks": "Scan for deleted github forks. WARNING: This is SLOW. For a smaller repository, this process can take 20 minutes. For a larger repository, it could take hours.",

--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,12 +14,14 @@ class trufflehog(BaseModule):
 
     options = {
         "version": "3.81.9",
+        "config": "",
         "only_verified": True,
         "concurrency": 8,
         "deleted_forks": False,
     }
     options_desc = {
         "version": "trufflehog version",
+        "config": "File path to YAML trufflehog config",
         "only_verified": "Only report credentials that have been verified",
         "concurrency": "Number of concurrent workers",
         "deleted_forks": "Scan for deleted github forks. WARNING: This is SLOW. For a smaller repository, this process can take 20 minutes. For a larger repository, it could take hours.",
@@ -40,6 +42,9 @@ class trufflehog(BaseModule):
 
     async def setup(self):
         self.verified = self.config.get("only_verified", True)
+        self.config_file = self.config.get("config", "")
+        if self.config_file:
+            self.config_file = await self.helpers.wordlist(self.config_file)
         self.concurrency = int(self.config.get("concurrency", 8))
 
         self.deleted_forks = self.config.get("deleted_forks", False)
@@ -140,6 +145,8 @@ class trufflehog(BaseModule):
         ]
         if self.verified:
             command.append("--only-verified")
+        if self.config_file:
+            command.append("--config=" + str(self.config_file))
         command.append("--concurrency=" + str(self.concurrency))
         if module == "git":
             command.append("git")


### PR DESCRIPTION
In some cases a user may want to specify a custom detector for truffle hog, this can be done through its config file.
You can also create advanced customization's of the truffle-hog tool via this config file.
This PR adds that as an option to download a config file from a URL or file and have it cached before loading it into trufflehog.

I tested it with this command
`bbot -t https://github.com/trufflesecurity/test_keys -m code_repository, git_clone, trufflehog --config modules.trufflehog.config=https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/examples/generic.yml modules.trufflehog.only_verified=False --verbose`