### PR TITLE
Update trufflehog to 3.82.11

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.9",
+        "version": "3.82.11",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Revert "Compress release with UPX" by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3455


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.10...v3.82.11