### PR TITLE
Update trufflehog to 3.83.4

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.83.3",
+        "version": "3.83.4",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module github.com/azuread/microsoft-authentication-library-for-go to v1.3.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3561
* [Fix] Twitter analyzer panics by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3565
* added pattern test cases for all detectors starting with Alphabet `a` by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3539
* added pattern test cases for detectors starting with b by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3559


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.83.3...v3.83.4