### PR TITLE
Add "retries" config to teams output module

### DIFF
--- a/bbot/modules/output/discord.py
+++ b/bbot/modules/output/discord.py
@@ -8,9 +8,10 @@ class Discord(WebhookOutputModule):
         "created_date": "2023-08-14",
         "author": "@TheTechromancer",
     }
-    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW"}
+    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW", "retries": 10}
     options_desc = {
         "webhook_url": "Discord webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
+        "retries": "Number of times to retry sending the message before skipping the event",
     }

--- a/bbot/modules/output/slack.py
+++ b/bbot/modules/output/slack.py
@@ -10,11 +10,12 @@ class Slack(WebhookOutputModule):
         "created_date": "2023-08-14",
         "author": "@TheTechromancer",
     }
-    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW"}
+    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW", "retries": 10}
     options_desc = {
         "webhook_url": "Discord webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
+        "retries": "Number of times to retry sending the message before skipping the event",
     }
     content_key = "text"
 

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -8,12 +8,17 @@ class Teams(WebhookOutputModule):
         "created_date": "2023-08-14",
         "author": "@TheTechromancer",
     }
-    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW"}
+    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW", "retries": 10}
     options_desc = {
         "webhook_url": "Teams webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
+        "retries": "Number of times to retry sending the message before skipping the event (Default: 10)",
     }
+
+    async def setup(self):
+        self._api_retries = self.config.get("retries", 10)
+        return await super().setup()
 
     async def handle_event(self, event):
         data = self.format_message(event)

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -36,9 +36,9 @@ class Teams(WebhookOutputModule):
             else:
                 response_headers = response.headers
                 try:
-                    retry_after = int(response_headers.get("Retry-After", 123))
+                    retry_after = float(response_headers.get("Retry-After", 1))
                 except Exception:
-                    retry_after = 123
+                    retry_after = 1
                 self.verbose(
                     f"Error sending {event}: status code {status_code}, response headers: {response_headers}, retrying in {retry_after} seconds"
                 )

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -8,41 +8,20 @@ class Teams(WebhookOutputModule):
         "created_date": "2023-08-14",
         "author": "@TheTechromancer",
     }
-    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW", "retries": 10}
+    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW"}
     options_desc = {
         "webhook_url": "Teams webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
-        "retries": "Number of times to retry sending the message before skipping the event (Default: 10)",
     }
-    _module_threads = 5
-
-    async def setup(self):
-        self.retries = self.config.get("retries", 10)
-        return await super().setup()
 
     async def handle_event(self, event):
-        for _ in range(self.retries):
-            data = self.format_message(event)
-
-            response = await self.helpers.request(
-                url=self.webhook_url,
-                method="POST",
-                json=data,
-            )
-            status_code = getattr(response, "status_code", 0)
-            if self.evaluate_response(response):
-                break
-            else:
-                response_headers = response.headers
-                try:
-                    retry_after = float(response_headers.get("Retry-After", 1))
-                except Exception:
-                    retry_after = 1
-                self.verbose(
-                    f"Error sending {event}: status code {status_code}, response headers: {response_headers}, retrying in {retry_after} seconds"
-                )
-                await self.helpers.sleep(retry_after)
+        data = self.format_message(event)
+        await self.api_request(
+            url=self.webhook_url,
+            method="POST",
+            json=data,
+        )
 
     def trim_message(self, message):
         if len(message) > self.message_size_limit:

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -8,16 +8,21 @@ class Teams(WebhookOutputModule):
         "created_date": "2023-08-14",
         "author": "@TheTechromancer",
     }
-    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW"}
+    options = {"webhook_url": "", "event_types": ["VULNERABILITY", "FINDING"], "min_severity": "LOW", "retries": 10}
     options_desc = {
         "webhook_url": "Teams webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
+        "retries": "Number of times to retry sending the message before skipping the event (Default: 10)",
     }
     _module_threads = 5
 
+    async def setup(self):
+        self.retries = self.config.get("retries", 10)
+        return await super().setup()
+
     async def handle_event(self, event):
-        while 1:
+        for _ in range(self.retries):
             data = self.format_message(event)
 
             response = await self.helpers.request(

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -13,12 +13,8 @@ class Teams(WebhookOutputModule):
         "webhook_url": "Teams webhook URL",
         "event_types": "Types of events to send",
         "min_severity": "Only allow VULNERABILITY events of this severity or higher",
-        "retries": "Number of times to retry sending the message before skipping the event (Default: 10)",
+        "retries": "Number of times to retry sending the message before skipping the event",
     }
-
-    async def setup(self):
-        self._api_retries = self.config.get("retries", 10)
-        return await super().setup()
 
     async def handle_event(self, event):
         data = self.format_message(event)

--- a/bbot/modules/output/teams.py
+++ b/bbot/modules/output/teams.py
@@ -34,13 +34,13 @@ class Teams(WebhookOutputModule):
             if self.evaluate_response(response):
                 break
             else:
-                response_data = getattr(response, "text", "")
+                response_headers = response.headers
                 try:
-                    retry_after = response.json().get("retry_after", 1)
+                    retry_after = int(response_headers.get("Retry-After", 123))
                 except Exception:
-                    retry_after = 1
+                    retry_after = 123
                 self.verbose(
-                    f"Error sending {event}: status code {status_code}, response: {response_data}, retrying in {retry_after} seconds"
+                    f"Error sending {event}: status code {status_code}, response headers: {response_headers}, retrying in {retry_after} seconds"
                 )
                 await self.helpers.sleep(retry_after)
 

