### PR TITLE
Update trufflehog to 3.88.9

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -13,7 +13,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.4",
+        "version": "3.88.9",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* [tempfix] - add bounds check check to avoid panics by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3867
* Implemented Postman collection authorization scanning by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/3910
* Make log command extensible internally by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3888
* Add protos for GitHub Realtime by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3911


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.8...v3.88.9