### PR TITLE
Reduce Pytest Output in GitHub Action

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -61,3 +61,4 @@ jobs:
           poetry env use python3.11
           poetry install
           poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=DEBUG .
+          poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no .

--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -61,4 +61,4 @@ jobs:
           poetry env use python3.11
           poetry install
           poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=DEBUG .
-          poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no .
+          poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-capture-level=INFO --log-file=pytest_debug.log --show-capture=no .

--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -61,4 +61,4 @@ jobs:
           poetry env use python3.11
           poetry install
           poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=DEBUG .
-          poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-capture-level=INFO --log-file=pytest_debug.log --show-capture=no .
+          poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           poetry install
       - name: Run tests
         run: |
-          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-capture-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
+          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
       - name: Upload Debug Logs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           poetry install
       - name: Run tests
         run: |
-          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
+          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-capture-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
       - name: Upload Debug Logs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,12 @@ jobs:
           poetry install
       - name: Run tests
         run: |
-          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
+          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-level=INFO --log-file=pytest_debug.log --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
+      - name: Upload Debug Logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-debug-logs
+          path: pytest_debug.log
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
           poetry install
       - name: Run tests
         run: |
-          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-level=INFO --log-file=pytest_debug.log --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
+          poetry run pytest --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --log-level=DEBUG --log-file=pytest_debug.log --show-capture=no --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
       - name: Upload Debug Logs
         uses: actions/upload-artifact@v3
         with:

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -25,6 +25,10 @@ else:
     for h in root_logger.handlers:
         h.addFilter(lambda x: x.levelname not in ("STDOUT", "TRACE"))
 
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.INFO)  # Prevent DEBUG logs from going to console
+root_logger.addHandler(console_handler)
+
 CORE.merge_default(test_config)
 
 

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -13,6 +13,7 @@ from bbot.core import CORE
 from bbot.core.helpers.misc import execute_sync_or_async
 from bbot.core.helpers.interactsh import server_list as interactsh_servers
 
+root_logger = logging.getLogger()
 
 test_config = OmegaConf.load(Path(__file__).parent / "test.conf")
 if test_config.get("debug", False):
@@ -21,7 +22,6 @@ if test_config.get("debug", False):
     CORE.logger.log_level = logging.DEBUG
 else:
     # silence stdout + trace
-    root_logger = logging.getLogger()
     for h in root_logger.handlers:
         h.addFilter(lambda x: x.levelname not in ("STDOUT", "TRACE"))
 


### PR DESCRIPTION
Full log files will still be available via a separate file. GitHub Actions are not capable of displaying the level of output we are currently producing.