### PR TITLE
Fix parent_url() to remove querystring

### DIFF
--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -365,7 +365,7 @@ def parent_url(u):
     if path.parent == path:
         return None
     else:
-        return urlunparse(parsed._replace(path=str(path.parent)))
+        return urlunparse(parsed._replace(path=str(path.parent), query=''))
 
 
 def url_parents(u):

--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -365,7 +365,7 @@ def parent_url(u):
     if path.parent == path:
         return None
     else:
-        return urlunparse(parsed._replace(path=str(path.parent), query=''))
+        return urlunparse(parsed._replace(path=str(path.parent), query=""))
 
 
 def url_parents(u):

--- a/bbot/test/test_step_1/test_helpers.py
+++ b/bbot/test/test_step_1/test_helpers.py
@@ -49,6 +49,8 @@ async def test_helpers_misc(helpers, scan, bbot_scanner, bbot_httpserver):
     assert helpers.url_depth("http://evilcorp.com/") == 0
     assert helpers.url_depth("http://evilcorp.com") == 0
 
+    assert helpers.parent_url("http://evilcorp.com/subdir1/subdir2?foo=bar") == "http://evilcorp.com/subdir1"
+
     ### MISC ###
     assert helpers.is_domain("evilcorp.co.uk")
     assert not helpers.is_domain("www.evilcorp.co.uk")


### PR DESCRIPTION
When querystring was present (like when parameter extraction is enabled) the parent_url helper was retaining the querystring as it traversed up the directory structure, leading to malformed URLs being speculated.