### PR TITLE
Encrypt cached sudo password

### DIFF
--- a/bbot/core/core.py
+++ b/bbot/core/core.py
@@ -34,8 +34,6 @@ class BBOTCore:
         self._logger = None
         self._files_config = None
 
-        self.bbot_sudo_pass = None
-
         self._config = None
         self._custom_config = None
 

--- a/bbot/core/helpers/command.py
+++ b/bbot/core/helpers/command.py
@@ -295,7 +295,7 @@ def _prepare_command_kwargs(self, command, kwargs):
     if sudo and os.geteuid() != 0:
         self.depsinstaller.ensure_root()
         env["SUDO_ASKPASS"] = str((self.tools_dir / self.depsinstaller.askpass_filename).resolve())
-        env["BBOT_SUDO_PASS"] = self.depsinstaller._sudo_password
+        env["BBOT_SUDO_PASS"] = self.depsinstaller.encrypted_sudo_pw
         kwargs["env"] = env
 
         PATH = os.environ.get("PATH", "")

--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -367,6 +367,8 @@ class DepsInstaller:
 
     @property
     def encrypted_sudo_pw(self):
+        if self._sudo_password is None:
+            return ""
         return self._encrypt_sudo_pw(self._sudo_password)
 
     def _encrypt_sudo_pw(self, pw):

--- a/bbot/core/helpers/depsinstaller/sudo_askpass.py
+++ b/bbot/core/helpers/depsinstaller/sudo_askpass.py
@@ -20,6 +20,8 @@ def decrypt_password(encrypted_data, key):
 
 def main():
     encrypted_password = os.environ.get(ENV_VAR_NAME, "")
+    # remove variable from environment once we've got it
+    os.environ.pop(ENV_VAR_NAME, None)
     encryption_keypath = Path(os.environ.get(KEY_ENV_VAR_PATH, ""))
 
     if not encrypted_password or not encryption_keypath.is_file():

--- a/bbot/core/helpers/depsinstaller/sudo_askpass.py
+++ b/bbot/core/helpers/depsinstaller/sudo_askpass.py
@@ -1,5 +1,39 @@
 #!/usr/bin/env python3
-
 import os
+import sys
+from pathlib import Path
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
 
-print(os.environ.get("BBOT_SUDO_PASS", ""), end="")
+ENV_VAR_NAME = "BBOT_SUDO_PASS"
+KEY_ENV_VAR_PATH = "BBOT_SUDO_KEYFILE"
+
+
+def decrypt_password(encrypted_data, key):
+    iv, ciphertext = encrypted_data.split(":")
+    iv = bytes.fromhex(iv)
+    ct = bytes.fromhex(ciphertext)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    pt = unpad(cipher.decrypt(ct), AES.block_size)
+    return pt.decode("utf-8")
+
+
+def main():
+    encrypted_password = os.environ.get(ENV_VAR_NAME, "")
+    encryption_keypath = Path(os.environ.get(KEY_ENV_VAR_PATH, ""))
+
+    if not encrypted_password or not encryption_keypath.is_file():
+        print("Error: Encrypted password or encryption key not found in environment variables.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        key = encryption_keypath.read_bytes()
+        decrypted_password = decrypt_password(encrypted_password, key)
+        print(decrypted_password, end="")
+    except Exception as e:
+        print(f'Error decrypting password "{encrypted_password}": {str(e)}', file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When not running as root, and when a password is required to `sudo`, bbot will cache the password so you don't have to repeatedly enter it during the scan. Whenever a process is executed that needs sudo privileges, the sudo password is inserted into its isolated environment, which is then passed to sudo using a custom `askpass` script.

This worked well but wasn't super secure, since it introduced the opportunity for a subprocess to snag your sudo password (accidentally or as part of telemetry collection, etc.).

For extra security, this PR encrypts the password using a randomly-generated 32-byte key which is discarded at the end of the scan.