### PR TITLE
Update trufflehog to 3.83.6

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.83.4",
+        "version": "3.83.6",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Log why false positives are skipped by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3579
* Log false positive result as string by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3582


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.83.5...v3.83.6