### PR TITLE
Update trufflehog to 3.88.12

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.9",
+        "version": "3.88.12",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Updated job completion status for Postman by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/3922
* Move `SetArchiveMaxTimeout` to archive file by @rgmz in https://github.com/trufflesecurity/trufflehog/pull/3918
* Export git.handleBinary and getSafeRemoteURL by @rosecodym in https://github.com/trufflesecurity/trufflehog/pull/3921
* Updated Sendgrid Analyzer by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3906
* [Feature] Airtable Analyzer for OAuth Tokens by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3879
* Remove duplicate `github.com/jedib0t/go-pretty` dependency by @Juneezee in https://github.com/trufflesecurity/trufflehog/pull/3924


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.11...v3.88.12