### PR TITLE
Update trufflehog to 3.82.5

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.4",
+        "version": "3.82.5",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module github.com/couchbase/gocb/v2 to v2.9.2 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3332
* RailwayApp Detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3331
* [fix] Correctly initialize detectors with cloud endpoint customization by @mcastorina in https://github.com/trufflesecurity/trufflehog/pull/3333


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.4...v3.82.5