### PR TITLE
Update trufflehog to 3.88.13

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.12",
+        "version": "3.88.13",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* elevenlabs analyzer by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3850


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/3.88.13...v3.88.13