### PR TITLE
Update trufflehog to 3.82.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.81.10",
+        "version": "3.82.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* adding pypi v1 support by @dylanTruffle in https://github.com/trufflesecurity/trufflehog/pull/3289


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.0...v3.82.1