### PR TITLE
Update nuclei to 3.4.8

### DIFF
--- a/bbot/modules/nuclei.py
+++ b/bbot/modules/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.4.7",
+        "version": "3.4.8",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Features & Improvements
- Remove singletons from Nuclei engine (continuation of [#6210](https://github.com/projectdiscovery/nuclei/pull/6210)) ([#6296](https://github.com/projectdiscovery/nuclei/pull/6296)) by @hdm  
- Address race conditions in `http.Request` and `MemGuardian` ([#6321](https://github.com/projectdiscovery/nuclei/pull/6321)) by @hdm  
- Support concurrent Nuclei engines in the same process ([#6322](https://github.com/projectdiscovery/nuclei/pull/6322)) by @hdm  
- feat: log event for template host skipped during scanning ([#6324](https://github.com/projectdiscovery/nuclei/pull/6324)) by @Ice3man543  
- feat(code): log unavailable engines as error while validating ([#6326](https://github.com/projectdiscovery/nuclei/pull/6326)) by @dwisiswant0  
- Bump `github.com/bytedance/sonic` to v1.14.0 for Go 1.25 compatibility ([#6348](https://github.com/projectdiscovery/nuclei/pull/6348)) by @stefanb  
- feat: loading templates performance improvements ([#6364](https://github.com/projectdiscovery/nuclei/pull/6364)) by @Ice3man543  
- feat(fuzz): evaluate variables ([#6358](https://github.com/projectdiscovery/nuclei/pull/6358)) by @dwisiswant0  
- Enable templates for template listing and displaying ([#6343](https://github.com/projectdiscovery/nuclei/pull/6343)) by @dogancanbakir 
- Refactor: use `maps.Copy` for cleaner map handling ([#6283](https://github.com/projectdiscovery/nuclei/pull/6283)) by @gopherorg  



### 🐞 Bug Fixes
- Fix headless: variables now available in headless templates ([#6301](https://github.com/projectdiscovery/nuclei/pull/6301)) by @alban-stourbe-wmx  
- Fix lib: scans not stopping on context cancellation ([#6310](https://github.com/projectdiscovery/nuclei/pull/6310)) by @dwisiswant0  
- Fix panic from uninitialized colorizer ([#6315](https://github.com/projectdiscovery/nuclei/pull/6315)) by @josedh  
- Fix to preserve original transport for linear HTTP client ([#6357](https://github.com/projectdiscovery/nuclei/pull/6357)) by @Ice3man543  
- Fix offlinehttp: replace "-" with "_" in headers for DSL variables ([#6363](https://github.com/projectdiscovery/nuclei/pull/6363)) by @Isaac0616  
- Fix(events): correct JSON encoder type in `ScanStatsWorker` ([#6366](https://github.com/projectdiscovery/nuclei/pull/6366)) by @dwisiswant0  
- Fix: prevent nil pointer panic in WAF detector ([#6368](https://github.com/projectdiscovery/nuclei/pull/6368)) by @knakul853  
- Fix headless: merge extra headers ([#6376](https://github.com/projectdiscovery/nuclei/pull/6376)) by @ysokolovsky  
- Fix: prevent unnecessary template updates ([#6379](https://github.com/projectdiscovery/nuclei/pull/6379)) by @dwisiswant0  

### 🔨 Maintenance
- chore(deps): bump the modules group with 3 updates ([#6305](https://github.com/projectdiscovery/nuclei/pull/6305)) by @dependabot[bot]  
- chore(config): remove deprecated code and calls ([#6311](https://github.com/projectdiscovery/nuclei/pull/6311)) by @dwisiswant0  
- build(docker): bump builder image `golang:1.23-alpine` → `golang:1.24-alpine` ([#6316](https://github.com/projectdiscovery/nuclei/pull/6316)) by @dwisiswant0  
- chore: fix inconsistent function name in comment ([#6338](https://github.com/projectdiscovery/nuclei/pull/6338)) by @jishudashen  
- build(make): update `template-validate` commands ([#6385](https://github.com/projectdiscovery/nuclei/pull/6385)) by @dwisiswant0  
- chore(deps): bump go_modules group with 2 updates ([#6388](https://github.com/projectdiscovery/nuclei/pull/6388)) by @dependabot[bot]  
- ci(tests): migrate to golangci-lint v2 ([#6380](https://github.com/projectdiscovery/nuclei/pull/6380)) by @dwisiswant0  



## New Contributors
* @josedh made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6315
* @hdm made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6296
* @gopherorg made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6283
* @jishudashen made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6338
* @stefanb made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6348
* @Isaac0616 made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6363
* @ysokolovsky made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6376

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.4.7...v3.4.8