### PR TITLE
Replaced xml.etree with defusedxml

### DIFF
--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -894,7 +894,7 @@ def extract_params_xml(xml_data, compare_mode="getparam"):
         >>> extract_params_xml('<root><child1><child2>value</child2></child1></root>')
         {('root', None), ('child1', None), ('child2', 'value')}
     """
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     try:
         root = ET.fromstring(xml_data)

--- a/bbot/modules/bucket_file_enum.py
+++ b/bbot/modules/bucket_file_enum.py
@@ -1,5 +1,5 @@
 from bbot.modules.base import BaseModule
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 
 class bucket_file_enum(BaseModule):


### PR DESCRIPTION
In this PR ,

I have replaced `xml.etree.ElementTree.fromstring`  with `defusedxml.ElementTree.fromstring`

As `defusedxml.ElementTree.fromstring` is secure and `ET.fromstring(content)`  amking this function secure.