### PR TITLE
Ignore empty targets

### DIFF
--- a/bbot/__init__.py
+++ b/bbot/__init__.py
@@ -2,3 +2,5 @@
 __version__ = "v0.0.0"
 
 from .scanner import Scanner, Preset
+
+__all__ = ["Scanner", "Preset"]

--- a/bbot/core/event/__init__.py
+++ b/bbot/core/event/__init__.py
@@ -1,1 +1,3 @@
 from .base import make_event, is_event, event_from_json
+
+__all__ = ["make_event", "is_event", "event_from_json"]

--- a/bbot/core/helpers/__init__.py
+++ b/bbot/core/helpers/__init__.py
@@ -1,4 +1,4 @@
 from .url import *
 from .misc import *
-from . import regexes
-from . import validators
+from . import regexes as regexes
+from . import validators as validators

--- a/bbot/core/helpers/depsinstaller/__init__.py
+++ b/bbot/core/helpers/depsinstaller/__init__.py
@@ -1,1 +1,3 @@
 from .installer import DepsInstaller
+
+__all__ = ["DepsInstaller"]

--- a/bbot/core/helpers/dns/__init__.py
+++ b/bbot/core/helpers/dns/__init__.py
@@ -1,1 +1,1 @@
-from .dns import DNSHelper
+from .dns import DNSHelper  # noqa

--- a/bbot/core/helpers/web/__init__.py
+++ b/bbot/core/helpers/web/__init__.py
@@ -1,1 +1,1 @@
-from .web import WebHelper
+from .web import WebHelper  # noqa

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -1,5 +1,4 @@
 from sys import executable
-from urllib.parse import urlparse
 
 from bbot.modules.base import BaseModule
 

--- a/bbot/scanner/__init__.py
+++ b/bbot/scanner/__init__.py
@@ -1,2 +1,4 @@
 from .preset import Preset
 from .scanner import Scanner
+
+__all__ = ["Preset", "Scanner"]

--- a/bbot/scanner/preset/__init__.py
+++ b/bbot/scanner/preset/__init__.py
@@ -1,1 +1,3 @@
 from .preset import Preset
+
+__all__ = ["Preset"]

--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -28,6 +28,8 @@ class BaseTarget(RadixTarget):
     accept_target_types = ["TARGET"]
 
     def __init__(self, *targets, **kwargs):
+        # ignore blank targets (sometimes happens as a symptom of .splitlines())
+        targets = [stripped for t in targets if (stripped := t.strip())]
         self.event_seeds = set()
         super().__init__(*targets, **kwargs)
 

--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -29,7 +29,7 @@ class BaseTarget(RadixTarget):
 
     def __init__(self, *targets, **kwargs):
         # ignore blank targets (sometimes happens as a symptom of .splitlines())
-        targets = [stripped for t in targets if (stripped := t.strip())]
+        targets = [stripped for t in targets if (stripped := (t.strip() if isinstance(t, str) else t))]
         self.event_seeds = set()
         super().__init__(*targets, **kwargs)
 

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -1,11 +1,8 @@
 import os  # noqa
-import sys
-import zlib
 import pytest
 import shutil  # noqa
 import asyncio  # noqa
 import logging
-import subprocess
 import tldextract
 import pytest_httpserver
 from pathlib import Path
@@ -16,8 +13,8 @@ from werkzeug.wrappers import Request
 from bbot.errors import *  # noqa: F401
 from bbot.core import CORE
 from bbot.scanner import Preset
+from bbot.core.helpers.misc import mkdir, rand_string
 from bbot.core.helpers.async_helpers import get_event_loop
-from bbot.core.helpers.misc import mkdir, rand_string, get_python_constraints
 
 
 log = logging.getLogger("bbot.test.fixtures")

--- a/bbot/test/bbot_fixtures.py
+++ b/bbot/test/bbot_fixtures.py
@@ -1,4 +1,5 @@
 import os  # noqa
+import sys  # noqa
 import pytest
 import shutil  # noqa
 import asyncio  # noqa

--- a/bbot/test/conftest.py
+++ b/bbot/test/conftest.py
@@ -1,5 +1,6 @@
 import os
 import ssl
+import time
 import shutil
 import pytest
 import asyncio
@@ -8,8 +9,6 @@ from pathlib import Path
 from contextlib import suppress
 from omegaconf import OmegaConf
 from pytest_httpserver import HTTPServer
-import time
-import queue
 
 from bbot.core import CORE
 from bbot.core.helpers.misc import execute_sync_or_async

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1079,8 +1079,6 @@ scan_name: bbot_test
 
 # regression test for https://github.com/blacklanternsecurity/bbot/issues/2337
 def test_preset_serialization():
-    from ipaddress import ip_address, ip_network
-
     preset = Preset("192.168.1.1")
     preset = preset.bake()
 

--- a/bbot/test/test_step_2/module_tests/test_module_dotnetnuke.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dotnetnuke.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 from .base import ModuleTestBase
 from werkzeug.wrappers import Response

--- a/bbot/test/test_step_2/module_tests/test_module_host_header.py
+++ b/bbot/test/test_step_2/module_tests/test_module_host_header.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 from werkzeug.wrappers import Response
 

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -1,5 +1,5 @@
 import re
-from .base import ModuleTestBase, tempwordlist
+from .base import ModuleTestBase
 
 
 class TestTelerik(ModuleTestBase):

--- a/bbot/test/test_step_2/module_tests/test_module_websocket.py
+++ b/bbot/test/test_step_2/module_tests/test_module_websocket.py
@@ -1,7 +1,6 @@
 import json
 import asyncio
 import logging
-import websockets
 from websockets.asyncio.server import serve
 
 from .base import ModuleTestBase

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ skip = "./docs/javascripts/vega*.js,./bbot/wordlists/*"
 line-length = 119
 format.exclude = ["bbot/test/test_step_1/test_manager_*"]
 lint.select = ["E", "F"]
-lint.ignore = ["E402", "E711", "E713", "E721", "E741", "F401", "F403", "F405", "E501"]
+lint.ignore = ["E402", "E711", "E713", "E721", "E741", "F403", "F405", "E501"]
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Gracefully skips any empty strings that are passed into a target.

Also cleans up some unused imports. We had temporarily disabled `F401` due to a `ruff` bug, but it's since been fixed. This PR re-enables it.