### PR TITLE
Update trufflehog to 3.88.2

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.1",
+        "version": "3.88.2",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Deprecated RockSet and RestPack detectors by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3812
* [chore] - remove resumption option by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3830
* Update ScrapingBee detector by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3820
* Updated Slack detector. Added revoked token check by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3831


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.1...v3.88.2