### PR TITLE
Bump upload-artifact to v4 in github action

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -64,7 +64,7 @@ jobs:
           poetry run pytest --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO .
       - name: Upload Debug Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-debug-logs
           path: pytest_debug.log

--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -66,5 +66,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-debug-logs
-          path: pytest_debug.log
+          name: pytest-debug-logs-${{ matrix.os }}
+          path: pytest_debug_${{ matrix.os }}.log

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pytest-debug-logs
-          path: pytest_debug.log
+          name: pytest-debug-logs-${{ matrix.python-version }}
+          path: pytest_debug_${{ matrix.python-version }}.log
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           poetry run pytest -vv --exitfirst --reruns 2 -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO --cov-config=bbot/test/coverage.cfg --cov-report xml:cov.xml --cov=bbot .
       - name: Upload Debug Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-debug-logs
           path: pytest_debug.log


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d2561004-b391-4512-9436-18eaa40a7ee9)

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/