### PR TITLE
Update trufflehog to 3.87.0

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.86.1",
+        "version": "3.87.0",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* updated tickettailor detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3766
* Added pattern unit tests for detectors starting with the letters r through s by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3752
* [UPDATE] Updated plaidkey detector results, and added uniqueness check by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3709
* updated and fixed typeform detectors by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3769
* Added pattern unit tests for detectors starting with the letters w through z by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3771
* fixed vouchery detector integration tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3775
* fix(deps): update module github.com/jedib0t/go-pretty/v6 to v6.6.5 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3777
* fix(deps): update module pault.ag/go/debian to v0.18.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3778
* [fix] - PrefixRegex test by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3780
* fix: corrected verification endpoint & validation logic for bombbomb by @sahil9001 in https://github.com/trufflesecurity/trufflehog/pull/3462
* updated pusher channel key detector and fixed it's integration tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3782
* Make |detectionTimeout| configurable by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3768
* fix(deps): update module github.com/go-ldap/ldap/v3 to v3.4.9 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3781
* fix(deps): update golang.org/x/exp digest to 4a55095 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3779
* fix(deps): update github.com/mholt/archives digest to 23e0af8 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3785
* fix(deps): update module google.golang.org/api to v0.212.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3786
* fix(deps): update module google.golang.org/protobuf to v1.36.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3787
* fix(deps): update golang.org/x/exp digest to b2144cd by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3788


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.86.1...v3.87.0