### PR TITLE
Update trufflehog to 3.88.0

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.87.2",
+        "version": "3.88.0",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Added new detector for Twilio APIKey by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3803
* Update docs from --only-verified with --results by @smoy in https://github.com/trufflesecurity/trufflehog/pull/3798
* fixed plivo detector integration test by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3794
* fixed integration test for opsgenie detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3795
* fixed integration test for neutrinoapi detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3796
* fixed netlify detector integration tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3797
* fixed website pulse detector integration tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3776
* Disabled blocknative detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3804
* [Fix] detector's integration tests starting with alphabet 'm' by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3807
* fix(deps): update module google.golang.org/api to v0.214.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3806
* fix(deps): update module github.com/googleapis/gax-go/v2 to v2.14.1 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3805
* Implement verification cache by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3801

## New Contributors
* @smoy made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/3798

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.87.2...v3.88.0