### PR TITLE
Update trufflehog to 3.86.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.84.2",
+        "version": "3.86.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update golang.org/x/exp digest to 1443442 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3758
* fix(deps): update module google.golang.org/api to v0.211.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3759
* updated testingbot detector and it's integration tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3763
* [Fix] detector's integration tests starting with alphabet 'e' & 'f' by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3764
* [Fix] detector's integration tests starting with alphabet 'g' by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3765
* [refactor] - s3 metrics by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3760
* fix(deps): update golang.org/x/exp digest to 1829a12 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3761
* fix(deps): update module golang.org/x/crypto to v0.31.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3767


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.86.0...v3.86.1