### PR TITLE
Update trufflehog to 3.88.31

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.20",
+        "version": "3.88.31",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* [Fix] Line number issue for custom detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/3997
* Replace anthropic references with groq by @lihararora in https://github.com/trufflesecurity/trufflehog/pull/4147
* Updated Github Source Validate method by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4144
* [Feat] Added Dropbox API OAuth2 Token Analyzer by @nabeelalam in https://github.com/trufflesecurity/trufflehog/pull/4080
* Add per-chunk detection logging by @martinlocklear in https://github.com/trufflesecurity/trufflehog/pull/4152
* chore: run setup-go after checkout by @Juneezee in https://github.com/trufflesecurity/trufflehog/pull/4143
* Fixed Shopify detector line number by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4149
* Added DataBricks Analyzer by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4135
* Add a bunch of Postman logging by @martinlocklear in https://github.com/trufflesecurity/trufflehog/pull/4154
* Update Twitch detector to handle new RawV2 field by @amanfcp in https://github.com/trufflesecurity/trufflehog/pull/4150

## New Contributors
* @lihararora made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/4147

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.30...v3.88.31