### PR TITLE
Avoid Duplicate Ouput before Saving in output.txt

### DIFF
--- a/bbot/modules/output/txt.py
+++ b/bbot/modules/output/txt.py
@@ -13,10 +13,15 @@ class TXT(BaseOutputModule):
 
     async def setup(self):
         self._prep_output_dir(self.output_filename)
+        self._seen = set()   # track already-written lines
         return True
 
     async def handle_event(self, event):
         event_str = self.human_event_str(event)
+
+        if event_str in self._seen:
+            return  # skip duplicates
+        self._seen.add(event_str)
 
         if self.file is not None:
             self.file.write(event_str + "\n")


### PR DESCRIPTION
Previosuly :  Duplicates were being saved 


<img width="631" height="154" alt="previos" src="https://github.com/user-attachments/assets/5c1fee88-b74e-4fd6-aa23-6cfe3b283867" />

this pr solves that issue while terminal user can sort out in terminal with  

```
sort output.txt | uniq > newoutput.txt
```

i
