### PR TITLE
Update trufflehog to 3.90.8

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -14,7 +14,7 @@ class trufflehog(BaseModule):
     }
 
     options = {
-        "version": "3.90.6",
+        "version": "3.90.8",
         "config": "",
         "only_verified": True,
         "concurrency": 8,


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Pre-filter GitHub v1 findings to prevent large numbers of validation requests by @trufflesteeeve in https://github.com/trufflesecurity/trufflehog/pull/4468


**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.90.7...v3.90.8