### PR TITLE
Update trufflehog to 3.88.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.0",
+        "version": "3.88.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* fixed github issue 3774 for custom detector secret size by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3816
* fixed github issue 3819 for endpoint customizer tests by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3823
* fixed github issue 3821 for string shannon entropy test by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3824
* fixed bombbomb detector pattern test as part of issue 3817 by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3825
* Stop using context.TODO in archive handler by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3809
* fix(deps): update module github.com/go-git/go-git/v5 to v5.13.0 [security] by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3829


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.0...v3.88.1