### PR TITLE
Keep the dict sorted by keys to spot two duplicates

### DIFF
--- a/bbot/core/helpers/libmagic.py
+++ b/bbot/core/helpers/libmagic.py
@@ -15,54 +15,52 @@ def get_compression(mime_type):
     mime_type = mime_type.lower()
     # from https://github.com/cdgriffith/puremagic/blob/master/puremagic/magic_data.json
     compression_map = {
-        "application/gzip": "gzip",  # Gzip compressed file
-        "application/zip": "zip",  # Zip archive
-        "application/x-bzip2": "bzip2",  # Bzip2 compressed file
-        "application/x-xz": "xz",  # XZ compressed file
-        "application/x-7z-compressed": "7z",  # 7-Zip archive
-        "application/vnd.rar": "rar",  # RAR archive
-        "application/x-lzma": "lzma",  # LZMA compressed file
-        "application/x-compress": "compress",  # Unix compress file
-        "application/zstd": "zstd",  # Zstandard compressed file
-        "application/x-lz4": "lz4",  # LZ4 compressed file
-        "application/x-tar": "tar",  # Tar archive
-        "application/x-zip-compressed-fb2": "zip",  # Zip archive (FB2)
-        "application/epub+zip": "zip",  # EPUB book (Zip archive)
-        "application/pak": "pak",  # PAK archive
-        "application/x-lha": "lha",  # LHA archive
         "application/arj": "arj",  # ARJ archive
-        "application/vnd.ms-cab-compressed": "cab",  # Microsoft Cabinet archive
-        "application/x-sit": "sit",  # StuffIt archive
         "application/binhex": "binhex",  # BinHex encoded file
-        "application/x-lrzip": "lrzip",  # Long Range ZIP
-        "application/x-alz": "alz",  # ALZip archive
-        "application/x-tgz": "tgz",  # Gzip compressed Tar archive
-        "application/x-gzip": "gzip",  # Gzip compressed file
-        "application/x-lzip": "lzip",  # Lzip compressed file
-        "application/x-zstd-compressed-tar": "zstd",  # Zstandard compressed Tar archive
-        "application/x-lz4-compressed-tar": "lz4",  # LZ4 compressed Tar archive
-        "application/vnd.comicbook+zip": "zip",  # Comic book archive (Zip)
-        "application/vnd.palm": "palm",  # Palm OS data
+        "application/epub+zip": "zip",  # EPUB book (Zip archive)
         "application/fictionbook2+zip": "zip",  # FictionBook 2.0 (Zip)
         "application/fictionbook3+zip": "zip",  # FictionBook 3.0 (Zip)
-        "application/x-cpio": "cpio",  # CPIO archive
-        "application/x-java-pack200": "pack200",  # Java Pack200 archive
-        "application/x-par2": "par2",  # PAR2 recovery file
-        "application/x-rar-compressed": "rar",  # RAR archive
+        "application/gzip": "gzip",  # Gzip compressed file
         "application/java-archive": "zip",  # Java Archive (JAR)
-        "application/x-webarchive": "zip",  # Web archive (Zip)
+        "application/pak": "pak",  # PAK archive
         "application/vnd.android.package-archive": "zip",  # Android package (APK)
-        "application/x-itunes-ipa": "zip",  # iOS application archive (IPA)
-        "application/x-stuffit": "sit",  # StuffIt archive
-        "application/x-archive": "ar",  # Unix archive
-        "application/x-qpress": "qpress",  # Qpress archive
-        "application/x-xar": "xar",  # XAR archive
-        "application/x-ace": "ace",  # ACE archive
-        "application/x-zoo": "zoo",  # Zoo archive
-        "application/x-arc": "arc",  # ARC archive
-        "application/x-zstd-compressed-tar": "zstd",  # Zstandard compressed Tar archive
-        "application/x-lz4-compressed-tar": "lz4",  # LZ4 compressed Tar archive
         "application/vnd.comicbook-rar": "rar",  # Comic book archive (RAR)
+        "application/vnd.comicbook+zip": "zip",  # Comic book archive (Zip)
+        "application/vnd.ms-cab-compressed": "cab",  # Microsoft Cabinet archive
+        "application/vnd.palm": "palm",  # Palm OS data
+        "application/vnd.rar": "rar",  # RAR archive
+        "application/x-7z-compressed": "7z",  # 7-Zip archive
+        "application/x-ace": "ace",  # ACE archive
+        "application/x-alz": "alz",  # ALZip archive
+        "application/x-arc": "arc",  # ARC archive
+        "application/x-archive": "ar",  # Unix archive
+        "application/x-bzip2": "bzip2",  # Bzip2 compressed file
+        "application/x-compress": "compress",  # Unix compress file
+        "application/x-cpio": "cpio",  # CPIO archive
+        "application/x-gzip": "gzip",  # Gzip compressed file
+        "application/x-itunes-ipa": "zip",  # iOS application archive (IPA)
+        "application/x-java-pack200": "pack200",  # Java Pack200 archive
+        "application/x-lha": "lha",  # LHA archive
+        "application/x-lrzip": "lrzip",  # Long Range ZIP
+        "application/x-lz4-compressed-tar": "lz4",  # LZ4 compressed Tar archive
+        "application/x-lz4": "lz4",  # LZ4 compressed file
+        "application/x-lzip": "lzip",  # Lzip compressed file
+        "application/x-lzma": "lzma",  # LZMA compressed file
+        "application/x-par2": "par2",  # PAR2 recovery file
+        "application/x-qpress": "qpress",  # Qpress archive
+        "application/x-rar-compressed": "rar",  # RAR archive
+        "application/x-sit": "sit",  # StuffIt archive
+        "application/x-stuffit": "sit",  # StuffIt archive
+        "application/x-tar": "tar",  # Tar archive
+        "application/x-tgz": "tgz",  # Gzip compressed Tar archive
+        "application/x-webarchive": "zip",  # Web archive (Zip)
+        "application/x-xar": "xar",  # XAR archive
+        "application/x-xz": "xz",  # XZ compressed file
+        "application/x-zip-compressed-fb2": "zip",  # Zip archive (FB2)
+        "application/x-zoo": "zoo",  # Zoo archive
+        "application/x-zstd-compressed-tar": "zstd",  # Zstandard compressed Tar archive
+        "application/zip": "zip",  # Zip archive
+        "application/zstd": "zstd",  # Zstandard compressed file
     }
 
     return compression_map.get(mime_type, "")


