### PR TITLE
Update nuclei to 3.3.4

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.3",
+        "version": "3.3.4",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fixed (hopefully) skipping target list as found unresponsive erroneously by @tarunKoyalwar in https://github.com/projectdiscovery/nuclei/pull/5668


**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.3.3...v3.3.4