### PR TITLE
Update trufflehog to 3.88.4

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.3",
+        "version": "3.88.4",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Update postman metadata by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/3852
* Support exclude regexes, excludewords, and entropy filters for custom detectors by @zricethezav in https://github.com/trufflesecurity/trufflehog/pull/3860


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.3...v3.88.4