### PR TITLE
Update trufflehog to 3.82.4

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.2",
+        "version": "3.82.4",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Ignore glTF & JPEG XL files by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3325
* Endpoint customizer refresh by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3308
* fix(deps): update module google.golang.org/api to v0.198.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3323
* [Detector] Cut out unneccessary false positive session tokens of AWSSession Key by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3306
* Use captain for test aggregation by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3328
* Include all detector tests for captain by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3329
* Update timeout to 60s by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3330
* Adding Descriptions by @dylanTruffle in https://github.com/trufflesecurity/trufflehog/pull/3258

## New Contributors
* @kashifkhan0771 made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/3308

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.3...v3.82.4