### PR TITLE
updated code to show only 1 highlighted output in terminal instead twice

### DIFF
--- a/bbot/modules/output/stdout.py
+++ b/bbot/modules/output/stdout.py
@@ -63,7 +63,5 @@ class Stdout(BaseOutputModule):
         elif event.type == "FINDING":
             log_to_stderr(event_str, level="HUGEINFO", logname=False)
 
-        print(event_str)
-
     async def handle_json(self, event, event_json):
         print(json.dumps(event_json))


### PR DESCRIPTION
Greeting !!, @TheTechromancer Sorry to trouble you again!!

removing this show's output of "FINDING" in terminal only once ,

Previously it used to show twice one was highlighted and another normal , i removed 2nd one.

Before: this is shown for similar output , both are same
<img width="162" height="67" alt="finding" src="https://github.com/user-attachments/assets/d9866a9e-13a8-4222-8f8c-ca6554b319bc" />

After update only that highlighted one is shown in terminal