### PR TITLE
Add subwords capability to ffuf_shortnames

### DIFF
--- a/bbot/core/helpers/web/web.py
+++ b/bbot/core/helpers/web/web.py
@@ -281,7 +281,7 @@ class WebHelper(EngineClient):
             if not zip_filename:
                 raise WordlistError("zip_filename must be specified when zip is True")
             try:
-                with zipfile.ZipFile(filename, 'r') as zip_ref:
+                with zipfile.ZipFile(filename, "r") as zip_ref:
                     if zip_filename not in zip_ref.namelist():
                         raise WordlistError(f"File {zip_filename} not found in the zip archive {filename}")
                     zip_ref.extract(zip_filename, filename.parent)

--- a/bbot/core/helpers/web/web.py
+++ b/bbot/core/helpers/web/web.py
@@ -232,7 +232,7 @@ class WebHelper(EngineClient):
         if success:
             return filename
 
-    async def wordlist(self, path, lines=None, **kwargs):
+    async def wordlist(self, path, lines=None, zip=False, zip_filename=None, **kwargs):
         """
         Asynchronous function for retrieving wordlists, either from a local path or a URL.
         Allows for optional line-based truncation and caching. Returns the full path of the wordlist
@@ -242,6 +242,9 @@ class WebHelper(EngineClient):
             path (str): The local or remote path of the wordlist.
             lines (int, optional): Number of lines to read from the wordlist.
                 If specified, will return a truncated wordlist with this many lines.
+            zip (bool, optional): Whether to unzip the file after downloading. Defaults to False.
+            zip_filename (str, optional): The name of the file to extract from the ZIP archive.
+                Required if zip is True.
             cache_hrs (float, optional): Number of hours to cache the downloaded wordlist.
                 Defaults to 720 hours (30 days) for remote wordlists.
             **kwargs: Additional keyword arguments to pass to the 'download' function for remote wordlists.
@@ -259,6 +262,8 @@ class WebHelper(EngineClient):
             Fetching and truncating to the first 100 lines
             >>> wordlist_path = await self.helpers.wordlist("/root/rockyou.txt", lines=100)
         """
+        import zipfile
+
         if not path:
             raise WordlistError(f"Invalid wordlist: {path}")
         if "cache_hrs" not in kwargs:
@@ -271,6 +276,18 @@ class WebHelper(EngineClient):
             filename = Path(path).resolve()
             if not filename.is_file():
                 raise WordlistError(f"Unable to find wordlist at {path}")
+
+        if zip:
+            if not zip_filename:
+                raise WordlistError("zip_filename must be specified when zip is True")
+            try:
+                with zipfile.ZipFile(filename, 'r') as zip_ref:
+                    if zip_filename not in zip_ref.namelist():
+                        raise WordlistError(f"File {zip_filename} not found in the zip archive {filename}")
+                    zip_ref.extract(zip_filename, filename.parent)
+                    filename = filename.parent / zip_filename
+            except Exception as e:
+                raise WordlistError(f"Error unzipping file {filename}: {e}")
 
         if lines is None:
             return filename

--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -303,7 +303,6 @@ class ffuf(BaseModule):
                                     ]
                                     if len(pre_emit_temp_canary) == 0:
                                         yield found_json
