### PR TITLE
Update nuclei to 3.3.10

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.9",
+        "version": "3.3.10",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Other Changes
* added support to generate CPU & PGO profiles by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/6058
* added escape code blocks for markdown formatting by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/6089
* fixed auth validation on windows ox by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/6053
* fixed issue with secrets lookup logic by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/6059
* fixed race condition of the lastmatcherevent by @knakul853 in https://github.com/projectdiscovery/nuclei/pull/6080
* fixed incorrect nil return value by @huochexizhan in https://github.com/projectdiscovery/nuclei/pull/6079
* fixed issue with reporting close functionality by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/6066
* fixed nil pointer on context cancellation by @knakul853 in https://github.com/projectdiscovery/nuclei/pull/6085
* fixed issue with setting headers in fuzzing template by @dogancanbakir in https://github.com/projectdiscovery/nuclei/pull/5988

## New Contributors
* @knakul853 made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6080
* @huochexizhan made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6079

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.3.9...v3.3.10