### PR TITLE
Clean up downloaded files on scan finish.

### DIFF
--- a/bbot/modules/apkpure.py
+++ b/bbot/modules/apkpure.py
@@ -13,14 +13,16 @@ class apkpure(BaseModule):
         "author": "@domwhewell-sage",
     }
     options = {"output_folder": ""}
-    options_desc = {"output_folder": "Folder to download apk's to"}
+    options_desc = {
+        "output_folder": "Folder to download APKs to. If not specified, downloaded APKs will be deleted when the scan completes, to minimize disk usage."
+    }
 
     async def setup(self):
-        output_folder = self.config.get("output_folder")
+        output_folder = self.config.get("output_folder", "")
         if output_folder:
             self.output_dir = Path(output_folder) / "apk_files"
         else:
-            self.output_dir = self.scan.home / "apk_files"
+            self.output_dir = self.helpers.temp_dir / "apk_files"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/docker_pull.py
+++ b/bbot/modules/docker_pull.py
@@ -17,7 +17,7 @@ class docker_pull(BaseModule):
     options = {"all_tags": False, "output_folder": ""}
     options_desc = {
         "all_tags": "Download all tags from each registry (Default False)",
-        "output_folder": "Folder to download docker repositories to",
+        "output_folder": "Folder to download docker repositories to. If not specified, downloaded docker images will be deleted when the scan completes, to minimize disk usage.",
     }
 
     scope_distance_modifier = 2
@@ -34,11 +34,11 @@ class docker_pull(BaseModule):
             )
         }
         self.all_tags = self.config.get("all_tags", True)
-        output_folder = self.config.get("output_folder")
+        output_folder = self.config.get("output_folder", "")
         if output_folder:
             self.output_dir = Path(output_folder) / "docker_images"
         else:
-            self.output_dir = self.scan.home / "docker_images"
+            self.output_dir = self.helpers.temp_dir / "docker_images"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/filedownload.py
+++ b/bbot/modules/filedownload.py
@@ -84,12 +84,12 @@ class filedownload(BaseModule):
             "bz2",  #  Bzip2 Compressed File
         ],
         "max_filesize": "10MB",
-        "base_64_encoded_file": "false",
+        "output_folder": "",
     }
     options_desc = {
         "extensions": "File extensions to download",
         "max_filesize": "Cancel download if filesize is greater than this size",
-        "base_64_encoded_file": "Stream the bytes of a file and encode them in base 64 for event data.",
+        "output_folder": "Folder to download files to. If not specified, downloaded files will be deleted when the scan completes, to minimize disk usage.",
     }
 
     scope_distance_modifier = 3
@@ -97,10 +97,14 @@ class filedownload(BaseModule):
     async def setup(self):
         self.extensions = list({e.lower().strip(".") for e in self.config.get("extensions", [])})
         self.max_filesize = self.config.get("max_filesize", "10MB")
-        self.download_dir = self.scan.home / "filedownload"
-        self.helpers.mkdir(self.download_dir)
         self.urls_downloaded = set()
         self.files_downloaded = 0
+        output_dir = self.config.get("output_folder", "")
+        if output_dir:
+            self.download_dir = Path(output_dir) / "filedownload"
+        else:
+            self.download_dir = self.helpers.temp_dir / "filedownload"
+        self.helpers.mkdir(self.download_dir)
         self.mime_db_file = await self.helpers.wordlist(
             "https://raw.githubusercontent.com/jshttp/mime-db/master/db.json"
         )

--- a/bbot/modules/git_clone.py
+++ b/bbot/modules/git_clone.py
@@ -13,7 +13,10 @@ class git_clone(github):
         "author": "@domwhewell-sage",
     }
     options = {"api_key": "", "output_folder": ""}
-    options_desc = {"api_key": "Github token", "output_folder": "Folder to clone repositories to"}
+    options_desc = {
+        "api_key": "Github token",
+        "output_folder": "Folder to clone repositories to. If not specified, cloned repositories will be deleted when the scan completes, to minimize disk usage.",
+    }
 
     deps_apt = ["git"]
 
@@ -24,7 +27,7 @@ class git_clone(github):
         if output_folder:
             self.output_dir = Path(output_folder) / "git_repos"
         else:
-            self.output_dir = self.scan.home / "git_repos"
+            self.output_dir = self.helpers.temp_dir / "git_repos"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -19,7 +19,7 @@ class gitdumper(BaseModule):
         "max_semanic_version": 10,
     }
     options_desc = {
-        "output_folder": "Folder to download repositories to",
+        "output_folder": "Folder to download repositories to. If not specified, downloaded repositories will be deleted when the scan completes, to minimize disk usage.",
         "fuzz_tags": "Fuzz for common git tag names (v0.0.1, 0.0.2, etc.) up to the max_semanic_version",
         "max_semanic_version": "Maximum version number to fuzz for (default < v10.10.10)",
     }
@@ -28,11 +28,11 @@ class gitdumper(BaseModule):
 
     async def setup(self):
         self.urls_downloaded = set()
