### PR TITLE
Scan-specific temp folder

### DIFF
--- a/bbot/modules/apkpure.py
+++ b/bbot/modules/apkpure.py
@@ -22,7 +22,7 @@ class apkpure(BaseModule):
         if output_folder:
             self.output_dir = Path(output_folder) / "apk_files"
         else:
-            self.output_dir = self.helpers.temp_dir / "apk_files"
+            self.output_dir = self.scan.temp_dir / "apk_files"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/docker_pull.py
+++ b/bbot/modules/docker_pull.py
@@ -38,7 +38,7 @@ class docker_pull(BaseModule):
         if output_folder:
             self.output_dir = Path(output_folder) / "docker_images"
         else:
-            self.output_dir = self.helpers.temp_dir / "docker_images"
+            self.output_dir = self.scan.temp_dir / "docker_images"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/filedownload.py
+++ b/bbot/modules/filedownload.py
@@ -103,7 +103,7 @@ class filedownload(BaseModule):
         if output_dir:
             self.download_dir = Path(output_dir) / "filedownload"
         else:
-            self.download_dir = self.helpers.temp_dir / "filedownload"
+            self.download_dir = self.scan.temp_dir / "filedownload"
         self.helpers.mkdir(self.download_dir)
         self.mime_db_file = await self.helpers.wordlist(
             "https://raw.githubusercontent.com/jshttp/mime-db/master/db.json"

--- a/bbot/modules/git_clone.py
+++ b/bbot/modules/git_clone.py
@@ -27,7 +27,7 @@ class git_clone(github):
         if output_folder:
             self.output_dir = Path(output_folder) / "git_repos"
         else:
-            self.output_dir = self.helpers.temp_dir / "git_repos"
+            self.output_dir = self.scan.temp_dir / "git_repos"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/modules/gitdumper.py
+++ b/bbot/modules/gitdumper.py
@@ -33,7 +33,7 @@ class gitdumper(BaseModule):
         if output_folder:
             self.output_dir = Path(output_folder) / "git_repos"
         else:
-            self.output_dir = self.helpers.temp_dir / "git_repos"
+            self.output_dir = self.scan.temp_dir / "git_repos"
         self.helpers.mkdir(self.output_dir)
         self.unsafe_regex = self.helpers.re.compile(r"^\s*fsmonitor|sshcommand|askpass|editor|pager", re.IGNORECASE)
         self.ref_regex = self.helpers.re.compile(r"ref: refs/heads/([a-zA-Z\d_-]+)")

--- a/bbot/modules/postman_download.py
+++ b/bbot/modules/postman_download.py
@@ -25,7 +25,7 @@ class postman_download(postman):
         if output_folder:
             self.output_dir = Path(output_folder) / "postman_workspaces"
         else:
-            self.output_dir = self.helpers.temp_dir / "postman_workspaces"
+            self.output_dir = self.scan.temp_dir / "postman_workspaces"
         self.helpers.mkdir(self.output_dir)
         return await super().setup()
 

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -175,6 +175,10 @@ class Scanner:
         else:
             self.home = self.preset.bbot_home / "scans" / self.name
 
+        # scan temp dir
+        self.temp_dir = self.home / "temp"
+        self.helpers.mkdir(self.temp_dir)
+
         self._status = "NOT_STARTED"
         self._status_code = 0
 
@@ -884,7 +888,9 @@ class Scanner:
                 await mod._cleanup()
             with contextlib.suppress(Exception):
                 self.home.rmdir()
-            self.helpers.rm_rf(self.helpers.temp_dir, ignore_errors=True)
+            self.critical(f"Removing temp dir: {self.temp_dir}")
+            self.helpers.rm_rf(self.temp_dir, ignore_errors=True)
+            self.critical(f"Removed temp dir: {self.temp_dir} (exists: {self.temp_dir.exists()})")
             self.helpers.clean_old_scans()
 
     def in_scope(self, *args, **kwargs):

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -888,9 +888,7 @@ class Scanner:
                 await mod._cleanup()
             with contextlib.suppress(Exception):
                 self.home.rmdir()
-            self.critical(f"Removing temp dir: {self.temp_dir}")
             self.helpers.rm_rf(self.temp_dir, ignore_errors=True)
-            self.critical(f"Removed temp dir: {self.temp_dir} (exists: {self.temp_dir.exists()})")
             self.helpers.clean_old_scans()
 
     def in_scope(self, *args, **kwargs):

--- a/bbot/test/test_step_1/test_helpers.py
+++ b/bbot/test/test_step_1/test_helpers.py
@@ -963,11 +963,13 @@ async def test_rm_temp_dir_at_exit(helpers):
     scan = Scanner("127.0.0.1", modules=["httpx"])
     await scan._prep()
 
+    temp_dir = scan.home / "temp"
+
     # temp dir should exist
-    assert scan.helpers.temp_dir.exists()
+    assert temp_dir.exists()
 
     events = [e async for e in scan.async_start()]
     assert events
 
     # temp dir should be removed
-    assert not scan.helpers.temp_dir.exists()
+    assert not temp_dir.exists()


### PR DESCRIPTION
This PR creates a scan-specific temp folder, so that multiple scans can safely be executed at the same time without the risk of removing the temp folder while it's still in use by another scan.