### PR TITLE
Update trufflehog to 3.87.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.87.0",
+        "version": "3.87.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module google.golang.org/api to v0.213.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3790
* [fix] - use typed const by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3792
* fix(deps): update module github.com/elastic/go-elasticsearch/v8 to v8.17.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3789
* [fix] - integer types by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3793


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.87.0...v3.87.1