### PR TITLE
Fix portfilter priority

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -71,7 +71,7 @@ class BaseModule:
 
         _qsize (int): Outgoing queue size (0 for infinite). Default is 0.
 
-        _priority (int): Priority level of events raised by this module, 1-5. Default is 3.
+        _priority (int): Priority level of the module. Lower values are higher priority. Default is 3.
 
         _name (str): Module name, overridden automatically. Default is 'base'.
 

--- a/bbot/modules/portfilter.py
+++ b/bbot/modules/portfilter.py
@@ -18,6 +18,8 @@ class portfilter(BaseInterceptModule):
         "allowed_cdn_ports": "Comma-separated list of ports that are allowed to be scanned for CDNs",
     }
 
+    _priority = 4
+
     async def setup(self):
         self.cdn_tags = [t.strip() for t in self.config.get("cdn_tags", "").split(",")]
         self.allowed_cdn_ports = self.config.get("allowed_cdn_ports", "").strip()

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -289,6 +289,7 @@ class Scanner:
 
             # intercept modules get sewn together like human centipede
             self.intercept_modules = [m for m in self.modules.values() if m._intercept]
+            self.intercept_modules.sort(key=lambda x: x.priority)
             for i, intercept_module in enumerate(self.intercept_modules[1:]):
                 prev_intercept_module = self.intercept_modules[i]
                 self.debug(


### PR DESCRIPTION
Fixes https://github.com/blacklanternsecurity/bbot/issues/2306 by sorting the priority of intercept modules, so `cloudcheck` processes events before they're passed `portfilter`.