### PR TITLE
Changed to use the new `api_download` helper

### DIFF
--- a/bbot/modules/github_workflows.py
+++ b/bbot/modules/github_workflows.py
@@ -13,6 +13,7 @@ class github_workflows(github):
         "description": "Download a github repositories workflow logs and workflow artifacts",
         "created_date": "2024-04-29",
         "author": "@domwhewell-sage",
+        "auth_required": True,
     }
     options = {"api_key": "", "num_logs": 1, "output_folder": ""}
     options_desc = {
@@ -152,7 +153,7 @@ class github_workflows(github):
         filename = f"run_{run_id}.zip"
         file_destination = folder / filename
         try:
-            await self.helpers.download(
+            await self.api_download(
                 f"{self.base_url}/repos/{owner}/{repo}/actions/runs/{run_id}/logs",
                 filename=file_destination,
                 headers=self.headers,
@@ -166,7 +167,7 @@ class github_workflows(github):
             status_code = getattr(response, "status_code", 0)
             if status_code == 403:
                 self.warning(
-                    f"The current access key does not have access to workflow {owner}/{repo}/{run_id} (status: {status_code})"
+                    f"The current access key does not have access to workflow {owner}/{repo}/{run_id}, The API key must have the 'repo' scope or read 'Actions' repository permissions (status: {status_code})"
                 )
             else:
                 self.info(
@@ -212,7 +213,7 @@ class github_workflows(github):
         self.helpers.mkdir(folder)
         file_destination = folder / artifact_name
         try:
-            await self.helpers.download(
+            await self.api_download(
                 f"{self.base_url}/repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip",
                 filename=file_destination,
                 headers=self.headers,
@@ -228,6 +229,6 @@ class github_workflows(github):
             status_code = getattr(response, "status_code", 0)
             if status_code == 403:
                 self.warning(
-                    f"The current access key does not have access to workflow artifacts {owner}/{repo}/{artifact_id} (status: {status_code})"
+                    f"The current access key does not have access to workflow artifacts {owner}/{repo}/{artifact_id}, The API key must have the 'repo' scope or read 'Actions' repository permissions (status: {status_code})"
                 )
         return file_destination

--- a/bbot/test/test_step_2/module_tests/test_module_github_workflows.py
+++ b/bbot/test/test_step_2/module_tests/test_module_github_workflows.py
@@ -18,9 +18,12 @@ class TestGithub_Workflows(ModuleTestBase):
     zip_content = data.getvalue()
 
     async def setup_before_prep(self, module_test):
-        module_test.httpx_mock.add_response(url="https://api.github.com/zen")
+        module_test.httpx_mock.add_response(
+            url="https://api.github.com/zen", match_headers={"Authorization": "token asdf"}
+        )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/orgs/blacklanternsecurity",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "login": "blacklanternsecurity",
                 "id": 25311592,
@@ -56,6 +59,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/orgs/blacklanternsecurity/repos?per_page=100&page=1",
+            match_headers={"Authorization": "token asdf"},
             json=[
                 {
                     "id": 459780477,
@@ -162,6 +166,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/workflows?per_page=100&page=1",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "total_count": 3,
                 "workflows": [
@@ -182,6 +187,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/workflows/22452226/runs?status=success&per_page=1",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "total_count": 2993,
                 "workflow_runs": [
@@ -428,6 +434,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/runs/8839360698/logs",
+            match_headers={"Authorization": "token asdf"},
             headers={
                 "location": "https://productionresultssa10.blob.core.windows.net/actions-results/7beb304e-f42c-4830-a027-4f5dec53107d/workflow-job-run-3a559e2a-952e-58d2-b8db-2e604a9266d7/logs/steps/step-logs-0e34a19a-18b0-4208-b27a-f8c031db2d17.txt?rsct=text%2Fplain&se=2024-04-26T16%3A25%3A39Z&sig=a%2FiN8dOw0e3tiBQZAfr80veI8OYChb9edJ1eFY136B4%3D&sp=r&spr=https&sr=b&st=2024-04-26T16%3A15%3A34Z&sv=2021-12-02"
             },
@@ -439,6 +446,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/runs/8839360698/artifacts",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "total_count": 1,
                 "artifacts": [
@@ -466,6 +474,7 @@ class TestGithub_Workflows(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/artifacts/1829832535/zip",
+            match_headers={"Authorization": "token asdf"},
             headers={
                 "location": "https://pipelinesghubeus22.actions.githubusercontent.com/uYHz4cw2WwYcB2EU57uoCs3MaEDiz8veiVlAtReP3xevBriD1h/_apis/pipelines/1/runs/214601/signedartifactscontent?artifactName=build.tar.gz&urlExpires=2024-08-20T14%3A41%3A41.8000556Z&urlSigningMethod=HMACV2&urlSignature=OOBxLx4eE5A8uHjxOIvQtn3cLFQOBW927mg0hcTHO6U%3D"
             },

--- a/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
+++ b/bbot/test/test_step_2/module_tests/test_module_trufflehog.py
@@ -16,6 +16,7 @@ class TestTrufflehog(ModuleTestBase):
         "modules": {
             "postman_download": {"api_key": "asdf", "output_folder": str(download_dir)},
             "docker_pull": {"output_folder": str(download_dir)},
+            "github_org": {"api_key": "asdf"},
             "git_clone": {"output_folder": str(download_dir)},
         }
     }
@@ -34,7 +35,9 @@ class TestTrufflehog(ModuleTestBase):
     file_content = "Verifiable Secret:\nhttps://admin:admin@the-internet.herokuapp.com/basic_auth\n\nUnverifiable Secret:\nhttps://admin:admin@internal.host.com"
 
     async def setup_before_prep(self, module_test):
-        module_test.httpx_mock.add_response(url="https://api.github.com/zen")
+        module_test.httpx_mock.add_response(
+            url="https://api.github.com/zen", match_headers={"Authorization": "token asdf"}
+        )
         module_test.httpx_mock.add_response(
             url="https://api.getpostman.com/me",
             json={
@@ -68,6 +71,7 @@ class TestTrufflehog(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/orgs/blacklanternsecurity",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "login": "blacklanternsecurity",
                 "id": 25311592,
@@ -103,6 +107,7 @@ class TestTrufflehog(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/orgs/blacklanternsecurity/repos?per_page=100&page=1",
+            match_headers={"Authorization": "token asdf"},
             json=[
                 {
                     "id": 459780477,
@@ -310,6 +315,7 @@ class TestTrufflehog(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/workflows?per_page=100&page=1",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "total_count": 3,
                 "workflows": [
@@ -330,6 +336,7 @@ class TestTrufflehog(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/workflows/22452226/runs?status=success&per_page=1",
+            match_headers={"Authorization": "token asdf"},
             json={
                 "total_count": 2993,
                 "workflow_runs": [
@@ -576,6 +583,7 @@ class TestTrufflehog(ModuleTestBase):
         )
         module_test.httpx_mock.add_response(
             url="https://api.github.com/repos/blacklanternsecurity/bbot/actions/runs/8839360698/logs",
+            match_headers={"Authorization": "token asdf"},
             headers={
                 "location": "https://productionresultssa10.blob.core.windows.net/actions-results/7beb304e-f42c-4830-a027-4f5dec53107d/workflow-job-run-3a559e2a-952e-58d2-b8db-2e604a9266d7/logs/steps/step-logs-0e34a19a-18b0-4208-b27a-f8c031db2d17.txt?rsct=text%2Fplain&se=2024-04-26T16%3A25%3A39Z&sig=a%2FiN8dOw0e3tiBQZAfr80veI8OYChb9edJ1eFY136B4%3D&sp=r&spr=https&sr=b&st=2024-04-26T16%3A15%3A34Z&sv=2021-12-02"
             },
@@ -1221,6 +1229,7 @@ class TestTrufflehog_NonVerified(TestTrufflehog):
             "trufflehog": {"only_verified": False},
             "docker_pull": {"output_folder": str(download_dir)},
             "postman_download": {"api_key": "asdf", "output_folder": str(download_dir)},
+            "github_org": {"api_key": "asdf"},
             "git_clone": {"output_folder": str(download_dir)},
         }
     }


### PR DESCRIPTION
The github workflows module was still using the download helper when the rest of the module was utilizing the API key rotation feature this meant that the API key was no longer being included in the headers when it went to download a artifact but it also couldnt rotate API keys if it ever hit any rate-limits.

- It now uses the new `api_download` helper which includes the api key rotation feature

- And I have also updated the error messages from this module as the documentation and error messages from github was a bit lacking on what scopes your api key actully required when downloading artifacts from public repos

Closes #2374 
Closes #2315 