### PR TITLE
Add to social and code_repository modules to detect postman profiles and workspace links in pages

### DIFF
--- a/bbot/modules/code_repository.py
+++ b/bbot/modules/code_repository.py
@@ -19,6 +19,7 @@ class code_repository(BaseModule):
             (r"gitlab.(?:com|org)/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+", False),
         ],
         "docker": (r"hub.docker.com/r/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+", False),
+        "postman": (r"www.postman.com/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+", False),
     }
 
     scope_distance_modifier = 1

--- a/bbot/modules/social.py
+++ b/bbot/modules/social.py
@@ -25,6 +25,7 @@ class social(BaseModule):
         "discord": (r"discord.gg/([a-zA-Z0-9_-]+)", True),
         "docker": (r"hub.docker.com/[ru]/([a-zA-Z0-9_-]+)", False),
         "huggingface": (r"huggingface.co/([a-zA-Z0-9_-]+)", False),
+        "postman": (r"www.postman.com/([a-zA-Z0-9_-]+)", False),
     }
 
     scope_distance_modifier = 1

--- a/bbot/test/test_step_2/module_tests/test_module_code_repository.py
+++ b/bbot/test/test_step_2/module_tests/test_module_code_repository.py
@@ -14,13 +14,14 @@ class TestCodeRepository(ModuleTestBase):
                 <a href="https://gitlab.com/blacklanternsecurity/bbot"/>
                 <a href="https://gitlab.org/blacklanternsecurity/bbot"/>
                 <a href="https://hub.docker.com/r/blacklanternsecurity/bbot"/>
+                <a href="https://www.postman.com/blacklanternsecurity/bbot"/>
             </html>
             """
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert 4 == len([e for e in events if e.type == "CODE_REPOSITORY"])
+        assert 5 == len([e for e in events if e.type == "CODE_REPOSITORY"])
         assert 1 == len(
             [
                 e
@@ -55,5 +56,14 @@ class TestCodeRepository(ModuleTestBase):
                 if e.type == "CODE_REPOSITORY"
                 and "docker" in e.tags
                 and e.data["url"] == "https://hub.docker.com/r/blacklanternsecurity/bbot"
+            ]
+        )
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "CODE_REPOSITORY"
+                and "postman" in e.tags
+                and e.data["url"] == "https://www.postman.com/blacklanternsecurity/bbot"
             ]
         )

--- a/bbot/test/test_step_2/module_tests/test_module_social.py
+++ b/bbot/test/test_step_2/module_tests/test_module_social.py
@@ -14,13 +14,14 @@ class TestSocial(ModuleTestBase):
                 <a href="https://hub.docker.com/r/blacklanternsecurity"/>
                 <a href="https://hub.docker.com/r/blacklanternsecurity/bbot"/>
                 <a href="https://hub.docker.com/r/blacklanternSECURITY/bbot"/>
+                <a href="https://www.postman.com/blacklanternsecurity/bbot"/>
             </html>
             """
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert 3 == len([e for e in events if e.type == "SOCIAL"])
+        assert 4 == len([e for e in events if e.type == "SOCIAL"])
         assert 1 == len(
             [
                 e
@@ -43,6 +44,15 @@ class TestSocial(ModuleTestBase):
                 for e in events
                 if e.type == "SOCIAL"
                 and e.data["platform"] == "github"
+                and e.data["profile_name"] == "blacklanternsecurity"
+            ]
+        )
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "SOCIAL"
+                and e.data["platform"] == "postman"
                 and e.data["profile_name"] == "blacklanternsecurity"
             ]
         )


### PR DESCRIPTION
This PR adds to the social and code_repository modules to detect postman team profiles and workspaces in URLs and re-raise them as `SOCIAL` and `CODE_REPOSITORY` events

I will be opening a PR for the postman module so it consumes `SOCIAL` events and lists the workspaces from that team