### PR TITLE
Change trufflehog output messages

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -1,4 +1,5 @@
 import json
+from functools import partial
 from bbot.modules.base import BaseModule
 
 
@@ -174,7 +175,7 @@ class trufflehog(BaseModule):
             command.append("--delete-cached-data")
             command.append("--token=" + self.github_token)
 
-        stats_file = self.helpers.tempfile_tail(callback=self.log_trufflehog_status)
+        stats_file = self.helpers.tempfile_tail(callback=partial(self.log_trufflehog_status, path))
         try:
             with open(stats_file, "w") as stats_fh:
                 async for line in self.helpers.run_live(command, stderr=stats_fh):
@@ -200,7 +201,7 @@ class trufflehog(BaseModule):
         finally:
             stats_file.unlink()
 
-    def log_trufflehog_status(self, line):
+    def log_trufflehog_status(self, path, line):
         try:
             line = json.loads(line)
         except Exception:
@@ -209,4 +210,5 @@ class trufflehog(BaseModule):
         message = line.get("msg", "")
         ts = line.get("ts", "")
         status = f"Message: {message} | Timestamp: {ts}"
+        self.verbose(f"Current scan target: {path}")
         self.verbose(status)

--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -209,4 +209,4 @@ class trufflehog(BaseModule):
         message = line.get("msg", "")
         ts = line.get("ts", "")
         status = f"Message: {message} | Timestamp: {ts}"
-        self.info(status)
+        self.verbose(status)


### PR DESCRIPTION
As mentioned in #2287 the status updates from trufflehog were set as info

This PR changes them to verbose and I have added the current scan target to the status updates