### PR TITLE
Update nuclei to 3.3.7

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.6",
+        "version": "3.3.7",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
## What's Changed

## 🎉 New Features
* Added `OS_MAX_THREADS_ENV` environment variable to control the maximum number of OS threads the Go program can utilize by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5622
* Added `-enable-global-matchers`option to control the execution of global matchers by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5857

## 🐞Bug Fixes
* Fixed template signing signature issue caused by OS-specific line breaks (CRLF vs LF) by @tarunKoyalwar in https://github.com/projectdiscovery/nuclei/pull/5869
* Fixed trailing comma issue in JSONL exporeter by @bf-rbrown in https://github.com/projectdiscovery/nuclei/pull/5861
* Fixed template listing issue by ensuring default settings are respected by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5846


## New Contributors
* @bf-rbrown made their first contribution in https://github.com/projectdiscovery/nuclei/pull/5861

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.3.6...v3.3.7