-        output_folder = self.config.get("output_folder")
+        output_folder = self.config.get("output_folder", "")
         if output_folder:
             self.output_dir = Path(output_folder) / "git_repos"
         else:
-            self.output_dir = self.scan.home / "git_repos"
+            self.output_dir = self.helpers.temp_dir / "git_repos"
         self.helpers.mkdir(self.output_dir)
         self.unsafe_regex = self.helpers.re.compile(r"^\s*fsmonitor|sshcommand|askpass|editor|pager", re.IGNORECASE)
         self.ref_regex = self.helpers.re.compile(r"ref: refs/heads/([a-zA-Z\d_-]+)")

--- a/bbot/modules/postman_download.py
+++ b/bbot/modules/postman_download.py
@@ -14,15 +14,18 @@ class postman_download(postman):
         "author": "@domwhewell-sage",
     }
     options = {"output_folder": "", "api_key": ""}
-    options_desc = {"output_folder": "Folder to download postman workspaces to", "api_key": "Postman API Key"}
+    options_desc = {
+        "output_folder": "Folder to download postman workspaces to. If not specified, downloaded workspaces will be deleted when the scan completes, to minimize disk usage.",
+        "api_key": "Postman API Key",
+    }
     scope_distance_modifier = 2
 
     async def setup(self):
-        output_folder = self.config.get("output_folder")
+        output_folder = self.config.get("output_folder", "")
         if output_folder:
             self.output_dir = Path(output_folder) / "postman_workspaces"
         else:
-            self.output_dir = self.scan.home / "postman_workspaces"
+            self.output_dir = self.helpers.temp_dir / "postman_workspaces"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/test/test_step_2/module_tests/test_module_apkpure.py
+++ b/bbot/test/test_step_2/module_tests/test_module_apkpure.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 from .base import ModuleTestBase, tempapkfile
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestAPKPure(ModuleTestBase):
     modules_overrides = ["apkpure", "google_playstore", "speculate"]
+    config_overrides = {"modules": {"apkpure": {"output_folder": str(bbot_test_dir / "test_apkpure_files")}}}
     apk_file = tempapkfile()
 
     async def setup_after_prep(self, module_test):

--- a/bbot/test/test_step_2/module_tests/test_module_bucket_file_enum.py
+++ b/bbot/test/test_step_2/module_tests/test_module_bucket_file_enum.py
@@ -1,10 +1,16 @@
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestBucket_File_Enum(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["bucket_file_enum", "filedownload", "httpx", "excavate", "cloudcheck"]
-    config_overrides = {"scope": {"report_distance": 5}}
+
+    download_dir = bbot_test_dir / "test_bucket_file_enum"
+    config_overrides = {
+        "scope": {"report_distance": 5},
+        "modules": {"filedownload": {"output_folder": str(download_dir)}},
+    }
 
     open_bucket_url = "https://testbucket.s3.amazonaws.com/"
     open_bucket_body = """<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>testbucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated><Contents><Key>index.html</Key><LastModified>2023-05-22T23:04:38.000Z</LastModified><ETag>&quot;4a2d2d114f3abf90f8bd127c1f25095a&quot;</ETag><Size>5</Size><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>test.pdf</Key><LastModified>2022-04-30T21:13:40.000Z</LastModified><ETag>&quot;723b0018c2f5a7ef06a34f84f6fa97e4&quot;</ETag><Size>388901</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"""
@@ -32,8 +38,7 @@ trailer <</Root 1 0 R>>"""
         )
 
     def check(self, module_test, events):
-        download_dir = module_test.scan.home / "filedownload"
-        files = list(download_dir.glob("*.pdf"))
+        files = list((self.download_dir / "filedownload").glob("*.pdf"))
         assert any(e.type == "URL_UNVERIFIED" and e.data.endswith("test.pdf") for e in events)
         assert not any(e.type == "URL_UNVERIFIED" and e.data.endswith("test.css") for e in events)
         assert any(f.name.endswith("test.pdf") for f in files), "Failed to download PDF file from open bucket"

--- a/bbot/test/test_step_2/module_tests/test_module_docker_pull.py
+++ b/bbot/test/test_step_2/module_tests/test_module_docker_pull.py
@@ -3,10 +3,12 @@ import tarfile
 from pathlib import Path
 
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestDockerPull(ModuleTestBase):
     modules_overrides = ["speculate", "dockerhub", "docker_pull"]
+    config_overrides = {"modules": {"docker_pull": {"output_folder": str(bbot_test_dir / "test_docker_files")}}}
 
     async def setup_before_prep(self, module_test):
         module_test.httpx_mock.add_response(

--- a/bbot/test/test_step_2/module_tests/test_module_filedownload.py
+++ b/bbot/test/test_step_2/module_tests/test_module_filedownload.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestFileDownload(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["filedownload", "httpx", "excavate", "speculate"]
-    config_overrides = {"web": {"spider_distance": 2, "spider_depth": 2}}
+    config_overrides = {
+        "web": {"spider_distance": 2, "spider_depth": 2},
+        "modules": {"filedownload": {"output_folder": str(bbot_test_dir / "test_filedownload_files")}},
+    }
 
     pdf_data = """%PDF-1.
 1 0 obj<</Pages 2 0 R>>endobj

--- a/bbot/test/test_step_2/module_tests/test_module_git_clone.py
+++ b/bbot/test/test_step_2/module_tests/test_module_git_clone.py
@@ -6,10 +6,13 @@ import subprocess
 from pathlib import Path
 
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestGit_Clone(ModuleTestBase):
-    config_overrides = {"modules": {"git_clone": {"api_key": "asdf"}}}
+    config_overrides = {
+        "modules": {"git_clone": {"api_key": "asdf", "output_folder": str(bbot_test_dir / "test_git_files")}}
+    }
     modules_overrides = ["github_org", "speculate", "git_clone"]
 
     file_content = "https://admin:admin@the-internet.herokuapp.com/basic_auth"

--- a/bbot/test/test_step_2/module_tests/test_module_gitdumper.py
+++ b/bbot/test/test_step_2/module_tests/test_module_gitdumper.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestGitDumper_Dirlisting(ModuleTestBase):
@@ -8,6 +9,7 @@ class TestGitDumper_Dirlisting(ModuleTestBase):
     ]
 
     modules_overrides = ["git", "gitdumper", "httpx"]
