### PR TITLE
Fix preservation of scan id at scan init

### DIFF
--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -126,7 +126,7 @@ class Scanner:
         self._success = False
 
         if scan_id is not None:
-            self.id = str(id)
+            self.id = str(scan_id)
         else:
             self.id = f"SCAN:{sha1(rand_string(20)).hexdigest()}"
 


### PR DESCRIPTION
I was reading through the codebase & noticed this change happened here: https://github.com/blacklanternsecurity/bbot/commit/02acd94d67c26821b8b8aa79ccc01d2aa6ae09ad#diff-c6756c35a5fb1d7b87dc0ed3d33a2d211374dc196f245d26a362c82c8c346d5cR131

It _looked_ like an unintentional regression, so I thought I'd open a pr to check

(`id` is a python builtin function, and `str(id)` returns):
```py
cmyui@Joshs-MacBook-Pro ~ % python3
Python 3.13.0 (main, Oct  7 2024, 05:02:14) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> str(id)
'<built-in function id>'
```