### PR TITLE
Update trufflehog to 3.83.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.82.13",
+        "version": "3.83.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* standardize email pattern by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3524
* strip symbol table and DWARF generation by @zricethezav in https://github.com/trufflesecurity/trufflehog/pull/3534
* gcp cred not set by @zricethezav in https://github.com/trufflesecurity/trufflehog/pull/3535


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.83.0...v3.83.1