### PR TITLE
Add strategic timeouts to gitdumper

### DIFF
--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -123,7 +123,7 @@ class gitdumper(BaseModule):
         if dir_listing:
             urls = await self.recursive_dir_list(dir_listing)
             try:
-                await self.download_files(urls, repo_folder)
+                result = await self.download_files(urls, repo_folder)
             except asyncio.CancelledError:
                 self.verbose(f"Cancellation requested while downloading files from {repo_url}")
                 result = True

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -130,7 +130,7 @@ class gitdumper(BaseModule):
                     self.download_files(urls, repo_folder),
                     timeout=self.timeout,
                 )
-            except asyncio.TimeoutError:
+            except (asyncio.TimeoutError, asyncio.CancelledError):
                 self.verbose(f"Timeout of {self.timeout}s reached while downloading git objects from {repo_url}")
                 result = True
         else:

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -22,7 +22,7 @@ class gitdumper(BaseModule):
     }
     options_desc = {
         "output_folder": "Folder to download repositories to",
-        "timeout:": "Timeout for downloading git objects in seconds (default 3600)",
+        "timeout": "Timeout for downloading git objects in seconds (default 3600)",
         "fuzz_tags": "Fuzz for common git tag names (v0.0.1, 0.0.2, etc.) up to the max_semanic_version",
         "max_semanic_version": "Maximum version number to fuzz for (default < v10.10.10)",
     }

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -16,13 +16,11 @@ class gitdumper(BaseModule):
     }
     options = {
         "output_folder": "",
-        "timeout": 3600,
         "fuzz_tags": False,
         "max_semanic_version": 10,
     }
     options_desc = {
         "output_folder": "Folder to download repositories to",
-        "timeout": "Timeout for downloading git objects in seconds (default 3600)",
         "fuzz_tags": "Fuzz for common git tag names (v0.0.1, 0.0.2, etc.) up to the max_semanic_version",
         "max_semanic_version": "Maximum version number to fuzz for (default < v10.10.10)",
     }
@@ -36,7 +34,6 @@ class gitdumper(BaseModule):
             self.output_dir = Path(output_folder) / "git_repos"
         else:
             self.output_dir = self.scan.home / "git_repos"
-        self.timeout = self.config.get("timeout", 3600)
         self.helpers.mkdir(self.output_dir)
         self.unsafe_regex = self.helpers.re.compile(r"^\s*fsmonitor|sshcommand|askpass|editor|pager", re.IGNORECASE)
         self.ref_regex = self.helpers.re.compile(r"ref: refs/heads/([a-zA-Z\d_-]+)")
@@ -126,12 +123,9 @@ class gitdumper(BaseModule):
         if dir_listing:
             urls = await self.recursive_dir_list(dir_listing)
             try:
-                result = await asyncio.wait_for(
-                    self.download_files(urls, repo_folder),
-                    timeout=self.timeout,
-                )
-            except (asyncio.TimeoutError, asyncio.CancelledError):
-                self.verbose(f"Timeout of {self.timeout}s reached while downloading git objects from {repo_url}")
+                await self.download_files(urls, repo_folder)
+            except asyncio.CancelledError:
+                self.verbose(f"Cancellation requested while downloading files from {repo_url}")
                 result = True
         else:
             result = await self.git_fuzz(repo_url, repo_folder)
@@ -183,12 +177,9 @@ class gitdumper(BaseModule):
         if result:
             await self.download_current_branch(repo_url, repo_folder)
             try:
-                await asyncio.wait_for(
-                    self.download_git_objects(repo_url, repo_folder),
-                    timeout=self.timeout,
-                )
-            except asyncio.TimeoutError:
-                self.verbose(f"Timeout of {self.timeout}s reached while downloading git objects from {repo_url}")
+                await self.download_git_objects(repo_url, repo_folder)
+            except asyncio.CancelledError:
+                self.verbose(f"Cancellation requested while downloading git objects from {repo_url}")
             await self.download_git_packs(repo_url, repo_folder)
             return True
         else:

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -1,3 +1,4 @@
+import asyncio
 import regex as re
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -15,11 +16,13 @@ class gitdumper(BaseModule):
     }
     options = {
         "output_folder": "",
+        "timeout": 3600,
         "fuzz_tags": False,
         "max_semanic_version": 10,
     }
     options_desc = {
         "output_folder": "Folder to download repositories to",
+        "timeout:": "Timeout for downloading git objects in seconds (default 3600)",
         "fuzz_tags": "Fuzz for common git tag names (v0.0.1, 0.0.2, etc.) up to the max_semanic_version",
         "max_semanic_version": "Maximum version number to fuzz for (default < v10.10.10)",
     }
@@ -33,6 +36,7 @@ class gitdumper(BaseModule):
             self.output_dir = Path(output_folder) / "git_repos"
         else:
             self.output_dir = self.scan.home / "git_repos"
+        self.timeout = self.config.get("timeout", 3600)
         self.helpers.mkdir(self.output_dir)
         self.unsafe_regex = self.helpers.re.compile(r"^\s*fsmonitor|sshcommand|askpass|editor|pager", re.IGNORECASE)
         self.ref_regex = self.helpers.re.compile(r"ref: refs/heads/([a-zA-Z\d_-]+)")
@@ -121,7 +125,14 @@ class gitdumper(BaseModule):
         dir_listing = await self.directory_listing_enabled(repo_url)
         if dir_listing:
             urls = await self.recursive_dir_list(dir_listing)
-            result = await self.download_files(urls, repo_folder)
+            try:
+                result = await asyncio.wait_for(
+                    self.download_files(urls, repo_folder),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError:
+                self.verbose(f"Timeout of {self.timeout}s reached while downloading git objects from {repo_url}")
+                result = True
         else:
             result = await self.git_fuzz(repo_url, repo_folder)
         if result:
@@ -171,7 +182,13 @@ class gitdumper(BaseModule):
         result = await self.download_files(url_list, repo_folder)
         if result:
             await self.download_current_branch(repo_url, repo_folder)
-            await self.download_git_objects(repo_url, repo_folder)
+            try:
+                await asyncio.wait_for(
+                    self.download_git_objects(repo_url, repo_folder),
+                    timeout=self.timeout,
+                )
+            except asyncio.TimeoutError:
+                self.verbose(f"Timeout of {self.timeout}s reached while downloading git objects from {repo_url}")
             await self.download_git_packs(repo_url, repo_folder)
             return True
         else:


### PR DESCRIPTION
Git dumper can run for a long time on repositories with a large amount of objects #2455

Git dumper works by:
1. Ingest a git folder event
2. Download the objects from that folder (Either by recursive dir list or fuzzing) - This is the part that takes a while
3. Reconstruct the git folder

If we kill the module via a global timer #2362 we risk not having the 3rd step run which means we are left with a broken git folder and it wouldn't be scanned by other modules. So what this PR does is place the timeouts specifically on step 2 so if the timeout is reached we are still left with a usable git folder that is scanned by other modules.