### PR TITLE
Fix the `raw_response` returned

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1406,7 +1406,9 @@ class HTTP_RESPONSE(URL_UNVERIFIED, DictEvent):
         """
         Formats the status code, headers, and body into a single string formatted as an HTTP/1.1 response.
         """
-        return f'{self.data["raw_header"]}{self.data["body"]}'
+        raw_header = self.data.get("raw_header", "")
+        body = self.data.get("body", "")
+        return f'{raw_header}{body}'
 
     @property
     def http_status(self):


### PR DESCRIPTION
When trufflehog would get a `raw_response` from a `HTTP_RESPONSE` event, it would cause an error if the response did not include a `body` attribute. #2152

This change uses a get to try and obtain both values from a dictionary and return an empty string if it cant get the body.