### PR TITLE
Update trufflehog to 3.87.2

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.87.1",
+        "version": "3.87.2",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fix(deps): update module golang.org/x/net to v0.33.0 [security] by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3800


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.87.1...v3.87.2