### PR TITLE
Support multiple API keys per service

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,13 +303,17 @@ For more information, see [Targets](https://www.blacklanternsecurity.com/bbot/St
 
 Similar to Amass or Subfinder, BBOT supports API keys for various third-party services such as SecurityTrails, etc.
 
-The standard way to do this is to enter your API keys in **`~/.config/bbot/bbot.yml`**:
+The standard way to do this is to enter your API keys in **`~/.config/bbot/bbot.yml`**. Note that multiple API keys are allowed:
 ```yaml
 modules:
   shodan_dns:
     api_key: 4f41243847da693a4f356c0486114bc6
   c99:
-    api_key: 21a270d5f59c9b05813a72bb41707266
+    # multiple API keys
+    api_key:
+      - 21a270d5f59c9b05813a72bb41707266
+      - ea8f243d9885cf8ce9876a580224fd3c
+      - 5bc6ed268ab6488270e496d3183a1a27
   virustotal:
     api_key: dd5f0eee2e4a99b71a939bded450b246
   securitytrails:

--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -2788,3 +2788,15 @@ def top_tcp_ports(n, as_string=False):
     if as_string:
         return ",".join([str(s) for s in top_ports])
     return top_ports
+
+
+class SafeDict(dict):
+    def __missing__(self, key):
+        return "{" + key + "}"
+
+
+def safe_format(s, **kwargs):
+    """
+    Format string while ignoring unused keys (prevents KeyError)
+    """
+    return s.format_map(SafeDict(kwargs))

--- a/bbot/modules/anubisdb.py
+++ b/bbot/modules/anubisdb.py
@@ -20,7 +20,7 @@ class anubisdb(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}/{self.helpers.quote(query)}"
-        return await self.request_with_fail_count(url)
+        return await self.api_request(url)
 
     def abort_if_pre(self, hostname):
         """

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -336,7 +336,7 @@ class BaseModule:
 
     @property
     def failed_request_abort_threshold(self):
-        return max(self._failed_request_abort_threshold, len(self._api_keys))
+        return max(self._failed_request_abort_threshold, len(self._api_keys) * 2)
 
     async def ping(self):
         """Asynchronously checks the health of the configured API.

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -328,7 +328,10 @@ class BaseModule:
 
     def cycle_api_key(self):
         if self._api_keys:
+            self.verbose(f"Cycling API key")
             self._api_keys.insert(0, self._api_keys.pop())
+        else:
+            self.debug(f"No extra API keys to cycle")
 
     @property
     def failed_request_abort_threshold(self):

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1188,7 +1188,7 @@ class BaseModule:
                     self.debug(f"Failed to extract next page of results from {url}: {e}")
                     self.debug(traceback.format_exc())
             else:
-                new_url = url.format(page=page, page_size=page_size, offset=offset)
+                new_url = self.helpers.safe_format(url, page=page, page_size=page_size, offset=offset)
             result = await self.api_request(new_url, **requests_kwargs)
             if result is None:
                 self.verbose(f"api_page_iter() got no response for {url}")

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -311,6 +311,7 @@ class BaseModule:
                 self.hugesuccess(f"API is ready")
                 return True
             except Exception as e:
+                self.trace(traceback.format_exc())
                 return None, f"Error with API ({str(e).strip()})"
         else:
             return None, "No API key set"

--- a/bbot/modules/bevigil.py
+++ b/bbot/modules/bevigil.py
@@ -22,9 +22,12 @@ class bevigil(subdomain_enum_apikey):
 
     async def setup(self):
         self.api_key = self.config.get("api_key", "")
-        self.headers = {"X-Access-Token": self.api_key}
         self.urls = self.config.get("urls", False)
         return await super().setup()
+
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["X-Access-Token"] = self.api_key
+        return url, kwargs
 
     async def ping(self):
         pass
@@ -54,11 +57,11 @@ class bevigil(subdomain_enum_apikey):
 
     async def request_subdomains(self, query):
         url = f"{self.base_url}/{self.helpers.quote(query)}/subdomains/"
-        return await self.request_with_fail_count(url, headers=self.headers)
+        return await self.api_request(url)
 
     async def request_urls(self, query):
         url = f"{self.base_url}/{self.helpers.quote(query)}/urls/"
-        return await self.request_with_fail_count(url, headers=self.headers)
+        return await self.api_request(url)
 
     def parse_subdomains(self, r, query=None):
         results = set()

--- a/bbot/modules/binaryedge.py
+++ b/bbot/modules/binaryedge.py
@@ -21,18 +21,21 @@ class binaryedge(subdomain_enum_apikey):
 
     async def setup(self):
         self.max_records = self.config.get("max_records", 1000)
-        self.headers = {"X-Key": self.config.get("api_key", "")}
         return await super().setup()
+
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["X-Key"] = self.api_key
+        return url, kwargs
 
     async def ping(self):
         url = f"{self.base_url}/user/subscription"
-        j = (await self.request_with_fail_count(url, headers=self.headers)).json()
+        j = (await self.api_request(url)).json()
         assert j.get("requests_left", 0) > 0
 
     async def request_url(self, query):
         # todo: host query (certs + services)
         url = f"{self.base_url}/query/domains/subdomain/{self.helpers.quote(query)}"
-        return await self.request_with_fail_count(url, headers=self.headers)
+        return await self.api_request(url)
 
     def parse_results(self, r, query):
         j = r.json()

--- a/bbot/modules/builtwith.py
+++ b/bbot/modules/builtwith.py
@@ -59,12 +59,12 @@ class builtwith(subdomain_enum_apikey):
                         )
 
     async def request_domains(self, query):
-        url = f"{self.base_url}/v20/api.json?KEY={self.api_key}&LOOKUP={query}&NOMETA=yes&NOATTR=yes&HIDETEXT=yes&HIDEDL=yes"
-        return await self.request_with_fail_count(url)
+        url = f"{self.base_url}/v20/api.json?KEY={{api_key}}&LOOKUP={query}&NOMETA=yes&NOATTR=yes&HIDETEXT=yes&HIDEDL=yes"
+        return await self.api_request(url)
 
     async def request_redirects(self, query):
-        url = f"{self.base_url}/redirect1/api.json?KEY={self.api_key}&LOOKUP={query}"
-        return await self.request_with_fail_count(url)
+        url = f"{self.base_url}/redirect1/api.json?KEY={{api_key}}&LOOKUP={query}"
+        return await self.api_request(url)
 
     def parse_domains(self, r, query):
         """

--- a/bbot/modules/c99.py
+++ b/bbot/modules/c99.py
@@ -17,13 +17,13 @@ class c99(subdomain_enum_apikey):
     base_url = "https://api.c99.nl"
 
     async def ping(self):
-        url = f"{self.base_url}/randomnumber?key={self.api_key}&between=1,100&json"
-        response = await self.request_with_fail_count(url)
+        url = f"{self.base_url}/randomnumber?key={{api_key}}&between=1,100&json"
+        response = await self.api_request(url)
         assert response.json()["success"] == True
 
     async def request_url(self, query):
-        url = f"{self.base_url}/subdomainfinder?key={self.api_key}&domain={self.helpers.quote(query)}&json"
-        return await self.request_with_fail_count(url)
+        url = f"{self.base_url}/subdomainfinder?key={{api_key}}&domain={self.helpers.quote(query)}&json"
+        return await self.api_request(url)
 
     def parse_results(self, r, query):
         j = r.json()

--- a/bbot/modules/certspotter.py
+++ b/bbot/modules/certspotter.py
@@ -15,7 +15,7 @@ class certspotter(subdomain_enum):
 
     def request_url(self, query):
         url = f"{self.base_url}/issuances?domain={self.helpers.quote(query)}&include_subdomains=true&expand=dns_names"
-        return self.request_with_fail_count(url, timeout=self.http_timeout + 30)
+        return self.api_request(url, timeout=self.http_timeout + 30)
 
     def parse_results(self, r, query):
         json = r.json()

--- a/bbot/modules/chaos.py
+++ b/bbot/modules/chaos.py
@@ -18,13 +18,17 @@ class chaos(subdomain_enum_apikey):
 
     async def ping(self):
         url = f"{self.base_url}/example.com"
-        response = await self.request_with_fail_count(url, headers={"Authorization": self.api_key})
+        response = await self.api_request(url)
         assert response.json()["domain"] == "example.com"
+
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["Authorization"] = self.api_key
+        return url, kwargs
 
     async def request_url(self, query):
         _, domain = self.helpers.split_domain(query)
         url = f"{self.base_url}/{domain}/subdomains"
-        return await self.request_with_fail_count(url, headers={"Authorization": self.api_key})
+        return await self.api_request(url)
 
     def parse_results(self, r, query):
         j = r.json()

--- a/bbot/modules/columbus.py
+++ b/bbot/modules/columbus.py
@@ -15,7 +15,7 @@ class columbus(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}/{self.helpers.quote(query)}?days=365"
-        return await self.request_with_fail_count(url)
+        return await self.api_request(url)
 
     def parse_results(self, r, query):
         results = set()

--- a/bbot/modules/crt.py
+++ b/bbot/modules/crt.py
@@ -21,7 +21,7 @@ class crt(subdomain_enum):
     async def request_url(self, query):
         params = {"q": f"%.{query}", "output": "json"}
         url = self.helpers.add_get_params(self.base_url, params).geturl()
-        return await self.request_with_fail_count(url, timeout=self.http_timeout + 30)
+        return await self.api_request(url, timeout=self.http_timeout + 30)
 
     def parse_results(self, r, query):
         j = r.json()

--- a/bbot/modules/dehashed.py
+++ b/bbot/modules/dehashed.py
@@ -90,7 +90,7 @@ class dehashed(subdomain_enum):
         url = f"{self.base_url}?query={query}&size=10000&page=" + "{page}"
         page = 0
         num_entries = 0
-        agen = self.helpers.api_page_iter(url=url, auth=self.auth, headers=self.headers, json=False)
+        agen = self.api_page_iter(url=url, auth=self.auth, headers=self.headers, json=False)
         async for result in agen:
             result_json = {}
             with suppress(Exception):

--- a/bbot/modules/dnsdumpster.py
+++ b/bbot/modules/dnsdumpster.py
@@ -18,7 +18,7 @@ class dnsdumpster(subdomain_enum):
     async def query(self, domain):
         ret = []
         # first, get the CSRF tokens
-        res1 = await self.request_with_fail_count(self.base_url)
+        res1 = await self.api_request(self.base_url)
         status_code = getattr(res1, "status_code", 0)
         if status_code in [429]:
             self.verbose(f'Too many requests "{status_code}"')
@@ -62,7 +62,7 @@ class dnsdumpster(subdomain_enum):
 
         # Otherwise, do the needful
         subdomains = set()
-        res2 = await self.request_with_fail_count(
+        res2 = await self.api_request(
             f"{self.base_url}/",
             method="POST",
             cookies={"csrftoken": csrftoken},

--- a/bbot/modules/dockerhub.py
+++ b/bbot/modules/dockerhub.py
@@ -64,7 +64,7 @@ class dockerhub(BaseModule):
     async def get_repos(self, username):
         repos = []
         url = f"{self.api_url}/repositories/{username}?page_size=25&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, json=False)
+        agen = self.api_page_iter(url, json=False)
         try:
             async for r in agen:
                 if r is None:

--- a/bbot/modules/emailformat.py
+++ b/bbot/modules/emailformat.py
@@ -18,7 +18,7 @@ class emailformat(BaseModule):
     async def handle_event(self, event):
         _, query = self.helpers.split_domain(event.data)
         url = f"{self.base_url}/d/{self.helpers.quote(query)}/"
-        r = await self.request_with_fail_count(url)
+        r = await self.api_request(url)
         if not r:
             return
         for email in await self.helpers.re.extract_emails(r.text):

--- a/bbot/modules/fullhunt.py
+++ b/bbot/modules/fullhunt.py
@@ -18,18 +18,21 @@ class fullhunt(subdomain_enum_apikey):
 
     async def setup(self):
         self.api_key = self.config.get("api_key", "")
-        self.headers = {"x-api-key": self.api_key}
         return await super().setup()
 
     async def ping(self):
         url = f"{self.base_url}/auth/status"
-        j = (await self.request_with_fail_count(url, headers=self.headers)).json()
+        j = (await self.api_request(url)).json()
         remaining = j["user_credits"]["remaining_credits"]
         assert remaining > 0, "No credits remaining"
 
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["x-api-key"] = self.api_key
+        return url, kwargs
+
     async def request_url(self, query):
         url = f"{self.base_url}/domain/{self.helpers.quote(query)}/subdomains"
-        response = await self.request_with_fail_count(url, headers=self.headers)
+        response = await self.api_request(url)
         return response
 
     def parse_results(self, r, query):

--- a/bbot/modules/github_codesearch.py
+++ b/bbot/modules/github_codesearch.py
@@ -42,7 +42,7 @@ class github_codesearch(github, subdomain_enum):
     async def query(self, query):
         repos = {}
         url = f"{self.base_url}/search/code?per_page=100&type=Code&q={self.helpers.quote(query)}&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, json=False)
+        agen = self.api_page_iter(url, headers=self.headers, json=False)
         num_results = 0
         try:
             async for r in agen:

--- a/bbot/modules/github_org.py
+++ b/bbot/modules/github_org.py
@@ -104,7 +104,7 @@ class github_org(github):
     async def query_org_repos(self, query):
         repos = []
         url = f"{self.base_url}/orgs/{self.helpers.quote(query)}/repos?per_page=100&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, json=False)
+        agen = self.api_page_iter(url, json=False)
         try:
             async for r in agen:
                 if r is None:
@@ -132,7 +132,7 @@ class github_org(github):
     async def query_org_members(self, query):
         members = []
         url = f"{self.base_url}/orgs/{self.helpers.quote(query)}/members?per_page=100&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, json=False)
+        agen = self.api_page_iter(url, json=False)
         try:
             async for r in agen:
                 if r is None:
@@ -160,7 +160,7 @@ class github_org(github):
     async def query_user_repos(self, query):
         repos = []
         url = f"{self.base_url}/users/{self.helpers.quote(query)}/repos?per_page=100&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, json=False)
+        agen = self.api_page_iter(url, json=False)
         try:
             async for r in agen:
                 if r is None:
@@ -189,7 +189,7 @@ class github_org(github):
         is_org = False
         in_scope = False
         url = f"{self.base_url}/orgs/{org}"
-        r = await self.helpers.request(url, headers=self.headers)
+        r = await self.api_request(url)
         if r is None:
             return is_org, in_scope
         status_code = getattr(r, "status_code", 0)

--- a/bbot/modules/github_workflows.py
+++ b/bbot/modules/github_workflows.py
@@ -88,7 +88,7 @@ class github_workflows(github):
     async def get_workflows(self, owner, repo):
         workflows = []
         url = f"{self.base_url}/repos/{owner}/{repo}/actions/workflows?per_page=100&page=" + "{page}"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, json=False)
+        agen = self.api_page_iter(url, json=False)
         try:
             async for r in agen:
                 if r is None:
@@ -115,7 +115,7 @@ class github_workflows(github):
     async def get_workflow_runs(self, owner, repo, workflow_id):
         runs = []
         url = f"{self.base_url}/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs?status=success&per_page={self.num_logs}"
-        r = await self.helpers.request(url, headers=self.headers)
+        r = await self.api_request(url)
         if r is None:
             return runs
         status_code = getattr(r, "status_code", 0)
@@ -176,7 +176,7 @@ class github_workflows(github):
     async def get_run_artifacts(self, owner, repo, run_id):
         artifacts = []
         url = f"{self.base_url}/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts"
-        r = await self.helpers.request(url, headers=self.headers)
+        r = await self.api_request(url)
         if r is None:
             return artifacts
         status_code = getattr(r, "status_code", 0)

--- a/bbot/modules/gitlab.py
+++ b/bbot/modules/gitlab.py
@@ -16,10 +16,7 @@ class gitlab(BaseModule):
     scope_distance_modifier = 2
 
     async def setup(self):
-        self.headers = {}
-        self.api_key = self.config.get("api_key", "")
-        if self.api_key:
-            self.headers.update({"Authorization": f"Bearer {self.api_key}"})
+        await self.require_api_key()
         return True
 
     async def filter_event(self, event):
@@ -111,7 +108,7 @@ class gitlab(BaseModule):
             await self.handle_namespace(group, event)
 
     async def gitlab_json_request(self, url):
-        response = await self.helpers.request(url, headers=self.headers)
+        response = await self.api_request(url)
         if response is not None:
             try:
                 json = response.json()

--- a/bbot/modules/hackertarget.py
+++ b/bbot/modules/hackertarget.py
@@ -15,7 +15,7 @@ class hackertarget(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}/hostsearch/?q={self.helpers.quote(query)}"
-        response = await self.request_with_fail_count(url)
+        response = await self.api_request(url)
         return response
 
     def parse_results(self, r, query):

--- a/bbot/modules/hunterio.py
+++ b/bbot/modules/hunterio.py
@@ -18,8 +18,8 @@ class hunterio(subdomain_enum_apikey):
     limit = 100
 
     async def ping(self):
-        url = f"{self.base_url}/account?api_key={self.api_key}"
-        r = await self.helpers.request(url)
+        url = f"{self.base_url}/account?api_key={{api_key}}"
+        r = await self.api_request(url)
         resp_content = getattr(r, "text", "")
         assert getattr(r, "status_code", 0) == 200, resp_content
 
@@ -56,10 +56,9 @@ class hunterio(subdomain_enum_apikey):
     async def query(self, query):
         emails = []
         url = (
-            f"{self.base_url}/domain-search?domain={query}&api_key={self.api_key}"
-            + "&limit={page_size}&offset={offset}"
+            f"{self.base_url}/domain-search?domain={query}&api_key={{api_key}}" + "&limit={page_size}&offset={offset}"
         )
-        agen = self.helpers.api_page_iter(url, page_size=self.limit)
+        agen = self.api_page_iter(url, page_size=self.limit)
         try:
             async for j in agen:
                 new_emails = j.get("data", {}).get("emails", [])

--- a/bbot/modules/internetdb.py
+++ b/bbot/modules/internetdb.py
@@ -64,7 +64,7 @@ class internetdb(BaseModule):
         if ip is None:
             return
         url = f"{self.base_url}/{ip}"
-        r = await self.request_with_fail_count(url)
+        r = await self.api_request(url)
         if r is None:
             self.debug(f"No response for {event.data}")
             return

--- a/bbot/modules/ip2location.py
+++ b/bbot/modules/ip2location.py
@@ -32,12 +32,12 @@ class IP2Location(BaseModule):
 
     async def ping(self):
         url = self.build_url("8.8.8.8")
-        r = await self.request_with_fail_count(url)
+        r = await self.api_request(url)
         resp_content = getattr(r, "text", "")
         assert getattr(r, "status_code", 0) == 200, resp_content
 
     def build_url(self, data):
-        url = f"{self.base_url}/?key={self.api_key}&ip={data}&format=json&source=bbot"
+        url = f"{self.base_url}/?key={{api_key}}&ip={data}&format=json&source=bbot"
         if self.lang:
             url = f"{url}&lang={self.lang}"
         return url
@@ -45,7 +45,7 @@ class IP2Location(BaseModule):
     async def handle_event(self, event):
         try:
             url = self.build_url(event.data)
-            result = await self.request_with_fail_count(url)
+            result = await self.api_request(url)
             if result:
                 geo_data = result.json()
                 if not geo_data:

--- a/bbot/modules/ipstack.py
+++ b/bbot/modules/ipstack.py
@@ -28,15 +28,15 @@ class Ipstack(BaseModule):
         return await self.require_api_key()
 
     async def ping(self):
-        url = f"{self.base_url}/check?access_key={self.api_key}"
-        r = await self.request_with_fail_count(url)
+        url = f"{self.base_url}/check?access_key={{api_key}}"
+        r = await self.api_request(url)
         resp_content = getattr(r, "text", "")
         assert getattr(r, "status_code", 0) == 200, resp_content
 
     async def handle_event(self, event):
         try:
-            url = f"{self.base_url}/{event.data}?access_key={self.api_key}"
-            result = await self.request_with_fail_count(url)
+            url = f"{self.base_url}/{event.data}?access_key={{api_key}}"
+            result = await self.api_request(url)
             if result:
                 geo_data = result.json()
                 if not geo_data:

--- a/bbot/modules/leakix.py
+++ b/bbot/modules/leakix.py
@@ -25,15 +25,20 @@ class leakix(subdomain_enum_apikey):
             return await self.require_api_key()
         return ret
 
+    def prepare_api_request(self, url, kwargs):
+        if self.api_key:
+            kwargs["headers"]["api-key"] = self.api_key
+        return url, kwargs
+
     async def ping(self):
         url = f"{self.base_url}/host/1.2.3.4.5"
-        r = await self.helpers.request(url, headers=self.headers)
+        r = await self.helpers.request(url)
         resp_content = getattr(r, "text", "")
         assert getattr(r, "status_code", 0) != 401, resp_content
 
     async def request_url(self, query):
         url = f"{self.base_url}/api/subdomains/{self.helpers.quote(query)}"
-        response = await self.request_with_fail_count(url, headers=self.headers)
+        response = await self.api_request(url)
         return response
 
     def parse_results(self, r, query=None):

--- a/bbot/modules/myssl.py
+++ b/bbot/modules/myssl.py
@@ -15,7 +15,7 @@ class myssl(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}?domain={self.helpers.quote(query)}"
-        return await self.request_with_fail_count(url)
+        return await self.api_request(url)
 
     def parse_results(self, r, query):
         results = set()

--- a/bbot/modules/otx.py
+++ b/bbot/modules/otx.py
@@ -15,7 +15,7 @@ class otx(subdomain_enum):
 
     def request_url(self, query):
         url = f"{self.base_url}/api/v1/indicators/domain/{self.helpers.quote(query)}/passive_dns"
-        return self.request_with_fail_count(url)
+        return self.api_request(url)
 
     def parse_results(self, r, query):
         j = r.json()

--- a/bbot/modules/passivetotal.py
+++ b/bbot/modules/passivetotal.py
@@ -24,7 +24,7 @@ class passivetotal(subdomain_enum_apikey):
 
     async def ping(self):
         url = f"{self.base_url}/account/quota"
-        j = (await self.request_with_fail_count(url, auth=self.auth)).json()
+        j = (await self.api_request(url, auth=self.auth)).json()
         limit = j["user"]["limits"]["search_api"]
         used = j["user"]["counts"]["search_api"]
         assert used < limit, "No quota remaining"
@@ -35,7 +35,7 @@ class passivetotal(subdomain_enum_apikey):
 
     async def request_url(self, query):
         url = f"{self.base_url}/enrichment/subdomains?query={self.helpers.quote(query)}"
-        return await self.request_with_fail_count(url, auth=self.auth)
+        return await self.api_request(url, auth=self.auth)
 
     def parse_results(self, r, query):
         for subdomain in r.json().get("subdomains", []):

--- a/bbot/modules/postman_download.py
+++ b/bbot/modules/postman_download.py
@@ -18,9 +18,6 @@ class postman_download(postman):
     scope_distance_modifier = 2
 
     async def setup(self):
-        self.api_key = self.config.get("api_key", "")
-        self.authorization_headers = {"X-Api-Key": self.api_key}
-
         output_folder = self.config.get("output_folder")
         if output_folder:
             self.output_dir = Path(output_folder) / "postman_workspaces"
@@ -29,9 +26,13 @@ class postman_download(postman):
         self.helpers.mkdir(self.output_dir)
         return await self.require_api_key()
 
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["X-Api-Key"] = self.api_key
+        return url, kwargs
+
     async def ping(self):
         url = f"{self.api_url}/me"
-        response = await self.helpers.request(url, headers=self.authorization_headers)
+        response = await self.api_request(url)
         assert getattr(response, "status_code", 0) == 200, response.text
 
     async def filter_event(self, event):
@@ -125,7 +126,7 @@ class postman_download(postman):
     async def get_workspace(self, workspace_id):
         workspace = {}
         workspace_url = f"{self.api_url}/workspaces/{workspace_id}"
-        r = await self.helpers.request(workspace_url, headers=self.authorization_headers)
+        r = await self.api_request(workspace_url)
         if r is None:
             return workspace
         status_code = getattr(r, "status_code", 0)
@@ -155,7 +156,7 @@ class postman_download(postman):
     async def get_environment(self, environment_id):
         environment = {}
         environment_url = f"{self.api_url}/environments/{environment_id}"
-        r = await self.helpers.request(environment_url, headers=self.authorization_headers)
+        r = await self.api_request(environment_url)
         if r is None:
             return environment
         status_code = getattr(r, "status_code", 0)
@@ -170,7 +171,7 @@ class postman_download(postman):
     async def get_collection(self, collection_id):
         collection = {}
         collection_url = f"{self.api_url}/collections/{collection_id}"
-        r = await self.helpers.request(collection_url, headers=self.authorization_headers)
+        r = await self.api_request(collection_url)
         if r is None:
             return collection
         status_code = getattr(r, "status_code", 0)

--- a/bbot/modules/rapiddns.py
+++ b/bbot/modules/rapiddns.py
@@ -15,7 +15,7 @@ class rapiddns(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}/subdomain/{self.helpers.quote(query)}?full=1#result"
-        response = await self.request_with_fail_count(url, timeout=self.http_timeout + 10)
+        response = await self.api_request(url, timeout=self.http_timeout + 10)
         return response
 
     def parse_results(self, r, query):

--- a/bbot/modules/securitytrails.py
+++ b/bbot/modules/securitytrails.py
@@ -21,14 +21,14 @@ class securitytrails(subdomain_enum_apikey):
         return await super().setup()
 
     async def ping(self):
-        url = f"{self.base_url}/ping?apikey={self.api_key}"
-        r = await self.request_with_fail_count(url)
+        url = f"{self.base_url}/ping?apikey={{api_key}}"
+        r = await self.api_request(url)
         resp_content = getattr(r, "text", "")
         assert getattr(r, "status_code", 0) == 200, resp_content
 
     async def request_url(self, query):
-        url = f"{self.base_url}/domain/{query}/subdomains?apikey={self.api_key}"
-        response = await self.request_with_fail_count(url)
+        url = f"{self.base_url}/domain/{query}/subdomains?apikey={{api_key}}"
+        response = await self.api_request(url)
         return response
 
     def parse_results(self, r, query):

--- a/bbot/modules/shodan_dns.py
+++ b/bbot/modules/shodan_dns.py
@@ -17,8 +17,8 @@ class shodan_dns(shodan):
     base_url = "https://api.shodan.io"
 
     async def request_url(self, query):
-        url = f"{self.base_url}/dns/domain/{self.helpers.quote(query)}?key={self.api_key}"
-        response = await self.request_with_fail_count(url)
+        url = f"{self.base_url}/dns/domain/{self.helpers.quote(query)}?key={{api_key}}"
+        response = await self.api_request(url)
         return response
 
     def parse_results(self, r, query):

--- a/bbot/modules/skymem.py
+++ b/bbot/modules/skymem.py
@@ -24,7 +24,7 @@ class skymem(emailformat):
         _, query = self.helpers.split_domain(event.data)
         # get first page
         url = f"{self.base_url}/srch?q={self.helpers.quote(query)}"
-        r = await self.request_with_fail_count(url)
+        r = await self.api_request(url)
         if not r:
             return
         responses = [r]
@@ -34,7 +34,7 @@ class skymem(emailformat):
         if domain_ids:
             domain_id = domain_ids[0]
             for page in range(2, 22):
-                r2 = await self.request_with_fail_count(f"{self.base_url}/domain/{domain_id}?p={page}")
+                r2 = await self.api_request(f"{self.base_url}/domain/{domain_id}?p={page}")
                 if not r2:
                     continue
                 responses.append(r2)

--- a/bbot/modules/templates/github.py
+++ b/bbot/modules/templates/github.py
@@ -36,6 +36,7 @@ class github(BaseModule):
             self.hugesuccess(f"API is ready")
             return True
         except Exception as e:
+            self.trace(traceback.format_exc())
             return None, f"Error with API ({str(e).strip()})"
         return True
 

--- a/bbot/modules/templates/github.py
+++ b/bbot/modules/templates/github.py
@@ -10,20 +10,27 @@ class github(BaseModule):
     _qsize = 1
     base_url = "https://api.github.com"
 
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["Authorization"] = f"token {self.api_key}"
+        return url, kwargs
+
     async def setup(self):
         await super().setup()
-        self.api_key = None
         self.headers = {}
+        api_keys = set()
         for module_name in ("github", "github_codesearch", "github_org", "git_clone"):
             module_config = self.scan.config.get("modules", {}).get(module_name, {})
             api_key = module_config.get("api_key", "")
-            if api_key:
-                self.api_key = api_key
-                self.headers = {"Authorization": f"token {self.api_key}"}
-                break
-        if not self.api_key:
+            if isinstance(api_key, str):
+                api_key = [api_key]
+            for key in api_key:
+                key = key.strip()
+                if key:
+                    api_keys.update(key)
+        if not api_keys:
             if self.auth_required:
                 return None, "No API key set"
+        self.api_key = api_keys
         try:
             await self.ping()
             self.hugesuccess(f"API is ready")

--- a/bbot/modules/templates/github.py
+++ b/bbot/modules/templates/github.py
@@ -1,3 +1,5 @@
+import traceback
+
 from bbot.modules.base import BaseModule
 
 

--- a/bbot/modules/templates/shodan.py
+++ b/bbot/modules/templates/shodan.py
@@ -28,6 +28,7 @@ class shodan(subdomain_enum):
             self.hugesuccess(f"API is ready")
             return True
         except Exception as e:
+            self.trace(traceback.format_exc())
             return None, f"Error with API ({str(e).strip()})"
         return True
 

--- a/bbot/modules/templates/shodan.py
+++ b/bbot/modules/templates/shodan.py
@@ -1,3 +1,5 @@
+import traceback
+
 from bbot.modules.templates.subdomain_enum import subdomain_enum
 
 

--- a/bbot/modules/templates/subdomain_enum.py
+++ b/bbot/modules/templates/subdomain_enum.py
@@ -63,7 +63,7 @@ class subdomain_enum(BaseModule):
 
     async def request_url(self, query):
         url = f"{self.base_url}/subdomains/{self.helpers.quote(query)}"
-        return await self.request_with_fail_count(url)
+        return await self.api_request(url)
 
     def make_query(self, event):
         query = event.data
@@ -78,11 +78,7 @@ class subdomain_enum(BaseModule):
             if self.scan.in_scope(p):
                 query = p
                 break
-        try:
-            return ".".join([s for s in query.split(".") if s != "_wildcard"])
-        except Exception:
-            self.critical(query)
-            raise
+        return ".".join([s for s in query.split(".") if s != "_wildcard"])
 
     def parse_results(self, r, query=None):
         json = r.json()

--- a/bbot/modules/trickest.py
+++ b/bbot/modules/trickest.py
@@ -24,9 +24,9 @@ class Trickest(subdomain_enum_apikey):
 
     def prepare_api_request(self, url, kwargs):
         kwargs["headers"]["Authorization"] = f"Token {self.api_key}"
+        return url, kwargs
 
     async def ping(self):
-
         url = f"{self.base_url}/dataset"
         response = await self.api_request(url)
         status_code = getattr(response, "status_code", 0)

--- a/bbot/modules/trickest.py
+++ b/bbot/modules/trickest.py
@@ -22,10 +22,13 @@ class Trickest(subdomain_enum_apikey):
     dataset_id = "a0a49ca9-03bb-45e0-aa9a-ad59082ebdfc"
     page_size = 50
 
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["Authorization"] = f"Token {self.api_key}"
+
     async def ping(self):
-        self.headers = {"Authorization": f"Token {self.api_key}"}
+
         url = f"{self.base_url}/dataset"
-        response = await self.helpers.request(url, headers=self.headers)
+        response = await self.api_request(url)
         status_code = getattr(response, "status_code", 0)
         if status_code != 200:
             response_text = getattr(response, "text", "no response from server")
@@ -54,7 +57,7 @@ class Trickest(subdomain_enum_apikey):
         url = f"{self.base_url}/view?q=hostname%20~%20%22.{self.helpers.quote(query)}%22"
         url += f"&dataset_id={self.dataset_id}"
         url += "&limit={page_size}&offset={offset}&select=hostname&orderby=hostname"
-        agen = self.helpers.api_page_iter(url, headers=self.headers, page_size=self.page_size)
+        agen = self.api_page_iter(url, page_size=self.page_size)
         try:
             async for response in agen:
                 subdomains = self.parse_results(response)

--- a/bbot/modules/zoomeye.py
+++ b/bbot/modules/zoomeye.py
@@ -27,6 +27,7 @@ class zoomeye(subdomain_enum_apikey):
 
     def prepare_api_request(self, url, kwargs):
         kwargs["headers"]["API-KEY"] = self.api_key
+        return url, kwargs
 
     async def ping(self):
         url = f"{self.base_url}/resources-info"

--- a/bbot/modules/zoomeye.py
+++ b/bbot/modules/zoomeye.py
@@ -22,13 +22,15 @@ class zoomeye(subdomain_enum_apikey):
 
     async def setup(self):
         self.max_pages = self.config.get("max_pages", 20)
-        self.headers = {"API-KEY": self.config.get("api_key", "")}
         self.include_related = self.config.get("include_related", False)
         return await super().setup()
 
+    def prepare_api_request(self, url, kwargs):
+        kwargs["headers"]["API-KEY"] = self.api_key
+
     async def ping(self):
         url = f"{self.base_url}/resources-info"
-        r = await self.helpers.request(url, headers=self.headers)
+        r = await self.api_request(url)
         assert int(r.json()["quota_info"]["remain_total_quota"]) > 0, "No quota remaining"
 
     async def handle_event(self, event):
@@ -54,7 +56,7 @@ class zoomeye(subdomain_enum_apikey):
         query_type = 0 if self.include_related else 1
         url = f"{self.base_url}/domain/search?q={self.helpers.quote(query)}&type={query_type}&page=" + "{page}"
         i = 0
-        agen = self.helpers.api_page_iter(url, headers=self.headers)
+        agen = self.api_page_iter(url)
         try:
             async for j in agen:
                 r = list(self.parse_results(j))

--- a/bbot/scanner/preset/environ.py
+++ b/bbot/scanner/preset/environ.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from bbot.core.helpers.misc import cpu_architecture, os_platform, os_platform_friendly
 
 
+REQUESTS_PATCHED = False
+
+
 def increase_limit(new_limit):
     try:
         import resource
@@ -120,7 +123,10 @@ class BBOTEnviron:
 
         urllib3.disable_warnings()
         ssl_verify = self.preset.config.get("ssl_verify", False)
-        if not ssl_verify:
+
+        global REQUESTS_PATCHED
+        if not ssl_verify and not REQUESTS_PATCHED:
+            REQUESTS_PATCHED = True
             import requests
             import functools
 

--- a/bbot/test/test_step_1/test_helpers.py
+++ b/bbot/test/test_step_1/test_helpers.py
@@ -424,6 +424,10 @@ async def test_helpers_misc(helpers, scan, bbot_scanner, bbot_httpserver):
 
     assert type(helpers.make_date()) == str
 
+    # string formatter
+    s = "asdf {unused} {used}"
+    assert helpers.safe_format(s, used="fdsa") == "asdf {unused} fdsa"
+
     # punycode
     assert helpers.smart_encode_punycode("ドメイン.テスト") == "xn--eckwd4c7c.xn--zckzah"
     assert helpers.smart_decode_punycode("xn--eckwd4c7c.xn--zckzah") == "ドメイン.テスト"

--- a/bbot/test/test_step_1/test_manager_scope_accuracy.py
+++ b/bbot/test/test_step_1/test_manager_scope_accuracy.py
@@ -114,8 +114,9 @@ async def test_manager_scope_accuracy(bbot_scanner, bbot_httpserver, bbot_other_
         await scan.helpers.dns._mock_dns(_dns_mock)
         if scan_callback is not None:
             scan_callback(scan)
+        output_events = [e async for e in scan.async_start()]
         return (
-            [e async for e in scan.async_start()],
+            output_events,
             dummy_module.events,
             dummy_module_nodupes.events,
             dummy_graph_output_module.events,

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -252,7 +252,7 @@ async def test_web_helpers(bbot_scanner, bbot_httpserver, httpx_mock):
         uri=f"{base_path}/3", query_string={"page_size": "100", "offset": "200"}
     ).respond_with_data("page3")
     results = []
-    agen = scan1.helpers.api_page_iter(template_url)
+    agen = scan1.api_page_iter(template_url)
     try:
         async for result in agen:
             if result and result.text.startswith("page"):
@@ -262,7 +262,7 @@ async def test_web_helpers(bbot_scanner, bbot_httpserver, httpx_mock):
     finally:
         await agen.aclose()
     assert not results
-    agen = scan1.helpers.api_page_iter(template_url, json=False)
+    agen = scan1.api_page_iter(template_url, json=False)
     try:
         async for result in agen:
             if result and result.text.startswith("page"):

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -153,8 +153,11 @@ async def test_web_helpers(bbot_scanner, bbot_httpserver, httpx_mock):
 
     await scan._cleanup()
 
-    scan1 = bbot_scanner("8.8.8.8")
+    scan1 = bbot_scanner("8.8.8.8", modules=["ipneighbor"])
     scan2 = bbot_scanner("127.0.0.1")
+
+    await scan1._prep()
+    module = scan1.modules["ipneighbor"]
 
     web_config = CORE.config.get("web", {})
     user_agent = web_config.get("user_agent", "")
@@ -252,7 +255,7 @@ async def test_web_helpers(bbot_scanner, bbot_httpserver, httpx_mock):
         uri=f"{base_path}/3", query_string={"page_size": "100", "offset": "200"}
     ).respond_with_data("page3")
     results = []
-    agen = scan1.api_page_iter(template_url)
+    agen = module.api_page_iter(template_url)
     try:
         async for result in agen:
             if result and result.text.startswith("page"):
@@ -262,7 +265,7 @@ async def test_web_helpers(bbot_scanner, bbot_httpserver, httpx_mock):
     finally:
         await agen.aclose()
     assert not results
-    agen = scan1.api_page_iter(template_url, json=False)
+    agen = module.api_page_iter(template_url, json=False)
     try:
         async for result in agen:
             if result and result.text.startswith("page"):

--- a/bbot/test/test_step_2/module_tests/test_module_bevigil.py
+++ b/bbot/test/test_step_2/module_tests/test_module_bevigil.py
@@ -1,12 +1,16 @@
+import random
+
 from .base import ModuleTestBase
 
 
 class TestBeVigil(ModuleTestBase):
+    module_name = "bevigil"
     config_overrides = {"modules": {"bevigil": {"api_key": "asdf", "urls": True}}}
 
     async def setup_after_prep(self, module_test):
         module_test.httpx_mock.add_response(
             url=f"https://osint.bevigil.com/api/blacklanternsecurity.com/subdomains/",
+            match_headers={"X-Access-Token": "asdf"},
             json={
                 "domain": "blacklanternsecurity.com",
                 "subdomains": [
@@ -22,3 +26,26 @@ class TestBeVigil(ModuleTestBase):
     def check(self, module_test, events):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
         assert any(e.data == "https://asdf.blacklanternsecurity.com/" for e in events), "Failed to detect url"
+
+
+class TestBeVigilMultiKey(TestBeVigil):
+    api_keys = ["1234", "4321", "asdf", "fdsa"]
+    random.shuffle(api_keys)
+    config_overrides = {"modules": {"bevigil": {"api_key": api_keys, "urls": True}}}
+
+    async def setup_after_prep(self, module_test):
+        module_test.httpx_mock.add_response(
+            url=f"https://osint.bevigil.com/api/blacklanternsecurity.com/subdomains/",
+            match_headers={"X-Access-Token": "fdsa"},
+            json={
+                "domain": "blacklanternsecurity.com",
+                "subdomains": [
+                    "asdf.blacklanternsecurity.com",
+                ],
+            },
+        )
+        module_test.httpx_mock.add_response(
+            match_headers={"X-Access-Token": "asdf"},
+            url=f"https://osint.bevigil.com/api/blacklanternsecurity.com/urls/",
+            json={"domain": "blacklanternsecurity.com", "urls": ["https://asdf.blacklanternsecurity.com"]},
+        )

--- a/bbot/test/test_step_2/module_tests/test_module_binaryedge.py
+++ b/bbot/test/test_step_2/module_tests/test_module_binaryedge.py
@@ -7,6 +7,7 @@ class TestBinaryEdge(ModuleTestBase):
     async def setup_before_prep(self, module_test):
         module_test.httpx_mock.add_response(
             url=f"https://api.binaryedge.io/v2/query/domains/subdomain/blacklanternsecurity.com",
+            match_headers={"X-Key": "asdf"},
             json={
                 "query": "blacklanternsecurity.com",
                 "page": 1,
@@ -19,6 +20,7 @@ class TestBinaryEdge(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url=f"https://api.binaryedge.io/v2/user/subscription",
+            match_headers={"X-Key": "asdf"},
             json={
                 "subscription": {"name": "Free"},
                 "end_date": "2023-06-17",

--- a/bbot/test/test_step_2/module_tests/test_module_c99.py
+++ b/bbot/test/test_step_2/module_tests/test_module_c99.py
@@ -1,7 +1,10 @@
+import httpx
+
 from .base import ModuleTestBase
 
 
 class TestC99(ModuleTestBase):
+    module_name = "c99"
     config_overrides = {"modules": {"c99": {"api_key": "asdf"}}}
 
     async def setup_before_prep(self, module_test):
@@ -23,3 +26,39 @@ class TestC99(ModuleTestBase):
 
     def check(self, module_test, events):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
+
+
+class TestC99AbortThreshold(TestC99):
+    config_overrides = {"modules": {"c99": {"api_key": ["6789", "fdsa", "1234", "4321"]}}}
+
+    async def setup_before_prep(self, module_test):
+        module_test.httpx_mock.add_response(
+            url="https://api.c99.nl/randomnumber?key=fdsa&between=1,100&json",
+            json={"success": True, "output": 65},
+        )
+
+        self.url_count = {}
+
+        async def custom_callback(request):
+            url = str(request.url)
+            try:
+                self.url_count[url] += 1
+            except KeyError:
+                self.url_count[url] = 1
+            raise httpx.TimeoutException("timeout")
+
+        module_test.httpx_mock.add_callback(custom_callback)
+
+    def check(self, module_test, events):
+        assert module_test.module.failed_request_abort_threshold == 8
+        assert module_test.module.errored == True
+        assert [e.data for e in events if e.type == "DNS_NAME"] == ["blacklanternsecurity.com"]
+        assert self.url_count == {
+            "https://api.c99.nl/randomnumber?key=6789&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=4321&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=1234&between=1,100&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=blacklanternsecurity.com&json": 2,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=blacklanternsecurity.com&json": 2,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=blacklanternsecurity.com&json": 2,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=blacklanternsecurity.com&json": 2,
+        }

--- a/bbot/test/test_step_2/module_tests/test_module_c99.py
+++ b/bbot/test/test_step_2/module_tests/test_module_c99.py
@@ -28,7 +28,7 @@ class TestC99(ModuleTestBase):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
 
 
-class TestC99AbortThreshold(TestC99):
+class TestC99AbortThreshold1(TestC99):
     config_overrides = {"modules": {"c99": {"api_key": ["6789", "fdsa", "1234", "4321"]}}}
 
     async def setup_before_prep(self, module_test):
@@ -50,15 +50,102 @@ class TestC99AbortThreshold(TestC99):
         module_test.httpx_mock.add_callback(custom_callback)
 
     def check(self, module_test, events):
-        assert module_test.module.failed_request_abort_threshold == 8
-        assert module_test.module.errored == True
-        assert [e.data for e in events if e.type == "DNS_NAME"] == ["blacklanternsecurity.com"]
+        assert module_test.module.api_failure_abort_threshold == 13
+        assert module_test.module.errored == False
+        # assert module_test.module._api_request_failures == 4
+        assert module_test.module.api_retries == 4
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {"blacklanternsecurity.com"}
         assert self.url_count == {
             "https://api.c99.nl/randomnumber?key=6789&between=1,100&json": 1,
             "https://api.c99.nl/randomnumber?key=4321&between=1,100&json": 1,
             "https://api.c99.nl/randomnumber?key=1234&between=1,100&json": 1,
-            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=blacklanternsecurity.com&json": 2,
-            "https://api.c99.nl/subdomainfinder?key=6789&domain=blacklanternsecurity.com&json": 2,
-            "https://api.c99.nl/subdomainfinder?key=4321&domain=blacklanternsecurity.com&json": 2,
-            "https://api.c99.nl/subdomainfinder?key=1234&domain=blacklanternsecurity.com&json": 2,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=blacklanternsecurity.com&json": 1,
         }
+
+
+class TestC99AbortThreshold2(TestC99AbortThreshold1):
+    targets = ["blacklanternsecurity.com", "evilcorp.com"]
+
+    async def setup_before_prep(self, module_test):
+        await super().setup_before_prep(module_test)
+        await module_test.mock_dns(
+            {
+                "blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+                "evilcorp.com": {"A": ["127.0.0.11"]},
+                "evilcorp.net": {"A": ["127.0.0.22"]},
+                "evilcorp.co.uk": {"A": ["127.0.0.33"]},
+            }
+        )
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 13
+        assert module_test.module.errored == False
+        assert module_test.module._api_request_failures == 8
+        assert module_test.module.api_retries == 4
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {"blacklanternsecurity.com", "evilcorp.com"}
+        assert self.url_count == {
+            "https://api.c99.nl/randomnumber?key=6789&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=4321&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=1234&between=1,100&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=evilcorp.com&json": 1,
+        }
+
+
+class TestC99AbortThreshold3(TestC99AbortThreshold2):
+    targets = ["blacklanternsecurity.com", "evilcorp.com", "evilcorp.net"]
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 13
+        assert module_test.module.errored == False
+        assert module_test.module._api_request_failures == 12
+        assert module_test.module.api_retries == 4
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {
+            "blacklanternsecurity.com",
+            "evilcorp.com",
+            "evilcorp.net",
+        }
+        assert self.url_count == {
+            "https://api.c99.nl/randomnumber?key=6789&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=4321&between=1,100&json": 1,
+            "https://api.c99.nl/randomnumber?key=1234&between=1,100&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=blacklanternsecurity.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=evilcorp.com&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=fdsa&domain=evilcorp.net&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=6789&domain=evilcorp.net&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=4321&domain=evilcorp.net&json": 1,
+            "https://api.c99.nl/subdomainfinder?key=1234&domain=evilcorp.net&json": 1,
+        }
+
+
+class TestC99AbortThreshold4(TestC99AbortThreshold3):
+    targets = ["blacklanternsecurity.com", "evilcorp.com", "evilcorp.net", "evilcorp.co.uk"]
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 13
+        assert module_test.module.errored == True
+        assert module_test.module._api_request_failures == 13
+        assert module_test.module.api_retries == 4
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {
+            "blacklanternsecurity.com",
+            "evilcorp.com",
+            "evilcorp.net",
+            "evilcorp.co.uk",
+        }
+        assert len(self.url_count) == 16
+        assert all([v == 1 for v in self.url_count.values()])

--- a/bbot/test/test_step_2/module_tests/test_module_gitlab.py
+++ b/bbot/test/test_step_2/module_tests/test_module_gitlab.py
@@ -4,10 +4,13 @@ from .base import ModuleTestBase
 class TestGitlab(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["gitlab", "httpx"]
+    config_overrides = {"modules": {"gitlab": {"api_key": "asdf"}}}
 
     async def setup_before_prep(self, module_test):
         module_test.httpserver.expect_request("/").respond_with_data(headers={"X-Gitlab-Meta": "asdf"})
-        module_test.httpserver.expect_request("/api/v4/projects", query_string="simple=true").respond_with_json(
+        module_test.httpserver.expect_request(
+            "/api/v4/projects", query_string="simple=true", headers={"Authorization": "Bearer asdf"}
+        ).respond_with_json(
             [
                 {
                     "id": 33,
@@ -41,7 +44,9 @@ class TestGitlab(ModuleTestBase):
                 },
             ],
         )
-        module_test.httpserver.expect_request("/api/v4/groups", query_string="simple=true").respond_with_json(
+        module_test.httpserver.expect_request(
+            "/api/v4/groups", query_string="simple=true", headers={"Authorization": "Bearer asdf"}
+        ).respond_with_json(
             [
                 {
                     "id": 9,
@@ -84,7 +89,7 @@ class TestGitlab(ModuleTestBase):
             ]
         )
         module_test.httpserver.expect_request(
-            "/api/v4/groups/bbotgroup/projects", query_string="simple=true"
+            "/api/v4/groups/bbotgroup/projects", query_string="simple=true", headers={"Authorization": "Bearer asdf"}
         ).respond_with_json(
             [
                 {
@@ -120,7 +125,7 @@ class TestGitlab(ModuleTestBase):
             ]
         )
         module_test.httpserver.expect_request(
-            "/api/v4/users/bbotgroup/projects", query_string="simple=true"
+            "/api/v4/users/bbotgroup/projects", query_string="simple=true", headers={"Authorization": "Bearer asdf"}
         ).respond_with_json(
             [
                 {

--- a/bbot/test/test_step_2/module_tests/test_module_hunterio.py
+++ b/bbot/test/test_step_2/module_tests/test_module_hunterio.py
@@ -2,7 +2,7 @@ from .base import ModuleTestBase
 
 
 class TestHunterio(ModuleTestBase):
-    config_overrides = {"modules": {"hunterio": {"api_key": "asdf"}}}
+    config_overrides = {"modules": {"hunterio": {"api_key": ["asdf", "1234", "4321", "fdsa"]}}}
 
     async def setup_before_prep(self, module_test):
         module_test.httpx_mock.add_response(
@@ -29,7 +29,7 @@ class TestHunterio(ModuleTestBase):
             },
         )
         module_test.httpx_mock.add_response(
-            url="https://api.hunter.io/v2/domain-search?domain=blacklanternsecurity.com&api_key=asdf&limit=100&offset=0",
+            url="https://api.hunter.io/v2/domain-search?domain=blacklanternsecurity.com&api_key=fdsa&limit=100&offset=0",
             json={
                 "data": {
                     "domain": "blacklanternsecurity.com",
@@ -91,6 +91,70 @@ class TestHunterio(ModuleTestBase):
                 },
             },
         )
+        module_test.httpx_mock.add_response(
+            url="https://api.hunter.io/v2/domain-search?domain=blacklanternsecurity.com&api_key=4321&limit=100&offset=100",
+            json={
+                "data": {
+                    "domain": "blacklanternsecurity.com",
+                    "disposable": False,
+                    "webmail": False,
+                    "accept_all": False,
+                    "pattern": "{first}",
+                    "organization": "Black Lantern Security",
+                    "description": None,
+                    "twitter": None,
+                    "facebook": None,
+                    "linkedin": "https://linkedin.com/company/black-lantern-security",
+                    "instagram": None,
+                    "youtube": None,
+                    "technologies": ["jekyll", "nginx"],
+                    "country": "US",
+                    "state": "CA",
+                    "city": "Night City",
+                    "postal_code": "12345",
+                    "street": "123 Any St",
+                    "emails": [
+                        {
+                            "value": "fdsa@blacklanternsecurity.com",
+                            "type": "generic",
+                            "confidence": 77,
+                            "sources": [
+                                {
+                                    "domain": "blacklanternsecurity.com",
+                                    "uri": "http://blacklanternsecurity.com",
+                                    "extracted_on": "2021-06-09",
+                                    "last_seen_on": "2023-03-21",
+                                    "still_on_page": True,
+                                }
+                            ],
+                            "first_name": None,
+                            "last_name": None,
+                            "position": None,
+                            "seniority": None,
+                            "department": "support",
+                            "linkedin": None,
+                            "twitter": None,
+                            "phone_number": None,
+                            "verification": {"date": None, "status": None},
+                        }
+                    ],
+                    "linked_domains": [],
+                },
+                "meta": {
+                    "results": 1,
+                    "limit": 100,
+                    "offset": 0,
+                    "params": {
+                        "domain": "blacklanternsecurity.com",
+                        "company": None,
+                        "type": None,
+                        "seniority": None,
+                        "department": None,
+                    },
+                },
+            },
+        )
 
     def check(self, module_test, events):
-        assert any(e.data == "asdf@blacklanternsecurity.com" for e in events), "Failed to detect email"
+        assert any(e.data == "asdf@blacklanternsecurity.com" for e in events), "Failed to detect email #1"
+        assert any(e.data == "fdsa@blacklanternsecurity.com" for e in events), "Failed to detect email #2"

--- a/bbot/test/test_step_2/module_tests/test_module_postman_download.py
+++ b/bbot/test/test_step_2/module_tests/test_module_postman_download.py
@@ -8,6 +8,7 @@ class TestPostman_Download(ModuleTestBase):
     async def setup_before_prep(self, module_test):
         module_test.httpx_mock.add_response(
             url="https://api.getpostman.com/me",
+            match_headers={"X-Api-Key": "asdf"},
             json={
                 "user": {
                     "id": 000000,
@@ -236,6 +237,7 @@ class TestPostman_Download(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.getpostman.com/workspaces/3a7e4bdc-7ff7-4dd4-8eaa-61ddce1c3d1b",
+            match_headers={"X-Api-Key": "asdf"},
             json={
                 "workspace": {
                     "id": "3a7e4bdc-7ff7-4dd4-8eaa-61ddce1c3d1b",
@@ -330,6 +332,7 @@ class TestPostman_Download(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.getpostman.com/environments/10197090-f770f816-9c6a-40f7-bde3-c0855d2a1089",
+            match_headers={"X-Api-Key": "asdf"},
             json={
                 "environment": {
                     "id": "f770f816-9c6a-40f7-bde3-c0855d2a1089",
@@ -350,6 +353,7 @@ class TestPostman_Download(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.getpostman.com/collections/10197090-2aab9fd0-3715-4abe-8bb0-8cb0264d023f",
+            match_headers={"X-Api-Key": "asdf"},
             json={
                 "collection": {
                     "info": {

--- a/bbot/test/test_step_2/module_tests/test_module_rapiddns.py
+++ b/bbot/test/test_step_2/module_tests/test_module_rapiddns.py
@@ -8,7 +8,7 @@ class TestRapidDNS(ModuleTestBase):
 <td>asdf.blacklanternsecurity.com</td>
 <td><a href="/sameip/asdf.blacklanternsecurity.com.?t=cname#result" target="_blank" title="asdf.blacklanternsecurity.com. same ip website">asdf.blacklanternsecurity.com.</a>"""
 
-    async def setup_before_prep(self, module_test):
+    async def setup_after_prep(self, module_test):
         module_test.module.abort_if = lambda e: False
         module_test.httpx_mock.add_response(
             url=f"https://rapiddns.io/subdomain/blacklanternsecurity.com?full=1#result", text=self.web_body
@@ -21,7 +21,7 @@ class TestRapidDNS(ModuleTestBase):
 class TestRapidDNSAbortThreshold1(TestRapidDNS):
     module_name = "rapiddns"
 
-    async def setup_before_prep(self, module_test):
+    async def setup_after_prep(self, module_test):
         self.url_count = {}
 
         async def custom_callback(request):

--- a/bbot/test/test_step_2/module_tests/test_module_rapiddns.py
+++ b/bbot/test/test_step_2/module_tests/test_module_rapiddns.py
@@ -1,3 +1,5 @@
+import httpx
+
 from .base import ModuleTestBase
 
 
@@ -6,7 +8,7 @@ class TestRapidDNS(ModuleTestBase):
 <td>asdf.blacklanternsecurity.com</td>
 <td><a href="/sameip/asdf.blacklanternsecurity.com.?t=cname#result" target="_blank" title="asdf.blacklanternsecurity.com. same ip website">asdf.blacklanternsecurity.com.</a>"""
 
-    async def setup_after_prep(self, module_test):
+    async def setup_before_prep(self, module_test):
         module_test.module.abort_if = lambda e: False
         module_test.httpx_mock.add_response(
             url=f"https://rapiddns.io/subdomain/blacklanternsecurity.com?full=1#result", text=self.web_body
@@ -14,3 +16,93 @@ class TestRapidDNS(ModuleTestBase):
 
     def check(self, module_test, events):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
+
+
+class TestRapidDNSAbortThreshold1(TestRapidDNS):
+    module_name = "rapiddns"
+
+    async def setup_before_prep(self, module_test):
+        self.url_count = {}
+
+        async def custom_callback(request):
+            url = str(request.url)
+            try:
+                self.url_count[url] += 1
+            except KeyError:
+                self.url_count[url] = 1
+            raise httpx.TimeoutException("timeout")
+
+        module_test.httpx_mock.add_callback(custom_callback)
+
+        await module_test.mock_dns(
+            {
+                "blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+                "evilcorp.com": {"A": ["127.0.0.11"]},
+                "evilcorp.net": {"A": ["127.0.0.22"]},
+                "evilcorp.co.uk": {"A": ["127.0.0.33"]},
+            }
+        )
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 10
+        assert module_test.module.errored == False
+        assert module_test.module._api_request_failures == 3
+        assert module_test.module.api_retries == 3
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {"blacklanternsecurity.com"}
+        assert self.url_count == {
+            "https://rapiddns.io/subdomain/blacklanternsecurity.com?full=1#result": 3,
+        }
+
+
+class TestRapidDNSAbortThreshold2(TestRapidDNSAbortThreshold1):
+    targets = ["blacklanternsecurity.com", "evilcorp.com"]
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 10
+        assert module_test.module.errored == False
+        assert module_test.module._api_request_failures == 6
+        assert module_test.module.api_retries == 3
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {"blacklanternsecurity.com", "evilcorp.com"}
+        assert self.url_count == {
+            "https://rapiddns.io/subdomain/blacklanternsecurity.com?full=1#result": 3,
+            "https://rapiddns.io/subdomain/evilcorp.com?full=1#result": 3,
+        }
+
+
+class TestRapidDNSAbortThreshold3(TestRapidDNSAbortThreshold1):
+    targets = ["blacklanternsecurity.com", "evilcorp.com", "evilcorp.net"]
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 10
+        assert module_test.module.errored == False
+        assert module_test.module._api_request_failures == 9
+        assert module_test.module.api_retries == 3
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {
+            "blacklanternsecurity.com",
+            "evilcorp.com",
+            "evilcorp.net",
+        }
+        assert self.url_count == {
+            "https://rapiddns.io/subdomain/blacklanternsecurity.com?full=1#result": 3,
+            "https://rapiddns.io/subdomain/evilcorp.com?full=1#result": 3,
+            "https://rapiddns.io/subdomain/evilcorp.net?full=1#result": 3,
+        }
+
+
+class TestRapidDNSAbortThreshold4(TestRapidDNSAbortThreshold1):
+    targets = ["blacklanternsecurity.com", "evilcorp.com", "evilcorp.net", "evilcorp.co.uk"]
+
+    def check(self, module_test, events):
+        assert module_test.module.api_failure_abort_threshold == 10
+        assert module_test.module.errored == True
+        assert module_test.module._api_request_failures == 10
+        assert module_test.module.api_retries == 3
+        assert set([e.data for e in events if e.type == "DNS_NAME"]) == {
+            "blacklanternsecurity.com",
+            "evilcorp.com",
+            "evilcorp.net",
+            "evilcorp.co.uk",
+        }
+        assert len(self.url_count) == 4
+        assert list(self.url_count.values()).count(3) == 3
+        assert list(self.url_count.values()).count(1) == 1

--- a/docs/scanning/presets.md
+++ b/docs/scanning/presets.md
@@ -77,7 +77,10 @@ config:
     securitytrails:
       api_key: 21a270d5f59c9b05813a72bb41707266
     virustotal:
-      api_key: 4f41243847da693a4f356c0486114bc6
+      # multiple API keys are allowed
+      api_key:
+        - 4f41243847da693a4f356c0486114bc6
+        - 5bc6ed268ab6488270e496d3183a1a27
 ```
 
 To execute your custom preset, you do:


### PR DESCRIPTION
Addresses https://github.com/blacklanternsecurity/bbot/issues/1601.

TODO:
- [x] Add support for multiple API keys per module
- [x] Tests for multiple API keys
- [x] Tests for multiple API keys + api_page_iter
- [x] Tests for `failed_request_abort_threshold`