### PR TITLE
Update trufflehog to 3.83.2

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.83.1",
+        "version": "3.83.2",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module github.com/brianvoe/gofakeit/v7 to v7.1.2 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3536
* fixed gitlab extradata overwriting by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3537


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.83.1...v3.83.2