### PR TITLE
Update trufflehog to 3.89.2

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.89.1",
+        "version": "3.89.2",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Analyzer/datadog by @amanfcp in https://github.com/trufflesecurity/trufflehog/pull/4132
* (fix) validation to ensure only one of --org or --repo is provided for Github source by @abmussani in https://github.com/trufflesecurity/trufflehog/pull/4141
* addition of percent encoding for raw brackets CSM-1195 by @jordanTunstill in https://github.com/trufflesecurity/trufflehog/pull/4221
* fix(deps): update aws-sdk-go-v2 monorepo by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4213
* fix(deps): update module github.com/bradleyfalzon/ghinstallation/v2 to v2.14.0 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4025
* fix(deps): update github.com/avast/apkparser digest to 166ba17 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4119
* fix(deps): update module github.com/go-logr/logr to v1.4.3 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4228
* fix(deps): update module github.com/googleapis/gax-go/v2 to v2.14.2 by @renovate in https://github.com/trufflesecurity/trufflehog/pull/4231
* Log recursion limiting by @camgunz in https://github.com/trufflesecurity/trufflehog/pull/4236
* Add git metrics for cloning and scanning by @dustin-decker in https://github.com/trufflesecurity/trufflehog/pull/4234
* [bugfix] - Refactor Jenkins Log Chunking to Use HandleFile by @ahrav in https://github.com/trufflesecurity/trufflehog/pull/4225


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.89.1...v3.89.2