### PR TITLE
Update trufflehog to 3.82.2

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.1",
+        "version": "3.82.2",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module github.com/prometheus/client_golang to v1.20.3 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3279
* Instrument GitHub source with a UnitReporter by @mcastorina in https://github.com/trufflesecurity/trufflehog/pull/3284
* [analyze] Add Analyzer for MySQL by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3193
* [analyze] Add Analyzer for Mailgun by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3206
* [analyze] Add analyzer interface for Shopify by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3226
* Fix slice initialization error by @tiaoxizhan in https://github.com/trufflesecurity/trufflehog/pull/3293
* Fix GitHub analyzer panic on empty organization name by @mcastorina in https://github.com/trufflesecurity/trufflehog/pull/3295
* Add user agent suffix feature flag by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3297

## New Contributors
* @tiaoxizhan made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/3293

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.1...v3.82.2