+    config_overrides = {"modules": {"gitdumper": {"output_folder": str(bbot_test_dir / "test_output")}}}
 
     index_html = """<html>
         <head>

--- a/bbot/test/test_step_2/module_tests/test_module_postman_download.py
+++ b/bbot/test/test_step_2/module_tests/test_module_postman_download.py
@@ -1,8 +1,13 @@
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestPostman_Download(ModuleTestBase):
-    config_overrides = {"modules": {"postman_download": {"api_key": "asdf"}}}
+    config_overrides = {
+        "modules": {
+            "postman_download": {"api_key": "asdf", "output_folder": str(bbot_test_dir / "test_postman_files")}
+        }
+    }
     modules_overrides = ["postman", "postman_download", "speculate"]
 
     async def setup_before_prep(self, module_test):

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -6,10 +6,18 @@ import tarfile
 from pathlib import Path
 
 from .base import ModuleTestBase
+from bbot.test.bbot_fixtures import bbot_test_dir
 
 
 class TestTrufflehog(ModuleTestBase):
-    config_overrides = {"modules": {"postman_download": {"api_key": "asdf"}}}
+    download_dir = bbot_test_dir / "test_trufflehog"
+    config_overrides = {
+        "modules": {
+            "postman_download": {"api_key": "asdf", "output_folder": str(download_dir)},
+            "docker_pull": {"output_folder": str(download_dir)},
+            "git_clone": {"output_folder": str(download_dir)},
+        }
+    }
     modules_overrides = [
         "github_org",
         "speculate",
@@ -1201,7 +1209,15 @@ class TestTrufflehog(ModuleTestBase):
 
 
 class TestTrufflehog_NonVerified(TestTrufflehog):
-    config_overrides = {"modules": {"trufflehog": {"only_verified": False}, "postman_download": {"api_key": "asdf"}}}
+    download_dir = bbot_test_dir / "test_trufflehog_nonverified"
+    config_overrides = {
+        "modules": {
+            "trufflehog": {"only_verified": False},
+            "docker_pull": {"output_folder": str(download_dir)},
+            "postman_download": {"api_key": "asdf", "output_folder": str(download_dir)},
+            "git_clone": {"output_folder": str(download_dir)},
+        }
+    }
 
     def check(self, module_test, events):
         finding_events = [
@@ -1279,7 +1295,11 @@ class TestTrufflehog_HTTPResponse(ModuleTestBase):
 class TestTrufflehog_RAWText(ModuleTestBase):
     targets = ["http://127.0.0.1:8888/test.pdf"]
     modules_overrides = ["httpx", "trufflehog", "filedownload", "extractous"]
-    config_overrides = {"modules": {"trufflehog": {"only_verified": False}}}
+
+    download_dir = bbot_test_dir / "test_trufflehog_rawtext"
+    config_overrides = {
+        "modules": {"trufflehog": {"only_verified": False}, "filedownload": {"output_folder": str(download_dir)}}
+    }
 
     async def setup_before_prep(self, module_test):
         expect_args = {


### PR DESCRIPTION
Due to several modules like `docker_pull` that tend to download lots of hefty files, we've recently run into problems with disk space on systems that run recurring scans. This PR changes the default download location for these modules to be the scan's temp directory, which is automatically cleaned at the end of the scan. This allows modules like trufflehog to consume the files during the scan, without leaving them afterwards to take up disk space.

If you want to keep them after the scan, you can specify a custom `output_folder` on the module.

FYSA @domwhewell-sage I know you wrote most of these modules so how do you feel about this? 

Addresses https://github.com/blacklanternsecurity/bbot/issues/2459.