### PR DESCRIPTION
Keep dict keys sorted to make it easy to spot missing keys and nearly impossible to insert duplicates.

% `ruff check bbot/core/helpers/libmagic.py`
```
bbot/core/helpers/libmagic.py:63:9: F601 Dictionary key literal `"application/x-zstd-compressed-tar"` repeated
   |
61 |         "application/x-zoo": "zoo",  # Zoo archive
62 |         "application/x-arc": "arc",  # ARC archive
63 |         "application/x-zstd-compressed-tar": "zstd",  # Zstandard compressed Tar archive
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F601
64 |         "application/x-lz4-compressed-tar": "lz4",  # LZ4 compressed Tar archive
65 |         "application/vnd.comicbook-rar": "rar",  # Comic book archive (RAR)
   |
   = help: Remove repeated key literal `"application/x-zstd-compressed-tar"`

bbot/core/helpers/libmagic.py:64:9: F601 Dictionary key literal `"application/x-lz4-compressed-tar"` repeated
   |
62 |         "application/x-arc": "arc",  # ARC archive
63 |         "application/x-zstd-compressed-tar": "zstd",  # Zstandard compressed Tar archive
64 |         "application/x-lz4-compressed-tar": "lz4",  # LZ4 compressed Tar archive
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ F601
65 |         "application/vnd.comicbook-rar": "rar",  # Comic book archive (RAR)
66 |     }
   |
   = help: Remove repeated key literal `"application/x-lz4-compressed-tar"`

Found 2 errors.
```
% `ruff rule F601`
# multi-value-repeated-key-literal (F601)

Derived from the **Pyflakes** linter.

Fix is sometimes available.

## What it does
Checks for dictionary literals that associate multiple values with the
same key.

## Why is this bad?
Dictionary keys should be unique. If a key is associated with multiple values,
the earlier values will be overwritten. Including multiple values for the
same key in a dictionary literal is likely a mistake.

## Example
```python
foo = {
    "bar": 1,
    "baz": 2,
    "baz": 3,
}
foo["baz"]  # 3
```

Use instead:
```python
foo = {
    "bar": 1,
    "baz": 2,
}
foo["baz"]  # 2
```

## References
- [Python documentation: Dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries)
