### PR TITLE
Fix paramminer finish() repeating checks bug

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -176,6 +176,51 @@ url_extension_blacklist:
 # Distribute URLs with these extensions only to httpx (these are omitted from output)
 url_extension_httpx_only:
   - js
+
+# These url extensions have little to no change of being dynamic, so we exclude them from modules expecting dynamic endpoints
+url_extension_non_dynamic:
+  - pdf
+  - doc
+  - docx
+  - xls
+  - xlsx
+  - ppt
+  - pptx
+  - txt
+  - csv
+  - xml
+  - yaml
+  - ini
+  - log
+  - conf
+  - cfg
+  - env
+  - json
+  - md
+  - rtf
+  - tiff
+  - bmp
+  - jpg
+  - jpeg
+  - png
+  - gif
+  - svg
+  - ico
+  - mp3
+  - wav
+  - flac
+  - mp4
+  - mov
+  - avi
+  - mkv
+  - webm
+  - zip
+  - tar
+  - gz
+  - bz2
+  - 7z
+  - rar
+  
 # Don't output these types of events (they are still distributed to modules)
 omit_event_types:
   - HTTP_RESPONSE

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -177,8 +177,8 @@ url_extension_blacklist:
 url_extension_httpx_only:
   - js
 
-# These url extensions have little to no change of being dynamic, so we exclude them from modules expecting dynamic endpoints
-url_extension_non_dynamic:
+# These url extensions are almost always static, so we exclude them from modules that fuzz things
+url_extension_static:
   - pdf
   - doc
   - docx

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -195,7 +195,6 @@ url_extension_static:
   - conf
   - cfg
   - env
-  - json
   - md
   - rtf
   - tiff

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -264,11 +264,6 @@ class paramminer_headers(BaseModule):
         if str(event.module).startswith("paramminer"):
             return False
 
-        # Filter out events with URLs ending in '.pdf'
-        url = event.data.get("url")
-        if url.endswith(".pdf"):
-            return False
-
         return True
 
 

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -257,7 +257,7 @@ class paramminer_headers(BaseModule):
 
     async def filter_event(self, event):
         # Filter out non-dynamic endpoints
-        if event.data.get("url").endswith(tuple(f".{ext}" for ext in self.config.get("url_extension_non_dynamic", []))):
+        if event.data.get("url").endswith(tuple(f".{ext}" for ext in self.config.get("url_extension_static", []))):
             return False
 
         # We don't need to look at WEB_PARAMETERS that we produced

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -256,6 +256,10 @@ class paramminer_headers(BaseModule):
             await self.process_results(event, results)
 
     async def filter_event(self, event):
+        # Filter out non-dynamic endpoints
+        if event.data.get("url").endswith(tuple(f".{ext}" for ext in self.config.get("url_extension_non_dynamic", []))):
+            return False
+
         # We don't need to look at WEB_PARAMETERS that we produced
         if str(event.module).startswith("paramminer"):
             return False
@@ -266,3 +270,5 @@ class paramminer_headers(BaseModule):
             return False
 
         return True
+
+

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -256,7 +256,7 @@ class paramminer_headers(BaseModule):
             await self.process_results(event, results)
 
     async def filter_event(self, event):
-        # Filter out non-dynamic endpoints
+        # Filter out static endpoints
         if event.data.get("url").endswith(tuple(f".{ext}" for ext in self.config.get("url_extension_static", []))):
             return False
 

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -161,10 +161,11 @@ class paramminer_headers(BaseModule):
         if event.type == "WEB_PARAMETER":
             parameter_name = event.data.get("name")
             if self.recycle_words or (event.data.get("type") == "SPECULATIVE"):
-                if self.config.get("skip_boring_words", True) and parameter_name not in self.boring_words:
-                    if parameter_name not in self.wl:  # Ensure it's not already in the wordlist
-                        self.debug(f"Adding {parameter_name} to wordlist")
-                        self.extracted_words_master.add(parameter_name)
+                if self.config.get("skip_boring_words", True) and parameter_name in self.boring_words:
+                    return
+                if parameter_name not in self.wl:  # Ensure it's not already in the wordlist
+                    self.debug(f"Adding {parameter_name} to wordlist")
+                    self.extracted_words_master.add(parameter_name)
 
         elif event.type == "HTTP_RESPONSE":
             url = event.data.get("url")

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -247,7 +247,7 @@ class paramminer_headers(BaseModule):
             except HttpCompareError as e:
                 self.debug(f"Error initializing compare helper: {e}")
                 continue
