### PR TITLE
Update nuclei to 3.4.2

### DIFF
--- a/bbot/modules/deadly/nuclei.py
+++ b/bbot/modules/deadly/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.4.1",
+        "version": "3.4.2",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/deadly/nuclei.py."

# Release notes:
## What's Changed

## 🎉 New Features
* Added bearer support to Jira reporting for self-hosted environments by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/6145


## 🐞 Bug Fixes
* Fixed call to errors.Wrap to use the correct error variable by @alingse in https://github.com/projectdiscovery/nuclei/pull/6127

### Other Changes
* Various improvements to the GitHub Actions by @dwisiswant0, including:
  * Removal of i386 Docker manifest due to lack of 32-bit support [#6134](https://github.com/projectdiscovery/nuclei/pull/6134)
  * Addition of Docker manifests [#6125](https://github.com/projectdiscovery/nuclei/pull/6125)
  * Use of composite action for compatibility checks [#6139](https://github.com/projectdiscovery/nuclei/pull/6139)
  * Addition of setup-python steps for tests [#6154](https://github.com/projectdiscovery/nuclei/pull/6154)

## New Contributors
* @alingse made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6127

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.4.1...v3.4.2