### PR TITLE
Fix/check domain for verbose debug

### DIFF
--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -57,6 +57,15 @@ async def _main():
             return
         # ensure arguments (-c config options etc.) are valid
         options = preset.args.parsed
+        # ensure  if verbose (-v) is used with -t else throw help
+        if options.verbose and not options.targets:
+            print("Error: Missing target. Use bbot -t [TARGET] -v [OTHER OPTIONS]")
+            sys.exit(1)
+
+        # ensure if debug (-d) flag is used without -t flag
+        if options.debug and not options.targets:
+            print("Error: Missing target. Use bbot -t [TARGET] -d [OTHER OPTIONS] .")
+            sys.exit(1)
 
         # print help if no arguments
         if len(sys.argv) == 1:

--- a/bbot/core/helpers/cache.py
+++ b/bbot/core/helpers/cache.py
@@ -22,10 +22,12 @@ def cache_get(self, key, text=True, cache_hrs=24 * 7):
             else:
                 open_kwargs["mode"] = "rb"
             log.debug(f'Using cached content for "{key}"')
-            return open(filename, **open_kwargs).read()
+            # Using a  block to ensure the file is closed automatically
+            with open(filename, **open_kwargs) as f:
+                return f.read()
         else:
             log.debug(f'Cached content for "{key}" is older than {cache_hrs:,} hours')
-
+    return None
 
 def cache_put(self, key, content):
     """

--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -894,7 +894,7 @@ def extract_params_xml(xml_data, compare_mode="getparam"):
         >>> extract_params_xml('<root><child1><child2>value</child2></child1></root>')
         {('root', None), ('child1', None), ('child2', 'value')}
     """
-    import xml.etree.ElementTree as ET
+    import defusedxml.ElementTree as ET
 
     try:
         root = ET.fromstring(xml_data)

--- a/bbot/modules/bucket_file_enum.py
+++ b/bbot/modules/bucket_file_enum.py
@@ -1,5 +1,5 @@
 from bbot.modules.base import BaseModule
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 
 class bucket_file_enum(BaseModule):


### PR DESCRIPTION
**Added Validation for -d (debug) and -v (verbose) Flag W**

In this PR i have Implemented a check to **ensure that if the -d and -v flag  is used without the -t flag (target), the program displays an error message and shows the help section.**

This enhancement ensures that users are informed about the `missing -t argument when using the -d  and  -v flag.`



**Before Changes** :

![beforecheck](https://github.com/user-attachments/assets/a45d1f93-06f3-45d2-a07d-291c4a3dcf75)

![bef](https://github.com/user-attachments/assets/93c2abcb-074e-46fd-9bdd-b0086cb99303)


**After Changes** Clean Terminal with help usage:

![afterchag](https://github.com/user-attachments/assets/aa06873d-f305-4ad7-a55a-32b729030837)


