### PR TITLE
Update trufflehog to 3.88.20

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.15",
+        "version": "3.88.20",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Postman source handle different JSON info for headers by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/3995


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.19...v3.88.20