### PR TITLE
Clean up watchdog tasks on scan exit

### DIFF
--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -165,7 +165,6 @@ class BaseModule:
         self._default_handle_batch_timeout = self.scan.config.get(
             "module_handle_batch_timeout", 60 * 60 * 2
         )  # 2 hours
-        self._event_handler_watchdog_task = None
         self._event_handler_watchdog_interval = self.event_handler_timeout / 10
 
         # used for optional "per host" tracking
@@ -623,10 +622,11 @@ class BaseModule:
             asyncio.create_task(self._worker(), name=f"{self.scan.name}.{self.name}._worker()")
             for _ in range(self.module_threads)
         ]
-        self._event_handler_watchdog_task = asyncio.create_task(
+        watchdog_task = asyncio.create_task(
             self._event_handler_watchdog(),
             name=f"{self.scan.name}.{self.name}._event_handler_watchdog()",
         )
+        self._tasks.append(watchdog_task)
 
     async def _setup(self, deps_only=False):
         """ """


### PR DESCRIPTION
Minor housekeeping as these tasks weren't being cleaned up properly.