### PR TITLE
Update trufflehog to 3.82.6

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.5",
+        "version": "3.82.6",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* [chore] Ensure testing Endpoints() doesn't silently pass on change by @mcastorina in https://github.com/trufflesecurity/trufflehog/pull/3334
* fix(deps): update module google.golang.org/api to v0.199.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3336
* [chore] - Add named params to interface methods by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3335
* Fix race in `EscapedUnicode` decoder by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3031
* Improve process cleanup by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3339
* [fix] Move detector initialization to DefaultDetectors function by @mcastorina in https://github.com/trufflesecurity/trufflehog/pull/3341


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.5...v3.82.6