-                                        break
 
                                     else:
                                         self.verbose(

--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -306,7 +306,7 @@ class ffuf(BaseModule):
 
                                     else:
                                         self.verbose(
-                                            "Baseline changed mid-scan, or all strings send to this directory are coming back as a match. This may be due to a WAF turning on a block against you, or an unusual configuration on the web server."
+                                            f"Would have reported URL [{found_json['url']}], but baseline check failed. This could be due to a WAF turning on mid-scan, or an unusual web server configuration."
                                         )
                                         self.verbose(f"Aborting the current run against [{url}]")
                                         return

--- a/bbot/modules/deadly/ffuf.py
+++ b/bbot/modules/deadly/ffuf.py
@@ -307,7 +307,7 @@ class ffuf(BaseModule):
 
                                     else:
                                         self.verbose(
-                                            "Baseline changed mid-scan after multiple attempts. This is probably due to a WAF turning on a block against you."
+                                            "Baseline changed mid-scan, or all strings send to this directory are coming back as a match. This may be due to a WAF turning on a block against you, or an unusual configuration on the web server."
                                         )
                                         self.verbose(f"Aborting the current run against [{url}]")
                                         return

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -121,6 +121,7 @@ class ffuf_shortnames(ffuf):
                 if name == "MinimalWordPredictor":
                     return MinimalWordPredictor
                 return super().find_class(module, name)
+
         self.info("Loading ffuf_shortnames prediction models, could take a while if not cached")
         endpoint_model = await self.helpers.wordlist(
             "https://raw.githubusercontent.com/blacklanternsecurity/wordpredictor/refs/heads/main/trained_models/endpoints.bin"
@@ -145,9 +146,9 @@ class ffuf_shortnames(ffuf):
             subwords = await self.helpers.wordlist(
                 "https://raw.githubusercontent.com/nltk/nltk_data/refs/heads/gh-pages/packages/corpora/words.zip",
                 zip=True,
-                zip_filename="words/en"
+                zip_filename="words/en",
             )
-            with open(subwords, 'r') as f:
+            with open(subwords, "r") as f:
                 subword_list_content = f.readlines()
             self.subword_list = {word.lower().strip() for word in subword_list_content if 3 <= len(word.strip()) <= 5}
             self.debug(f"Created subword_list with {len(self.subword_list)} words")

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -40,6 +40,7 @@ class ffuf_shortnames(ffuf):
         "max_predictions": "The maximum number of predictions to generate per shortname prefix",
     }
 
+    deps_pip = ["numpy"]
     deps_common = ["ffuf"]
     in_scope_only = True
 

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -153,7 +153,7 @@ class ffuf_shortnames(ffuf):
             nltk.data.path.append(str(self.nltk_dir))
 
             try:
-                nltk.data.find('corpora/words.zip')
+                nltk.data.find("corpora/words.zip")
                 self.debug("NLTK words data already present")
             except LookupError:
                 self.debug("NLTK words data not found, downloading")

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -4,6 +4,7 @@ import re
 import random
 import string
 import logging
+import os
 
 from bbot.modules.deadly.ffuf import ffuf
 
@@ -142,10 +143,21 @@ class ffuf_shortnames(ffuf):
 
         self.subword_list = []
         if self.find_subwords:
-            self.debug("find_subwords is enabled, downloading nltk data")
+            self.debug("find_subwords is enabled, checking for nltk data")
             self.nltk_dir = self.helpers.tools_dir / "nltk_data"
-            self.debug(f"Attempting to download nltk data from {self.nltk_dir}")
-            nltk.download("words", download_dir=self.nltk_dir, quiet=True)
+
+            # Ensure the directory exists
+            os.makedirs(self.nltk_dir, exist_ok=True)
+
+            # Set the NLTK data path to include self.nltk_dir
+            nltk.data.path.append(str(self.nltk_dir))
+
+            try:
+                nltk.data.find('corpora/words.zip')
+                self.debug("NLTK words data already present")
+            except LookupError:
+                self.debug("NLTK words data not found, downloading")
+                nltk.download("words", download_dir=self.nltk_dir, quiet=True)
 
             from nltk.corpus import words
 

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -1,10 +1,7 @@
 import pickle
-import nltk
 import re
 import random
 import string
-import logging
-import os
 
 from bbot.modules.deadly.ffuf import ffuf
 

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -144,7 +144,7 @@ class ffuf_shortnames(ffuf):
         if self.find_subwords:
             self.debug("find_subwords is enabled, downloading nltk data")
             self.nltk_dir = self.helpers.tools_dir / "nltk_data"
-
+            self.debug(f"Attempting to download nltk data from {self.nltk_dir}")
             nltk.download("words", download_dir=self.nltk_dir, quiet=True)
 
             from nltk.corpus import words

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -42,7 +42,7 @@ class ffuf_shortnames(ffuf):
         "ignore_redirects": "Explicitly ignore redirects (301,302)",
         "find_common_prefixes": "Attempt to automatically detect common prefixes and make additional ffuf runs against them",
         "find_delimiters": "Attempt to detect common delimiters and make additional ffuf runs against them",
-        "find_subwords": "",
+        "find_subwords": "Attempt to detect subwords and make additional ffuf runs against them",
         "max_predictions": "The maximum number of predictions to generate per shortname prefix",
     }
 

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -193,6 +193,8 @@ class ffuf_shortnames(ffuf):
         return None
 
     async def filter_event(self, event):
+        if "iis-magic-url" in event.tags:
+            return False, "iis-magic-url URL_HINTs are not solvable by ffuf_shortnames"
         if event.parent.type != "URL":
             return False, "its parent event is not of type URL"
         return True

--- a/bbot/modules/ffuf_shortnames.py
+++ b/bbot/modules/ffuf_shortnames.py
@@ -300,27 +300,28 @@ class ffuf_shortnames(ffuf):
 
         if self.config.get("find_subwords"):
             subword, suffix = self.find_subword(filename_hint)
