### PR TITLE
Update trufflehog to 3.88.15

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.13",
+        "version": "3.88.15",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* [bug] - check for invalid_grant to avoid setting verification error by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3935
* Updated returned error to include original error by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/3949
* Updated custom detector setup docs by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3913
* chore(deps): update dependency go to v1.24.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3944
* [Feat] Planetscale Analyzer by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/3928
* Feature: Airtable Analyzer for Personal Access Tokens by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/3941
* Enumeration jobs should not consume concurrency slots by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/3952
* [chore] - re-activate plaidkey detector by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/3953
* chore(deps): update golang docker tag to v1.24 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/3950


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.14...v3.88.15