### PR TITLE
Update nuclei to 3.4.9

### DIFF
--- a/bbot/modules/nuclei.py
+++ b/bbot/modules/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.4.7",
+        "version": "3.4.9",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/nuclei.py."

# Release notes:
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Other Changes
* feat: fixed output event for skipped hosts by @Ice3man543 in https://github.com/projectdiscovery/nuclei/pull/6415


**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.4.8...v3.4.9