-            if "shortname-directory" in event.tags:
-                tempfile, tempfile_len = self.generate_templist(suffix, "directory")
-                async for r in self.execute_ffuf(tempfile, root_url, prefix=subword, exts=["/"]):
-                    await self.emit_event(
-                        r["url"],
-                        "URL_UNVERIFIED",
-                        parent=event,
-                        tags=[f"status-{r['status']}"],
-                        context=f'{{module}} brute-forced directories with detected subword "{subword}" and found {{event.type}}: {{event.data}}',
-                    )
-            elif "shortname-endpoint" in event.tags:
-                for ext in used_extensions:
-                    tempfile, tempfile_len = self.generate_templist(suffix, "endpoint")
-                    async for r in self.execute_ffuf(tempfile, root_url, prefix=subword, suffix=f".{ext}"):
+            if subword:
+                if "shortname-directory" in event.tags:
+                    tempfile, tempfile_len = self.generate_templist(suffix, "directory")
+                    async for r in self.execute_ffuf(tempfile, root_url, prefix=subword, exts=["/"]):
                         await self.emit_event(
                             r["url"],
                             "URL_UNVERIFIED",
                             parent=event,
                             tags=[f"status-{r['status']}"],
-                            context=f'{{module}} brute-forced {ext.upper()} files with detected subword "{subword}" and found {{event.type}}: {{event.data}}',
+                            context=f'{{module}} brute-forced directories with detected subword "{subword}" and found {{event.type}}: {{event.data}}',
                         )
+                elif "shortname-endpoint" in event.tags:
+                    for ext in used_extensions:
+                        tempfile, tempfile_len = self.generate_templist(suffix, "endpoint")
+                        async for r in self.execute_ffuf(tempfile, root_url, prefix=subword, suffix=f".{ext}"):
+                            await self.emit_event(
+                                r["url"],
+                                "URL_UNVERIFIED",
+                                parent=event,
+                                tags=[f"status-{r['status']}"],
+                                context=f'{{module}} brute-forced {ext.upper()} files with detected subword "{subword}" and found {{event.type}}: {{event.data}}',
+                            )
 
     async def finish(self):
         if self.config.get("find_common_prefixes"):

--- a/bbot/presets/web/dotnet-audit.yml
+++ b/bbot/presets/web/dotnet-audit.yml
@@ -17,6 +17,9 @@ config:
   modules:
     ffuf:
       extensions: asp,aspx,ashx,asmx,ascx
+      extensions_ignore_case: True
+    ffuf_shortnames:
+      find_subwords: True
     telerik:
       exploit_RAU_crypto: True
       include_subdirs: True # Run against every directory, not the default first received URL per-host

--- a/bbot/test/test_step_2/module_tests/test_module_ffuf.py
+++ b/bbot/test/test_step_2/module_tests/test_module_ffuf.py
@@ -45,6 +45,30 @@ class TestFFUF2(TestFFUF):
         assert not any(e.type == "URL_UNVERIFIED" and "11111111" in e.data for e in events)
 
 
+class TestFFUF_ignorecase(TestFFUF):
+    test_wordlist = ["11111111", "Admin", "admin", "zzzjunkword2"]
+    config_overrides = {
+        "modules": {"ffuf": {"wordlist": tempwordlist(test_wordlist), "extensions": "php", "ignore_case": True}}
+    }
+
+    async def setup_before_prep(self, module_test):
+        expect_args = {"method": "GET", "uri": "/admin"}
+        respond_args = {"response_data": "alive admin page"}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+        expect_args = {"method": "GET", "uri": "/Admin"}
+        respond_args = {"response_data": "alive admin page"}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+        expect_args = {"method": "GET", "uri": "/"}
+        respond_args = {"response_data": "alive"}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+    def check(self, module_test, events):
+        assert any(e.type == "URL_UNVERIFIED" and "admin" in e.data for e in events)
+        assert not any(e.type == "URL_UNVERIFIED" and "Admin" in e.data for e in events)
+
+
 class TestFFUFHeaders(TestFFUF):
     test_wordlist = ["11111111", "console", "junkword1", "zzzjunkword2"]
     config_overrides = {


### PR DESCRIPTION
Also adds ignore_case option to ffuf (useful for IIS where case doesn't matter)

Subwords uses python nltk (natural language toolkit) to try and find smaller words at the beginning of shortnames. If it does, it sends the remainder off to the predictor. This works well because web developers have a habit of making lots of "VerbAction" type two-word file names.