### PR TITLE
Update trufflehog to 3.88.34

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.88.31",
+        "version": "3.88.34",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Enhanced smartsheets detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4168
* feat: allow input source from pipe by @strazzere in https://github.com/trufflesecurity/trufflehog/pull/4088
* Prevent indefinite hang for sql server detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4174


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.88.33...v3.88.34