### PR TITLE
Fix Teams outputting UNKNOWN subheading

### DIFF
--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -62,7 +62,7 @@ class Teams(WebhookOutputModule):
     def get_severity_color(self, event):
         color = "Accent"
         if event.type == "VULNERABILITY":
-            severity = event.data.get("severity", "UNKNOWN")
+            severity = event.data.get("severity", "INFO")
             if severity == "CRITICAL":
                 color = "Attention"
             elif severity == "HIGH":
@@ -96,7 +96,7 @@ class Teams(WebhookOutputModule):
         if event.type in ("VULNERABILITY", "FINDING"):
             subheading = {
                 "type": "TextBlock",
-                "text": event.data.get("severity", "UNKNOWN"),
+                "text": event.data.get("severity", "INFO"),
                 "spacing": "None",
                 "size": "Large",
                 "wrap": True,


### PR DESCRIPTION
The teams webhook outputs UNKNOWN as the subheading for a finding if the event has no `severity` field.

This PR changes that to INFO to make it less ambiguous.