### PR TITLE
Hostname extraction - only extract whitelisted hosts

### DIFF
--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -828,6 +828,7 @@ class excavate(BaseInternalModule):
         yara.set_config(max_match_data=yara_max_match_data)
         yara_rules_combined = "\n".join(self.yara_rules_dict.values())
         try:
+            self.info(f"Compiling {len(self.yara_rules_dict):,} YARA rules")
             self.yara_rules = yara.compile(source=yara_rules_combined)
         except yara.SyntaxError as e:
             self.debug(yara_rules_combined)

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -1004,15 +1004,13 @@ class Scanner:
         A list of DNS hostname strings generated from the scan target
         """
         if self._dns_strings is None:
-            dns_targets = set(t.host for t in self.target if t.host and isinstance(t.host, str))
             dns_whitelist = set(t.host for t in self.whitelist if t.host and isinstance(t.host, str))
-            dns_targets.update(dns_whitelist)
-            dns_targets = sorted(dns_targets, key=len)
-            dns_targets_set = set()
+            dns_whitelist = sorted(dns_whitelist, key=len)
+            dns_whitelist_set = set()
             dns_strings = []
-            for t in dns_targets:
-                if not any(x in dns_targets_set for x in self.helpers.domain_parents(t, include_self=True)):
-                    dns_targets_set.add(t)
+            for t in dns_whitelist:
+                if not any(x in dns_whitelist_set for x in self.helpers.domain_parents(t, include_self=True)):
+                    dns_whitelist_set.add(t)
                     dns_strings.append(t)
             self._dns_strings = dns_strings
         return self._dns_strings


### PR DESCRIPTION
This modifies BBOT's hostname extraction to happen only for whitelisted hosts. Before, it was extracting both targets and whitelisted hosts, which in the case of a custom whitelist was causing out-of-scope hosts to be extracted.

@liquidsec let me know if this looks okay