### PR TITLE
Update trufflehog to 3.90.5

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.90.3",
+        "version": "3.90.5",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Fixed and improved currentsapi detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4391
* Improved and fixed copper detector by @kashifkhan0771 in https://github.com/trufflesecurity/trufflehog/pull/4394
* fix(deps): update module github.com/bradleyfalzon/ghinstallation/v2 to v2.16.0 by @renovate[bot] in https://github.com/trufflesecurity/trufflehog/pull/4342
* fix(deps): update module github.com/sendgrid/sendgrid-go to v3.16.1+incompatible by @renovate[bot] in https://github.com/trufflesecurity/trufflehog/pull/4232
* Utf16 bom support by @joeleonjr in https://github.com/trufflesecurity/trufflehog/pull/4326
* Add additional unicode escape support by @jltrfl in https://github.com/trufflesecurity/trufflehog/pull/4296
* Update PreCommit.md with audit mode details by @joeleonjr in https://github.com/trufflesecurity/trufflehog/pull/4280
* Update proto definitions for custom bitbucket oauth by @casey-tran in https://github.com/trufflesecurity/trufflehog/pull/4390

## New Contributors
* @jltrfl made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/4296

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.90.4...v3.90.5