### PR TITLE
Fix api_request in github_org and github_workflows modules

### DIFF
--- a/bbot/modules/ajaxpro.py
+++ b/bbot/modules/ajaxpro.py
@@ -62,7 +62,7 @@ class ajaxpro(BaseModule):
         self.debug("Ajaxpro detected, attempting to confirm exploitability")
         parsed_url = urlparse(detection_url)
         base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-        path = parsed_url.path.rsplit('/', 1)[0]
+        path = parsed_url.path.rsplit("/", 1)[0]
         full_url = f"{base_url}{path}/AjaxPro.Services.ICartService,AjaxPro.2.ashx"
 
         # Payload and headers defined inline

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1148,7 +1148,7 @@ class BaseModule:
             kwargs["url"] = new_url
 
             r = await self.helpers.request(**kwargs)
-            success = False if r is None else r.is_success
+            success = r is not None and self._api_response_is_success(r)
 
             if success:
                 self._api_request_failures = 0
@@ -1175,6 +1175,9 @@ class BaseModule:
             break
 
         return r
+
+    def _api_response_is_success(self, r):
+        return r.is_success
 
     async def api_page_iter(self, url, page_size=100, json=True, next_key=None, **requests_kwargs):
         """

--- a/bbot/modules/generic_ssrf.py
+++ b/bbot/modules/generic_ssrf.py
@@ -93,7 +93,7 @@ class Generic_SSRF(BaseSubmodule):
             ssrf_canary = f"{subdomain_tag}.{self.generic_ssrf.interactsh_domain}"
             self.generic_ssrf.parameter_subdomain_tags_map[subdomain_tag] = param
             query_string += f"{param}=http://{ssrf_canary}&"
-            test_paths.append((f"?{query_string.rstrip('&')}",subdomain_tag))
+            test_paths.append((f"?{query_string.rstrip('&')}", subdomain_tag))
         return test_paths
 
 
@@ -107,7 +107,6 @@ class Generic_SSRF_POST(BaseSubmodule):
     async def test(self, event):
         test_url = f"{event.data}"
 
-        
         post_data = {}
         for param in ssrf_params:
             subdomain_tag = self.generic_ssrf.helpers.rand_string(4, digits=False)
@@ -194,7 +193,7 @@ class generic_ssrf(BaseModule):
     async def interactsh_callback(self, r):
         full_id = r.get("full-id", None)
         subdomain_tag = full_id.split(".")[0]
-        
+
         if full_id:
             if "." in full_id:
                 match = self.interactsh_subdomain_tags.get(subdomain_tag)

--- a/bbot/modules/github_org.py
+++ b/bbot/modules/github_org.py
@@ -17,15 +17,16 @@ class github_org(github):
         "include_member_repos": "Also enumerate organization members' repositories",
     }
 
-    # we get lots of 404s, that's normal
-    _api_failure_abort_threshold = 9999999999
-
     scope_distance_modifier = 2
 
     async def setup(self):
         self.include_members = self.config.get("include_members", True)
         self.include_member_repos = self.config.get("include_member_repos", False)
         return await super().setup()
+
+    def _api_response_is_success(self, r):
+        # we allow 404s because they're normal
+        return r.is_success or getattr(r, "status_code", 0) == 404
 
     async def filter_event(self, event):
         if event.type == "SOCIAL":

--- a/bbot/modules/github_org.py
+++ b/bbot/modules/github_org.py
@@ -17,6 +17,9 @@ class github_org(github):
         "include_member_repos": "Also enumerate organization members' repositories",
     }
 
+    # we get lots of 404s, that's normal
+    _api_failure_abort_threshold = 9999999999
+
     scope_distance_modifier = 2
 
     async def setup(self):

--- a/bbot/modules/github_workflows.py
+++ b/bbot/modules/github_workflows.py
@@ -19,6 +19,9 @@ class github_workflows(github):
         "num_logs": "For each workflow fetch the last N successful runs logs (max 100)",
     }
 
+    # we get lots of 404s, that's normal
+    _api_failure_abort_threshold = 9999999999
+
     scope_distance_modifier = 2
 
     async def setup(self):

--- a/bbot/modules/github_workflows.py
+++ b/bbot/modules/github_workflows.py
@@ -19,9 +19,6 @@ class github_workflows(github):
         "num_logs": "For each workflow fetch the last N successful runs logs (max 100)",
     }
 
-    # we get lots of 404s, that's normal
-    _api_failure_abort_threshold = 9999999999
-
     scope_distance_modifier = 2
 
     async def setup(self):
@@ -32,6 +29,10 @@ class github_workflows(github):
         self.output_dir = self.scan.home / "workflow_logs"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
+
+    def _api_response_is_success(self, r):
+        # we allow 404s because they're normal
+        return r.is_success or getattr(r, "status_code", 0) == 404
 
     async def filter_event(self, event):
         if event.type == "CODE_REPOSITORY":

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -26,7 +26,7 @@ class iis_shortnames(BaseModule):
     options_desc = {
         "detect_only": "Only detect the vulnerability and do not run the shortname scanner",
         "max_node_count": "Limit how many nodes to attempt to resolve on any given recursion branch",
-        "speculate_magic_urls": "Attempt to discover iis 'magic' special folders"
+        "speculate_magic_urls": "Attempt to discover iis 'magic' special folders",
     }
     in_scope_only = True
 
@@ -239,15 +239,15 @@ class iis_shortnames(BaseModule):
                 "VULNERABILITY",
                 event,
                 context="{module} detected low {event.type}: IIS shortname enumeration",
-                tags=["iis-magic-url"]
+                tags=["iis-magic-url"],
             )
 
-
             if self.config.get("speculate_magic_urls") and "iis-magic-url" not in event.tags:
-
                 magic_url_bin = f"{normalized_url}bin::$INDEX_ALLOCATION/"
                 self.debug(f"making IIS magic URL: {magic_url_bin}")
-                magic_url_event = self.make_event(magic_url_bin, "URL", parent=event, tags=["iis-magic-url","status-403"])
+                magic_url_event = self.make_event(
+                    magic_url_bin, "URL", parent=event, tags=["iis-magic-url", "status-403"]
+                )
                 await self.scan.modules["iis_shortnames"].incoming_event_queue.put(magic_url_event)
 
             if not self.config.get("detect_only"):

--- a/bbot/test/test_step_2/module_tests/test_module_generic_ssrf.py
+++ b/bbot/test/test_step_2/module_tests/test_module_generic_ssrf.py
@@ -42,7 +42,9 @@ class TestGeneric_SSRF(ModuleTestBase):
 
     def check(self, module_test, events):
         assert any(
-            e.type == "VULNERABILITY" and "Out-of-band interaction: [Generic SSRF (GET)]" and "[Triggering Parameter: Dest]" in e.data["description"]
+            e.type == "VULNERABILITY"
+            and "Out-of-band interaction: [Generic SSRF (GET)]"
+            and "[Triggering Parameter: Dest]" in e.data["description"]
             for e in events
         ), "Failed to detect Generic SSRF (GET)"
         assert any(


### PR DESCRIPTION
As described in #2149, these two modules would often encounter 404's (From assumptions being made about endpoints existing).

These successive error responses would end up setting the `self._api_request_failures` to a value above the threshold so it would end up setting the error state in the module and prevent it from consuming more events.

To prevent this I have set the failure tolerance to a high number so as to not have the modules abort when they come across several repos(etc.) that do not exist