### PR TITLE
dependabot.yml: GitHub Action update PRs target-branch: "dev"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,4 @@ updates:
           - "*"  # Group all Actions updates into a single larger pull request
     schedule:
       interval: weekly
+    target-branch: "dev" 


### PR DESCRIPTION
Copied from line 7 above.  The default branch is not the contribution branch.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch