### PR TITLE
New Module: github_usersearch

### DIFF
--- a/bbot/modules/github_usersearch.py
+++ b/bbot/modules/github_usersearch.py
@@ -17,7 +17,8 @@ class github_usersearch(github, subdomain_enum):
 
     async def handle_event(self, event):
         self.verbose("Searching for users with emails matching in scope domains")
-        users = await self.query_users(event.data)
+        query = self.make_query(event)
+        users = await self.query_users(query)
         for user, email in users:
             user_url = f"https://github.com/{user}"
             event_data = {"platform": "github", "profile_name": user, "url": user_url}

--- a/bbot/modules/github_usersearch.py
+++ b/bbot/modules/github_usersearch.py
@@ -6,7 +6,7 @@ class github_usersearch(github):
     produced_events = ["SOCIAL", "EMAIL_ADDRESS"]
     flags = ["passive", "safe", "code-enum"]
     meta = {
-        "description": "Query Github's API for users with emails matching in scope domains",
+        "description": "Query Github's API for users with emails matching in scope domains that may not be discoverable by listing members of the organization.",
         "created_date": "2025-05-10",
         "author": "@domwhewell-sage",
         "auth_required": True,

--- a/bbot/modules/github_usersearch.py
+++ b/bbot/modules/github_usersearch.py
@@ -1,0 +1,73 @@
+from bbot.modules.templates.github import github
+
+
+class github_usersearch(github):
+    watched_events = ["DNS_NAME"]
+    produced_events = ["SOCIAL", "EMAIL_ADDRESS"]
+    flags = ["passive", "safe", "code-enum"]
+    meta = {
+        "description": "Query Github's API for users with emails matching in scope domains",
+        "created_date": "2025-05-10",
+        "author": "@domwhewell-sage",
+        "auth_required": True,
+    }
+    options = {"api_key": ""}
+    options_desc = {"api_key": "Github token"}
+
+    async def handle_event(self, event):
+        self.verbose("Searching for users with emails matching in scope domains")
+        users = await self.query_users(event.data)
+        for user, email in users:
+            user_url = f"https://github.com/{user}"
+            event_data = {"platform": "github", "profile_name": user, "url": user_url}
+            user_event = self.make_event(event_data, "SOCIAL", tags="github-org-member", parent=event)
+            if user_event:
+                await self.emit_event(
+                    user_event,
+                    context=f"{{module}} searched for users with {{DNS_NAME}} in the profile and discovered {{event.type}}: {user_url}",
+                )
+            if email:
+                await self.emit_event(
+                    email,
+                    "EMAIL_ADDRESS",
+                    parent=event,
+                    context=f"{{module}} found an {{event.type}} on the github profile {user_url}: {{event.data}}",
+                )
+
+    async def query_users(self, query):
+        users = []
+        graphql_query = f"""query search_users {{
+            search(query: "{query}", type: USER, first: 100, after: "{{NEXT_KEY}}") {{
+                userCount
+                pageInfo {{
+                    hasNextPage
+                    endCursor
+                }}
+                edges {{
+                    node {{
+                        ... on User {{
+                          login
+                          # bio Commented out as user can add arbritrary domains to their bio
+                          email # Email is verified by github
+                          websiteUrl # Website is not verified by github
+                        }}
+                    }}
+                }}
+            }}
+        }}"""
+        async for data in self.github_graphql_request(graphql_query, "search"):
+            if data:
+                user_count = data.get("userCount", 0)
+                self.verbose(f"Found {user_count} users with the query {query}, verifying if they are in-scope...")
+                edges = data.get("edges", [])
+                for node in edges:
+                    user = node.get("node", {})
+                    in_scope_hosts = await self.scan.extract_in_scope_hostnames(str(user))
+                    if in_scope_hosts:
+                        login = user.get("login", "")
+                        email = user.get("email", None)
+                        self.verbose(
+                            f'Found in-scope hostname(s): "{in_scope_hosts}" in the profile https://github.com/{login}, the profile appears to be in-scope'
+                        )
+                        users.append((login, email))
+        return users

--- a/bbot/modules/github_usersearch.py
+++ b/bbot/modules/github_usersearch.py
@@ -1,7 +1,8 @@
 from bbot.modules.templates.github import github
+from bbot.modules.templates.subdomain_enum import subdomain_enum
 
 
-class github_usersearch(github):
+class github_usersearch(github, subdomain_enum):
     watched_events = ["DNS_NAME"]
     produced_events = ["SOCIAL", "EMAIL_ADDRESS"]
     flags = ["passive", "safe", "code-enum"]

--- a/bbot/test/test_step_2/module_tests/test_module_github_usersearch.py
+++ b/bbot/test/test_step_2/module_tests/test_module_github_usersearch.py
@@ -1,0 +1,138 @@
+from .base import ModuleTestBase
+
+
+class TestGithub_Usersearch(ModuleTestBase):
+    config_overrides = {"modules": {"github_usersearch": {"api_key": "asdf"}}}
+    query_1 = """query search_users {
+            search(query: "blacklanternsecurity.com", type: USER, first: 100, after: "") {
+                userCount
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                edges {
+                    node {
+                        ... on User {
+                          login
+                          # bio Commented out as user can add arbritrary domains to their bio
+                          email # Email is verified by github
+                          websiteUrl # Website is not verified by github
+                        }
+                    }
+                }
+            }
+        }"""
+    query_2 = """query search_users {
+            search(query: "blacklanternsecurity.com", type: USER, first: 100, after: "Y3Vyc29yOjUz") {
+                userCount
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
+                edges {
+                    node {
+                        ... on User {
+                          login
+                          # bio Commented out as user can add arbritrary domains to their bio
+                          email # Email is verified by github
+                          websiteUrl # Website is not verified by github
+                        }
+                    }
+                }
+            }
+        }"""
+
+    async def setup_before_prep(self, module_test):
+        module_test.httpx_mock.add_response(url="https://api.github.com/zen")
+        module_test.httpx_mock.add_response(
+            url="https://api.github.com/graphql",
+            match_headers={"Authorization": "token asdf"},
+            match_json={"query": self.query_1},
+            json={
+                "data": {
+                    "search": {
+                        "userCount": 2,
+                        "pageInfo": {"hasNextPage": True, "endCursor": "Y3Vyc29yOjUz"},
+                        "edges": [
+                            {
+                                "node": {
+                                    "login": "user_one",
+                                    "email": "test@blacklanternsecurity.com",
+                                    "websiteUrl": None,
+                                }
+                            },
+                            {"node": {"login": "user_two", "email": None, "websiteUrl": None}},
+                        ],
+                    }
+                }
+            },
+        )
+        module_test.httpx_mock.add_response(
+            url="https://api.github.com/graphql",
+            match_headers={"Authorization": "token asdf"},
+            match_json={"query": self.query_2},
+            json={
+                "data": {
+                    "search": {
+                        "userCount": 1,
+                        "pageInfo": {"hasNextPage": False, "endCursor": "Y3Vyc29yOjU"},
+                        "edges": [
+                            {
+                                "node": {
+                                    "login": "user_three",
+                                    "email": None,
+                                    "websiteUrl": "https://blog.blacklanternsecurity.com",
+                                }
+                            }
+                        ],
+                    }
+                }
+            },
+        )
+
+    def check(self, module_test, events):
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "SOCIAL"
+                and e.data["platform"] == "github"
+                and e.data["profile_name"] == "user_one"
+                and str(e.module) == "github_usersearch"
+                and "github-org-member" in e.tags
+                and e.scope_distance == 1
+            ]
+        ), "Failed to find user_one github"
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "EMAIL_ADDRESS"
+                and e.data == "test@blacklanternsecurity.com"
+                and str(e.module) == "github_usersearch"
+            ]
+        ), "Failed to find email address for user_one"
+        assert 0 == len(
+            [
+                e
+                for e in events
+                if e.type == "SOCIAL"
+                and e.data["platform"] == "github"
+                and e.data["profile_name"] == "user_two"
+                and str(e.module) == "github_usersearch"
+                and "github-org-member" in e.tags
+                and e.scope_distance == 1
+            ]
+        ), "user_two should not be in scope due to no email or website"
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "SOCIAL"
+                and e.data["platform"] == "github"
+                and e.data["profile_name"] == "user_three"
+                and str(e.module) == "github_usersearch"
+                and "github-org-member" in e.tags
+                and e.scope_distance == 1
+            ]
+        ), "Failed to find user_three github"


### PR DESCRIPTION
This module uses the user search function in github to discover users that cannot be discovered by listing the members of an organization (As their profile visibility is set to private)

The `api_page_iter` function would not be able to handle paginated graphql responses as the `endCursor` value that points to the next page in graphql and does not contain a full url compatible with `next_key`.
I have created a shared graphql request in the github template module.