### PR TITLE
Update nuclei to 3.3.8

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.7",
+        "version": "3.3.8",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
## What's Changed

### 🐞 Bug Fixes
* Fixed missing browser initilization by @Mzack9999 in https://github.com/projectdiscovery/nuclei/pull/5896
* Fixed proxy configuration for concurrent requests, enabling isolated and parallel handling by @ShubhamRasal in https://github.com/projectdiscovery/nuclei/pull/5903
* Fixed recursive struct validation during JSON marshaling by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5883
* Fixed unresolved `interactsh-url` with `self-contained` for raw http templates by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5938
* Fixed a nil error associated with a previous internal event (#5949) by @iuliu8899 in https://github.com/projectdiscovery/nuclei/pull/5950

### Other Changes
* Updated function names in comments by @lvyaoting in https://github.com/projectdiscovery/nuclei/pull/5886
* Made markdown filename shorter by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5899
* Added support grouped dependency updates in dependabot by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5923
* Added encoding support for malformed URLs by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/5902
* Made sure the input URL is trimmed when the `-scan-all-ips` option is enabled by @p-l- in https://github.com/projectdiscovery/nuclei/pull/5897
* Made sure NoHostErrors is set by @iuliu8899 in https://github.com/projectdiscovery/nuclei/pull/5783


## New Contributors
* @p-l- made their first contribution in https://github.com/projectdiscovery/nuclei/pull/5897

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.3.7...v3.3.8