### PR TITLE
Continue on bad target

### DIFF
--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -80,7 +80,11 @@ class BaseTarget(RadixTarget):
             targets = [targets]
         event_seeds = set()
         for target in targets:
-            event_seed = EventSeed(target)
+            try:
+                event_seed = EventSeed(target)
+            except ValidationError as e:
+                log.warning(str(e))
+                continue
             if not event_seed._target_type in self.accept_target_types:
                 log.warning(f"Invalid target type for {self.__class__.__name__}: {event_seed.type}")
                 continue

--- a/bbot/test/test_step_1/test_event_seeds.py
+++ b/bbot/test/test_step_1/test_event_seeds.py
@@ -158,3 +158,7 @@ def test_event_seeds():
     assert blacklist_regex_seed.host == None
     assert blacklist_regex_seed.input == "REGEX:evil[0-9]{3}"
     assert blacklist_regex_seed._target_type == "BLACKLIST"
+
+    # invalid target
+    with pytest.raises(ValidationError, match="Unable to autodetect data type from"):
+        EventSeed("asdf:::asdf")

--- a/bbot/test/test_step_1/test_python_api.py
+++ b/bbot/test/test_step_1/test_python_api.py
@@ -84,10 +84,6 @@ def test_python_api_sync():
 def test_python_api_validation():
     from bbot.scanner import Scanner, Preset
 
-    # invalid target
-    with pytest.raises(ValidationError) as error:
-        Scanner("asdf:::asdf")
-    assert str(error.value) == 'Unable to autodetect data type from "asdf:::asdf"'
     # invalid module
     with pytest.raises(ValidationError) as error:
         Scanner(modules=["asdf"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bbot"
-version = "2.4.1"
+version = "2.4.2"
 description = "OSINT automation for hackers."
 authors = [
     "TheTechromancer",
@@ -109,7 +109,7 @@ lint.ignore = ["E402", "E711", "E713", "E721", "E741", "F401", "F403", "F405", "
 [tool.poetry-dynamic-versioning]
 enable = true
 metadata = false
-format-jinja = 'v2.4.1{% if branch == "dev" %}.{{ distance }}rc{% endif %}'
+format-jinja = 'v2.4.2{% if branch == "dev" %}.{{ distance }}rc{% endif %}'
 
 [tool.poetry-dynamic-versioning.substitution]
 files = ["*/__init__.py"]


### PR DESCRIPTION
If a malformed target is encountered, don't halt the scan. Instead, just log a warning and continue.