### PR TITLE
Reduce false positives with canary probe

### DIFF
--- a/bbot/modules/lightfuzz_submodules/base.py
+++ b/bbot/modules/lightfuzz_submodules/base.py
@@ -143,10 +143,6 @@ class BaseLightfuzz:
         allow_redirects=False,
     ):
 
-
-
-
-
         probe = self.outgoing_probe_value(probe)
 
         if event_type == "SPECULATIVE":

--- a/bbot/modules/reflected_parameters.py
+++ b/bbot/modules/reflected_parameters.py
@@ -19,8 +19,9 @@ class reflected_parameters(BaseModule):
         )
 
         if reflection_detected:
+            param_type = event.data.get("type", "UNKNOWN")
             description = (
-                f"GET Parameter value reflected in response body. Name: [{event.data['name']}] "
+                f"[{param_type}] Parameter value reflected in response body. Name: [{event.data['name']}] "
                 f"Source Module: [{str(event.module)}]"
             )
             if event.data.get("original_value"):
@@ -35,15 +36,16 @@ class reflected_parameters(BaseModule):
         probe_parameter_name = event.data["name"]
         probe_parameter_value = self.helpers.rand_string()
         canary_parameter_value = self.helpers.rand_string()
-        probe_url = self.helpers.add_get_params(
-            url, 
-            {
-                probe_parameter_name: probe_parameter_value,
-                "c4n4ry": canary_parameter_value
-            }
-        ).geturl()
 
-        probe_response = await self.helpers.request(probe_url, method="GET")
+        # Call the new function to send the probe with the canary
+        probe_response = await self.send_probe_with_canary(
+            event,
+            probe_parameter_name,
+            probe_parameter_value,
+            canary_parameter_value,
+            cookies=event.data.get("assigned_cookies", {}),
+            timeout=10
+        )
 
         # Check if the probe parameter value is reflected AND the canary is not
         if probe_response:
@@ -54,3 +56,34 @@ class reflected_parameters(BaseModule):
             )
             return reflection_result
         return False
+
+    async def send_probe_with_canary(self, event, parameter_name, parameter_value, canary_value, cookies, timeout=10):
+        method = "GET"
+        url = event.data["url"]
+        headers = {}
+        data = None
+        json_data = None
+
+        if event.data["type"] == "GETPARAM":
+            url = f"{url}?{parameter_name}={parameter_value}&c4n4ry={canary_value}"
+        elif event.data["type"] == "COOKIE":
+            cookies = {**cookies, parameter_name: f"{parameter_value}; c4n4ry={canary_value}"}
+        elif event.data["type"] == "HEADER":
+            headers = {parameter_name: f"{parameter_value}; c4n4ry={canary_value}"}
+        elif event.data["type"] == "POSTPARAM":
+            method = "POST"
+            data = {parameter_name: parameter_value, "c4n4ry": canary_value}
+        elif event.data["type"] == "BODYJSON":
+            method = "POST"
+            json_data = {parameter_name: parameter_value, "c4n4ry": canary_value}
+
+        response = await self.helpers.request(
+            method=method,
+            url=url,
+            headers=headers,
+            cookies=cookies,
+            data=data,
+            json=json_data,
+            timeout=timeout
+        )
+        return response

--- a/bbot/modules/reflected_parameters.py
+++ b/bbot/modules/reflected_parameters.py
@@ -35,19 +35,17 @@ class reflected_parameters(BaseModule):
         probe_parameter_name = event.data["name"]
         probe_parameter_value = self.helpers.rand_string()
         canary_parameter_value = self.helpers.rand_string()
-
-        # Add both the probe and canary parameters to the URL
         probe_url = self.helpers.add_get_params(
             url, 
             {
                 probe_parameter_name: probe_parameter_value,
-                "c4n4ry": canary_parameter_value  # Leet speak for "canary"
+                "c4n4ry": canary_parameter_value
             }
         ).geturl()
 
         probe_response = await self.helpers.request(probe_url, method="GET")
 