-            words_to_process = {i for i in sorted(self.extracted_words_master.copy()) if hash(i + url) not in self.already_checked}
+            words_to_process = {i for i in self.extracted_words_master.copy() if hash(i + url) not in self.already_checked}
             try:
                 results = await self.do_mining(words_to_process, url, batch_size, compare_helper)
             except HttpCompareError as e:

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
@@ -245,7 +245,7 @@ class TestParamminer_Getparams_xmlspeculative(Paramminer_Headers):
         assert paramminer_used_speculative, "Paramminer failed to confirm speculative GET parameter"
 
 
-class TestParamminer_Getparams_filter_non_dynamic(TestParamminer_Getparams_finish):
+class TestParamminer_Getparams_filter_static(TestParamminer_Getparams_finish):
 
     targets = ["http://127.0.0.1:8888/test1.php", "http://127.0.0.1:8888/test2.pdf"]
 
@@ -274,4 +274,4 @@ class TestParamminer_Getparams_filter_non_dynamic(TestParamminer_Getparams_finis
                     emitted_excavate_paramminer_duplicate = True
 
         assert found_hidden_getparam_recycled, "Failed to find hidden GET parameter"
-        assert not emitted_excavate_paramminer_duplicate, "Paramminer emitted parameter for non-dynamic URL"
+        assert not emitted_excavate_paramminer_duplicate, "Paramminer emitted parameter for static URL"

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
@@ -243,3 +243,35 @@ class TestParamminer_Getparams_xmlspeculative(Paramminer_Headers):
 
         assert excavate_discovered_speculative, "Excavate failed to discover speculative xml parameter"
         assert paramminer_used_speculative, "Paramminer failed to confirm speculative GET parameter"
+
+
+class TestParamminer_Getparams_filter_non_dynamic(TestParamminer_Getparams_finish):
+
+    targets = ["http://127.0.0.1:8888/test1.php", "http://127.0.0.1:8888/test2.pdf"]
+
+    test_1_html = """
+    <html><a href="/test2.pdf?abcd1234=foo">paramstest2</a></html>
+    """
+
+    def check(self, module_test, events):
+        found_hidden_getparam_recycled = False
+        emitted_excavate_paramminer_duplicate = False
+
+        for e in events:
+            if e.type == "WEB_PARAMETER":
+                if (
+                    "http://127.0.0.1:8888/test1.php" in e.data["url"]
+                    and "[Paramminer] Getparam: [abcd1234] Reasons: [body] Reflection: [False]"
+                    in e.data["description"]
+                ):
+                    found_hidden_getparam_recycled = True
+
+                if (
+                    "http://127.0.0.1:8888/test2.pdf" in e.data["url"]
+                    and "[Paramminer] Getparam: [abcd1234] Reasons: [body] Reflection: [False]"
+                    in e.data["description"]
+                ):
+                    emitted_excavate_paramminer_duplicate = True
+
+        assert found_hidden_getparam_recycled, "Failed to find hidden GET parameter"
+        assert not emitted_excavate_paramminer_duplicate, "Paramminer emitted parameter for non-dynamic URL"

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
@@ -193,9 +193,10 @@ class TestParamminer_Getparams_finish(Paramminer_Headers):
 class TestParamminer_Getparams_xmlspeculative(Paramminer_Headers):
     targets = ["http://127.0.0.1:8888/"]
     modules_overrides = ["httpx", "excavate", "paramminer_getparams"]
-    config_overrides = {"modules": {"paramminer_getparams": {"wordlist": tempwordlist([]), "recycle_words": False}}}
+    config_overrides = {"modules": {"paramminer_getparams": {"wordlist": tempwordlist(["data","common"]), "recycle_words": False}}}
     getparam_extract_xml = """
     <data>
+     <junkparameter>1</junkparameter>
      <obscureParameter>1</obscureParameter>
          <common>1</common>
      </data>


### PR DESCRIPTION
This fixes a serious bug with the paramminer finish() method that was causing the same parameters to be checked multiple times and make bigger scans take a ridiculous amount of time.

Related Issue:

https://github.com/blacklanternsecurity/bbot/issues/2159

**Summary of Changes**

## Centralized Parameter Handling:
Moved the logic for adding new parameters to self.extracted_words_master to the handle_event method only, ensuring only new parameters not in the wordlist are added, and only from WEB_PARAMETER events.

## Simplified finish Method:
Streamlined the finish method by directly using a set comprehension in a single operation to filter and process extracted_words_master. 
The use of list operations to remove already checked parameters was also very inefficient.

## Event Filtering Enhancement:
Now Filtering URLs ending in ~~.pdf~~ a static extension