### PR TITLE
Update nuclei to 3.4.1

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.3.10",
+        "version": "3.4.1",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed

### Other Changes
* Updated Docker image templates to fix release issues by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/6119


**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.4.0...v3.4.1