### PR TITLE
Handle 'fuck off' retry-after headers

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -96,9 +96,9 @@ web:
   http_retries: 1
   # HTTP retries (for httpx)
   httpx_retries: 1
-  # Default sleep interval when rate limited by 429 (when retry-after isn't provided)
+  # Default sleep interval when rate limited by 429 (and retry-after isn't provided)
   429_sleep_interval: 30
-  # Maximum sleep interval when rate limited by 429 (when an excessive retry-after is provided)
+  # Maximum sleep interval when rate limited by 429 (and an excessive retry-after is provided)
   429_max_sleep_interval: 60
   # Enable/disable debug messages for web requests/responses
   debug: false

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -96,6 +96,10 @@ web:
   http_retries: 1
   # HTTP retries (for httpx)
   httpx_retries: 1
+  # Default sleep interval when rate limited by 429 (when retry-after isn't provided)
+  429_sleep_interval: 30
+  # Maximum sleep interval when rate limited by 429 (when an excessive retry-after is provided)
+  429_max_sleep_interval: 60
   # Enable/disable debug messages for web requests/responses
   debug: false
   # Maximum number of HTTP redirects to follow

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -108,10 +108,6 @@ class BaseModule:
     _api_retries = 2
     # disable the module after this many failed attempts in a row
     _api_failure_abort_threshold = 3
-    # sleep for this many seconds after being rate limited
-    _429_sleep_interval = 30
-    # when following a retry-after header, don't sleep for longer than a minute
-    _429_max_sleep_interval = 60
 
     default_discovery_context = "{module} discovered {event.type}: {event.data}"
 
@@ -166,6 +162,10 @@ class BaseModule:
 
         # used for optional "per host" tracking
         self._per_host_tracker = set()
+
+        # 429 rate limit handling
+        self._429_sleep_interval = self.scan.web_config.get("429_sleep_interval", 30)
+        self._429_max_sleep_interval = self.scan.web_config.get("429_max_sleep_interval", 60)
 
     async def setup(self):
         """

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -110,6 +110,8 @@ class BaseModule:
     _api_failure_abort_threshold = 3
     # sleep for this many seconds after being rate limited
     _429_sleep_interval = 30
+    # when following a retry-after header, don't sleep for longer than a minute
+    _429_max_sleep_interval = 60
 
     default_discovery_context = "{module} discovered {event.type}: {event.data}"
 
@@ -1172,6 +1174,9 @@ class BaseModule:
                     retry_after = self._get_retry_after(r)
                     if retry_after or status_code == 429:
                         sleep_interval = int(retry_after) if retry_after is not None else self._429_sleep_interval
+                        if retry_after and retry_after > self._429_max_sleep_interval:
+                            self.verbose(f"Got an excessive retry-after header of {retry_after} from {new_url}, using {self._429_max_sleep_interval} instead")
+                            sleep_interval = self._429_max_sleep_interval
                         self.verbose(
                             f"Sleeping for {sleep_interval:,} seconds due to rate limit (HTTP status: {status_code})"
                         )

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1175,7 +1175,9 @@ class BaseModule:
                     if retry_after or status_code == 429:
                         sleep_interval = int(retry_after) if retry_after is not None else self._429_sleep_interval
                         if retry_after and retry_after > self._429_max_sleep_interval:
-                            self.verbose(f"Got an excessive retry-after header of {retry_after} from {new_url}, using {self._429_max_sleep_interval} instead")
+                            self.verbose(
+                                f"Got an excessive retry-after header of {retry_after} from {new_url}, using {self._429_max_sleep_interval} instead"
+                            )
                             sleep_interval = self._429_max_sleep_interval
                         self.verbose(
                             f"Sleeping for {sleep_interval:,} seconds due to rate limit (HTTP status: {status_code})"

--- a/bbot/modules/certspotter.py
+++ b/bbot/modules/certspotter.py
@@ -15,7 +15,7 @@ class certspotter(subdomain_enum):
 
     def request_url(self, query):
         url = f"{self.base_url}/issuances?domain={self.helpers.quote(query)}&include_subdomains=true&expand=dns_names"
-        return self.api_request(url, timeout=self.http_timeout + 30)
+        return self.api_request(url)
 
     async def parse_results(self, r, query):
         results = set()


### PR DESCRIPTION
Handles the case where APIs return an excessively high retry-after value, effectively freezing a module.