### PR TITLE
Update trufflehog to 3.90.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.89.2",
+        "version": "3.90.1",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Added KeySet Pagination for Gitlab Projects V2 Enumeration by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4319
* Salesforce Refresh Token Detector by @shahzadhaider1 in https://github.com/trufflesecurity/trufflehog/pull/4295


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.90.0...v3.90.1