--- a/bbot/modules/templates/webhook.py
+++ b/bbot/modules/templates/webhook.py
@@ -16,7 +16,7 @@ class WebhookOutputModule(BaseOutputModule):
     # abort module after 10 failed requests (not including retries)
     _api_failure_abort_threshold = 10
     # retry each request up to 10 times, respecting the Retry-After header
-    _api_failure_retry_limit = 10
+    _api_retries = 10
 
     async def setup(self):
         self.webhook_url = self.config.get("webhook_url", "")

--- a/bbot/modules/templates/webhook.py
+++ b/bbot/modules/templates/webhook.py
@@ -19,6 +19,10 @@ class WebhookOutputModule(BaseOutputModule):
     _api_retries = 10
 
     async def setup(self):
+        self._api_retries = self.config.get("retries", 10)
+        return await super().setup()
+
+    async def setup(self):
         self.webhook_url = self.config.get("webhook_url", "")
         self.min_severity = self.config.get("min_severity", "LOW").strip().upper()
         assert (

--- a/bbot/modules/templates/webhook.py
+++ b/bbot/modules/templates/webhook.py
@@ -20,9 +20,6 @@ class WebhookOutputModule(BaseOutputModule):
 
     async def setup(self):
         self._api_retries = self.config.get("retries", 10)
-        return await super().setup()
-
-    async def setup(self):
         self.webhook_url = self.config.get("webhook_url", "")
         self.min_severity = self.config.get("min_severity", "LOW").strip().upper()
         assert (
@@ -32,7 +29,7 @@ class WebhookOutputModule(BaseOutputModule):
         if not self.webhook_url:
             self.warning("Must set Webhook URL")
             return False
-        return True
+        return await super().setup()
 
     async def handle_event(self, event):
         message = self.format_message(event)

--- a/bbot/modules/templates/webhook.py
+++ b/bbot/modules/templates/webhook.py
@@ -13,6 +13,11 @@ class WebhookOutputModule(BaseOutputModule):
     content_key = "content"
     vuln_severities = ["UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
 
+    # abort module after 10 failed requests (not including retries)
+    _api_failure_abort_threshold = 10
+    # retry each request up to 10 times, respecting the Retry-After header
+    _api_failure_retry_limit = 10
+
     async def setup(self):
         self.webhook_url = self.config.get("webhook_url", "")
         self.min_severity = self.config.get("min_severity", "LOW").strip().upper()
@@ -26,28 +31,13 @@ class WebhookOutputModule(BaseOutputModule):
         return True
 
     async def handle_event(self, event):
-        while 1:
-            message = self.format_message(event)
-            data = {self.content_key: message}
-
-            response = await self.helpers.request(
-                url=self.webhook_url,
-                method="POST",
-                json=data,
-            )
-            status_code = getattr(response, "status_code", 0)
-            if self.evaluate_response(response):
-                break
-            else:
-                response_data = getattr(response, "text", "")
-                try:
-                    retry_after = response.json().get("retry_after", 1)
-                except Exception:
-                    retry_after = 1
-                self.verbose(
-                    f"Error sending {event}: status code {status_code}, response: {response_data}, retrying in {retry_after} seconds"
-                )
-                await self.helpers.sleep(retry_after)
+        message = self.format_message(event)
+        data = {self.content_key: message}
+        await self.api_request(
+            url=self.webhook_url,
+            method="POST",
+            json=data,
+        )
 
     def get_watched_events(self):
         if self._watched_events is None:

--- a/bbot/test/test_step_2/module_tests/test_module_teams.py
+++ b/bbot/test/test_step_2/module_tests/test_module_teams.py
@@ -7,7 +7,7 @@ class TestTeams(DiscordBase):
     modules_overrides = ["teams", "excavate", "badsecrets", "httpx"]
 
     webhook_url = "https://evilcorp.webhook.office.com/webhookb2/deadbeef@deadbeef/IncomingWebhook/deadbeef/deadbeef"
-    config_overrides = {"modules": {"teams": {"webhook_url": webhook_url}}}
+    config_overrides = {"modules": {"teams": {"webhook_url": webhook_url, "retries": 5}}}
 
     async def setup_after_prep(self, module_test):
         self.custom_setup(module_test)
@@ -15,6 +15,8 @@ class TestTeams(DiscordBase):
         def custom_response(request: httpx.Request):
             module_test.request_count += 1
             if module_test.request_count == 2:
+                return httpx.Response(status_code=429, headers={"Retry-After": "0.01"})
+            elif module_test.request_count == 3:
                 return httpx.Response(
                     status_code=400,
                     json={
@@ -28,3 +30,10 @@ class TestTeams(DiscordBase):
                 return httpx.Response(status_code=200)
 
         module_test.httpx_mock.add_callback(custom_response, url=self.webhook_url)
+
+    def check(self, module_test, events):
+        vulns = [e for e in events if e.type == "VULNERABILITY"]
+        findings = [e for e in events if e.type == "FINDING"]
+        assert len(findings) == 1
+        assert len(vulns) == 2
+        assert module_test.request_count == 5


### PR DESCRIPTION
This PR adds a "retries" config option to the teams output module as repeated failures would cause the module to hold up the scan from finishing #2203 
Also tweaked the code incase of a 429 response to obtain the Retry-After from the headers as the power automate webhook sends a empty body