### PR TITLE
Update trufflehog to 3.84.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.84.0",
+        "version": "3.84.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Remove `AzureAD/microsoft-authentication-library-for-go` by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3642
* Remove golang-jwt@v4 by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3644
* Detect GCP credentials in encoded JSON by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/2865
* fixed test failure by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3646
* [chore] - fix test by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3641
* fix(deps): update module google.golang.org/api to v0.208.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3647
* added godaddy detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3615
* updated buildkite detectors by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3611
* Recover general chunker panics by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3625
* Fix Algolia validity criteria by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3653
* fix(deps): update module google.golang.org/api to v0.209.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3655
* Separate org listing error from finding 0 members error cases by @trufflesteeeve in https://github.com/trufflesecurity/trufflehog/pull/3654
* [refactor] - Rename S3 ProgressTracker by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3652
* [feat] - Support S3 Source Resumption by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3570


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.84.0...v3.84.1