### PR TITLE
Update trufflehog to 3.89.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.89.0",
+        "version": "3.89.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* feat(docker): implement exclude paths functionality by @tannerjones4075 in https://github.com/trufflesecurity/trufflehog/pull/4057
* chore(deps): update dependency go to v1.24.4 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4136
* chore(deps): update sigstore/cosign-installer action to v3.8.2 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4212
* Update ngrok.go detector to handle 403s properly by @thiggy1342 in https://github.com/trufflesecurity/trufflehog/pull/4216

## New Contributors
* @tannerjones4075 made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/4057
* @thiggy1342 made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/4216

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.89.0...v3.89.1