-        # Check if the probe parameter value is reflected and the canary is not
+        # Check if the probe parameter value is reflected AND the canary is not
         if probe_response:
             response_text = probe_response.text
             reflection_result = (

--- a/bbot/modules/reflected_parameters.py
+++ b/bbot/modules/reflected_parameters.py
@@ -31,10 +31,28 @@ class reflected_parameters(BaseModule):
             await self.emit_event(data, "FINDING", event)
 
     async def detect_reflection(self, event, url):
-        """Detects reflection by sending a probe with a random value."""
+        """Detects reflection by sending a probe with a random value and a canary parameter."""
         probe_parameter_name = event.data["name"]
         probe_parameter_value = self.helpers.rand_string()
-        probe_url = self.helpers.add_get_params(url, {probe_parameter_name: probe_parameter_value}).geturl()
-        self.debug(f"reflected_parameters Probe URL: {probe_url}")
+        canary_parameter_value = self.helpers.rand_string()
+
+        # Add both the probe and canary parameters to the URL
+        probe_url = self.helpers.add_get_params(
+            url, 
+            {
+                probe_parameter_name: probe_parameter_value,
+                "c4n4ry": canary_parameter_value  # Leet speak for "canary"
+            }
+        ).geturl()
+
         probe_response = await self.helpers.request(probe_url, method="GET")
-        return probe_response and probe_parameter_value in probe_response.text
+
+        # Check if the probe parameter value is reflected and the canary is not
+        if probe_response:
+            response_text = probe_response.text
+            reflection_result = (
+                probe_parameter_value in response_text and 
+                canary_parameter_value not in response_text
+            )
+            return reflection_result
+        return False

--- a/bbot/modules/reflected_parameters.py
+++ b/bbot/modules/reflected_parameters.py
@@ -13,10 +13,7 @@ class reflected_parameters(BaseModule):
 
     async def handle_event(self, event):
         url = event.data.get("url")
-        from_paramminer = str(event.module) == "paramminer_getparams"
-        reflection_detected = (
-            "http-reflection" in event.tags if from_paramminer else await self.detect_reflection(event, url)
-        )
+        reflection_detected = await self.detect_reflection(event, url)
 
         if reflection_detected:
             param_type = event.data.get("type", "UNKNOWN")
@@ -63,19 +60,22 @@ class reflected_parameters(BaseModule):
         headers = {}
         data = None
         json_data = None
+        params = {parameter_name: parameter_value, "c4n4ry": canary_value}
 
         if event.data["type"] == "GETPARAM":
             url = f"{url}?{parameter_name}={parameter_value}&c4n4ry={canary_value}"
         elif event.data["type"] == "COOKIE":
-            cookies = {**cookies, parameter_name: f"{parameter_value}; c4n4ry={canary_value}"}
+            cookies.update(params)
         elif event.data["type"] == "HEADER":
-            headers = {parameter_name: f"{parameter_value}; c4n4ry={canary_value}"}
+            headers.update(params)
         elif event.data["type"] == "POSTPARAM":
             method = "POST"
-            data = {parameter_name: parameter_value, "c4n4ry": canary_value}
+            data = params
         elif event.data["type"] == "BODYJSON":
             method = "POST"
-            json_data = {parameter_name: parameter_value, "c4n4ry": canary_value}
+            json_data = params
+
+        self.debug(f"Sending {method} request to {url} with headers: {headers}, cookies: {cookies}, data: {data}, json: {json_data}")
 
         response = await self.helpers.request(
             method=method,

--- a/bbot/modules/reflected_parameters.py
+++ b/bbot/modules/reflected_parameters.py
@@ -33,8 +33,6 @@ class reflected_parameters(BaseModule):
         probe_parameter_name = event.data["name"]
         probe_parameter_value = self.helpers.rand_string()
         canary_parameter_value = self.helpers.rand_string()
-
-        # Call the new function to send the probe with the canary
         probe_response = await self.send_probe_with_canary(
             event,
             probe_parameter_name,

--- a/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
+++ b/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
@@ -29,7 +29,7 @@ class TestReflected_parameters_fromexcavate(ModuleTestBase):
         assert any(
             e.type == "FINDING"
             and e.data["description"]
-            == "GET Parameter value reflected in response body. Name: [reflected] Source Module: [excavate] Original Value: [foo]"
+            == "[GETPARAM] Parameter value reflected in response body. Name: [reflected] Source Module: [excavate] Original Value: [foo]"
             for e in events
         )
 
@@ -40,7 +40,7 @@ class TestReflected_parameters_fromparamminer(TestParamminer_Getparams):
     def check(self, module_test, events):
         assert any(
             e.type == "FINDING"
-            and "GET Parameter value reflected in response body. Name: [id] Source Module: [paramminer_getparams]"
+            and "[GETPARAM] Parameter value reflected in response body. Name: [id] Source Module: [paramminer_getparams]"
             in e.data["description"]
             for e in events
         )

--- a/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
+++ b/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
@@ -1,8 +1,9 @@
-from .base import ModuleTestBase
+from .base import ModuleTestBase, tempwordlist
 from werkzeug.wrappers import Response
 import re
 
 from .test_module_paramminer_getparams import TestParamminer_Getparams
+
 
 
 class TestReflected_parameters_fromexcavate(ModuleTestBase):
@@ -32,6 +33,32 @@ class TestReflected_parameters_fromexcavate(ModuleTestBase):
             == "[GETPARAM] Parameter value reflected in response body. Name: [reflected] Source Module: [excavate] Original Value: [foo]"
             for e in events
         )
+
+class TestReflected_parameters_headers(TestReflected_parameters_fromexcavate):
+    modules_overrides = ["httpx", "reflected_parameters", "excavate", "paramminer_headers"]
+    config_overrides = {
+        "modules": {
+            "paramminer_headers": {"wordlist": tempwordlist(["junkword1", "tracestate"]), "recycle_words": True}
+        }
+    }
+
+    def request_handler(self, request):
+        headers = {k.lower(): v for k, v in request.headers.items()}
+        if "tracestate" in headers:
+            reflected_value = headers["tracestate"]
+            reflected_block = f'<html><div>{reflected_value}</div></html>'
+            return Response(reflected_block, status=200)
+        else:
+            return Response('<html><div></div></html>', status=200)
+
+    def check(self, module_test, events):
+        assert any(
+            e.type == "FINDING"
+            and e.data["description"]
+            == "[HEADER] Parameter value reflected in response body. Name: [tracestate] Source Module: [paramminer_headers]"
+            for e in events
+        )
+
 
 
 class TestReflected_parameters_fromparamminer(TestParamminer_Getparams):
@@ -65,5 +92,114 @@ class TestReflected_parameters_with_canary(TestReflected_parameters_fromexcavate
         # Ensure no findings are emitted when the canary is reflected
         assert not any(
             e.type == "FINDING"
+            for e in events
+        )
+
+class TestReflected_parameters_cookies(TestReflected_parameters_fromexcavate):
+    modules_overrides = ["httpx", "reflected_parameters", "excavate", "paramminer_cookies"]
+    config_overrides = {
+        "modules": {
+            "paramminer_cookies": {"wordlist": tempwordlist(["junkword1", "testcookie"]), "recycle_words": True}
+        }
+    }
+
+    def request_handler(self, request):
+        cookies = request.cookies
+        if "testcookie" in cookies:
+            reflected_value = cookies["testcookie"]
+            reflected_block = f'<html><div>{reflected_value}</div></html>'
+            return Response(reflected_block, status=200)
+        else:
+            return Response('<html><div></div></html>', status=200)
+
+    def check(self, module_test, events):
+        assert any(
+            e.type == "FINDING"
+            and e.data["description"]
+            == "[COOKIE] Parameter value reflected in response body. Name: [testcookie] Source Module: [paramminer_cookies]"
+            for e in events
+        )
+
+class TestReflected_parameters_postparams(TestReflected_parameters_fromexcavate):
+    modules_overrides = ["httpx", "reflected_parameters", "excavate"]
+
+    def request_handler(self, request):
+        form_data = request.form
+        if "testparam" in form_data:
+            reflected_value = form_data["testparam"]
+            reflected_block = f'<html><div>{reflected_value}</div></html>'
+            return Response(reflected_block, status=200)
+        else:
+            form_html = '''
+            <html>
+                <body>
+                    <form action="/" method="post">
+                        <input type="text" name="testparam" value="default_value">
+                        <input type="submit" value="Submit">
+                    </form>
+                </body>
+            </html>
+            '''
+            return Response(form_html, status=200)
+
+    def check(self, module_test, events):
+        assert any(
+            e.type == "FINDING"
+            and e.data["description"]
+            == "[POSTPARAM] Parameter value reflected in response body. Name: [testparam] Source Module: [excavate] Original Value: [default_value]"
+            for e in events
+        )
+
+class TestReflected_parameters_bodyjson(TestReflected_parameters_fromexcavate):
+    modules_overrides = ["httpx", "reflected_parameters", "excavate"]
+
+    def request_handler(self, request):
+        # Ensure the request is expecting JSON data
+        if request.content_type == 'application/json':
+            json_data = request.json
+            if "username" in json_data:
+                reflected_value = json_data["username"]
+                reflected_block = f'<html><div>{reflected_value}</div></html>'
+                return Response(reflected_block, status=200)
+        # Provide an HTML page with a jQuery AJAX call
+        jsonajax_extract_html = '''
+        <html>
+        <script>
+        function doLogin(e) {
+          e.preventDefault();
+          var username = $("#usernamefield").val();
+          var password = $("#passwordfield").val();
+          $.ajax({
+            url: '/api/auth',
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ username: username, password: password }),
+            success: function (r) {
+              window.location.replace("/demo");
+            },
+            error: function (r) {
+              if (r.status == 401) {
+                notify("Access denied");
+              } else {
+                notify(r.responseText);
+              }
+            }
+          });
+        }
+        </script>
+        <form action=/ method=GET><input type=text name="novalue"><button type=submit class=button>Submit</button></form>
+        </html>
+        '''
+        return Response(jsonajax_extract_html, status=200)
+
+    async def setup_after_prep(self, module_test):
+        expect_args = re.compile("/")
+        module_test.set_expect_requests_handler(expect_args=expect_args, request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        assert any(
+            e.type == "FINDING"
+            and e.data["description"]
+            == "[BODYJSON] Parameter value reflected in response body. Name: [username] Source Module: [excavate]"
             for e in events
         )

--- a/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
+++ b/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
@@ -12,11 +12,13 @@ class TestReflected_parameters_fromexcavate(ModuleTestBase):
     def request_handler(self, request):
         normal_block = '<html><a href="/?reflected=foo">foo</a></html>'
         qs = str(request.query_string.decode())
-        if "reflected=" in qs:
-            value = qs.split("=")[1]
-            if "&" in value:
-                value = value.split("&")[0]
-            reflected_block = f'<html><a href="/?reflected={value}"></a></html>'
+        if qs:
+            # Split the query string into key-value pairs
+            params = qs.split("&")
+            # Construct the reflected block with all parameters
+            reflected_block = '<html><a href="/?'
+            reflected_block += '&'.join(params)
+            reflected_block += '"></a></html>'
             return Response(reflected_block, status=200)
         else:
             return Response(normal_block, status=200)
@@ -42,5 +44,28 @@ class TestReflected_parameters_fromparamminer(TestParamminer_Getparams):
             e.type == "FINDING"
             and "GET Parameter value reflected in response body. Name: [id] Source Module: [paramminer_getparams]"
             in e.data["description"]
+            for e in events
+        )
+
+class TestReflected_parameters_with_canary(TestReflected_parameters_fromexcavate):
+
+    def request_handler(self, request):
+        normal_block = '<html><a href="/?reflected=foo">foo</a></html>'
+        qs = str(request.query_string.decode())
+        if qs:
+            # Split the query string into key-value pairs
+            params = qs.split("&")
+            # Construct the reflected block with all parameters
+            reflected_block = '<html><a href="/?'
+            reflected_block += '&'.join(params)
+            reflected_block += '"></a></html>'
+            return Response(reflected_block, status=200)
+        else:
+            return Response(normal_block, status=200)
+
+    def check(self, module_test, events):
+        # Ensure no findings are emitted when the canary is reflected
+        assert not any(
+            e.type == "FINDING"
             for e in events
         )

--- a/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
+++ b/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
@@ -12,13 +12,11 @@ class TestReflected_parameters_fromexcavate(ModuleTestBase):
     def request_handler(self, request):
         normal_block = '<html><a href="/?reflected=foo">foo</a></html>'
         qs = str(request.query_string.decode())
-        if qs:
-            # Split the query string into key-value pairs
-            params = qs.split("&")
-            # Construct the reflected block with all parameters
-            reflected_block = '<html><a href="/?'
-            reflected_block += '&'.join(params)
-            reflected_block += '"></a></html>'
+        if "reflected=" in qs:
+            value = qs.split("=")[1]
+            if "&" in value:
+                value = value.split("&")[0]
+            reflected_block = f'<html><a href="/?reflected={value}"></a></html>'
             return Response(reflected_block, status=200)
         else:
             return Response(normal_block, status=200)

--- a/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
+++ b/bbot/test/test_step_2/module_tests/test_module_reflected_parameters.py
@@ -3,6 +3,7 @@ from werkzeug.wrappers import Response
 import re
 
 from .test_module_paramminer_getparams import TestParamminer_Getparams
+from .test_module_paramminer_headers import helper
 
 
 
@@ -59,10 +60,29 @@ class TestReflected_parameters_headers(TestReflected_parameters_fromexcavate):
             for e in events
         )
 
-
-
 class TestReflected_parameters_fromparamminer(TestParamminer_Getparams):
     modules_overrides = ["httpx", "paramminer_getparams", "reflected_parameters"]
+
+    def request_handler(self, request):
+        normal_block = '<html></html>'
+        qs = str(request.query_string.decode())
+        if "id=" in qs:
+            value = qs.split("=")[1]
+            if "&" in value:
+                value = value.split("&")[0]
+            reflected_block = f'<html><a href="/?id={value}"></a></html>'
+            return Response(reflected_block, status=200)
+        else:
+            return Response(normal_block, status=200)
+
+    async def setup_after_prep(self, module_test):
+        module_test.scan.modules["paramminer_getparams"].rand_string = lambda *args, **kwargs: "AAAAAAAAAAAAAA"
+        module_test.monkeypatch.setattr(
+            helper.HttpCompare, "gen_cache_buster", lambda *args, **kwargs: {"AAAAAA": "1"}
+        )
+
+        expect_args = re.compile("/")
+        module_test.set_expect_requests_handler(expect_args=expect_args, request_handler=self.request_handler)
 
     def check(self, module_test, events):
         assert any(


### PR DESCRIPTION
This PR significantly changes the behavior of the reflected params module. It now requires the check of a canary, along with the target parameter. This is to prevent situations where ALL parameters are reflected to the page. These scenarios are rarely interesting to an attacker.

This also adds the ability to test reflection in ALL parameter types - not just GET as before. Prior to this, all parameter types were tried as GET requests only. 

Tests were added for all new functionality.

This PR meets the goals set by https://github.com/blacklanternsecurity/bbot/issues/2097, although the approach ended up being somewhat different.