### PR TITLE
Update nuclei to 3.3.6

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.5",
+        "version": "3.3.6",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
## ⚠️ Breaking Changes:
* The `-enable-self-contained` or `-esc` flag is now required to load self-contained templates.
* The `-file` flag must be used to enable loading file templates.


## What's Changed

## 🎉 New Features
* Added analyzer support and time based delay analyzer for DAST mode by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/5781

See Analyzer documentation here: https://docs.projectdiscovery.io/templates/protocols/http/fuzzing-overview#analyzer 

* Added batch output support for JSONL output format by @kchason in https://github.com/projectdiscovery/nuclei/pull/5705

Configuration options for JSONL exporter:
```yaml
jsonl:
 # file is the file to export found JSONL result to
 file: ""
 # omit-raw whether to exclude the raw request and response from the output
 omit-raw: false
 # batch-size the number of records to keep in memory before writing them out to the JSONL file or 0 to disable batching (default)
 batch-size: 0
```

* Added ENV variable handling in dynamic secret file by @alban-stourbe-wmx in https://github.com/projectdiscovery/nuclei/pull/5835

Secrets can be set using ENV variables or defined with `-v` and `-env-vars` options:

### Env based secret
```yaml
variables:
   - key: password
     value: $PASSWORD
```

### Config file / Flag based secrets ( using -env-vars or -vars )
```yaml
variables:
     - key: password
     - value: {{password}}
```


## 🐞Bug Fixes
* Fixed code protocol template execution issues by @tarunKoyalwar in https://github.com/projectdiscovery/nuclei/pull/5767
* Fixed panic error in `-stats` option by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5774
* Fixed the issue with Jira tracker related to find request by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/5798
* Fixed workflow validation logic by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5805
* Fixed data race in `protocolstate`, `contextargs` and outdated tests by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5820


### Other Changes
* Disabled self-contained and file protocol templates as default by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5825

The `-esc` flag is implicitly enabled when `-code` flag is used.

* Added SDK functions to improve nuclei store and workflow access by @iuliu8899 in https://github.com/projectdiscovery/nuclei/pull/5766
* Fixed typo in headless protocol error message by @dmaciejak in https://github.com/projectdiscovery/nuclei/pull/5768
* Added missing backtick in DESIGN document by @chengehe in https://github.com/projectdiscovery/nuclei/pull/5789
* Improved GitHub Auto-Merge workflow by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5784
* Added SDK function to allow setting custom variables by @alban-stourbe-wmx in https://github.com/projectdiscovery/nuclei/pull/5678
* Improved GitHub workflows to run concurrently by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5818


## New Contributors
* @dmaciejak made their first contribution in https://github.com/projectdiscovery/nuclei/pull/5768
* @chengehe made their first contribution in https://github.com/projectdiscovery/nuclei/pull/5789

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.3.5...v3.3.6