### PR TITLE
Update trufflehog to 3.82.13

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.11",
+        "version": "3.82.13",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* [fix] - Inadvertent s3 body close by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3491
* [chore] - update error messages by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3490
* feat: fixed validation logic for `cannyio` by @sahil9001 in https://github.com/trufflesecurity/trufflehog/pull/3482
* feat: validation & verification fix for `apiscience` to `apimetrics` by @sahil9001 in https://github.com/trufflesecurity/trufflehog/pull/3475
* fix(deps): update module github.com/fatih/color to v1.18.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3492
* Re-order log context fields by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3430
* fix(deps): update module google.golang.org/api to v0.202.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3496
* fix: added correct verification endpoint & validation logic for alegra by @sahil9001 in https://github.com/trufflesecurity/trufflehog/pull/3437
* Delete unused logging code by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3504
* remove debug log by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3505
* fix: added correct api endpoint for verification & logic for Aeroworkflow by @sahil9001 in https://github.com/trufflesecurity/trufflehog/pull/3435


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.82.12...v3.82.13