### PR TITLE
Update trufflehog to 3.82.8

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.7",
+        "version": "3.82.8",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Update retracted bluemonday version by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3369
* Log skipped files on debug level by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3383
* Enhanced the easyinsight detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3384
* [Fix] Snowflake privatelink Support by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3286
* fix(deps): update module google.golang.org/api to v0.200.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3391
* Updated Fastly Personal Token Detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3386
* [chore] - Manually upgrade Github dep by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3387
* Separate detector tests into unit/integration by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3274
* fix(deps): update golang.org/x/exp digest to f66d83c by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3389
* fix: pr template link to golangci-lint by @JonZeolla in https://github.com/trufflesecurity/trufflehog/pull/3392
* Add SliceContainsString common util by @bill-rich in https://github.com/trufflesecurity/trufflehog/pull/3395

## New Contributors
* @JonZeolla made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/3392

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.7...v3.82.8