### PR TITLE
Update nuclei to 3.4.7

### DIFF
--- a/bbot/modules/nuclei.py
+++ b/bbot/modules/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.4.2",
+        "version": "3.4.7",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Other Changes
* Fixed issue with go install (`github.com/zmap/zgrab2` v0.2.0 => v0.1.8) by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/6295


**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.4.6...v3.4.7