### PR TITLE
More helpful error message when failing to load BBOT module

### DIFF
--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -16,6 +16,7 @@ from secrets import token_bytes
 from ansible_runner.interface import run
 from subprocess import CalledProcessError
 
+from bbot import __version__
 from ..misc import can_sudo_without_password, os_platform, rm_at_exit, get_python_constraints
 
 log = logging.getLogger("bbot.core.helpers.depsinstaller")
@@ -174,6 +175,7 @@ class DepsInstaller:
                     + self.venv
                     + str(self.parent_helper.bbot_home)
                     + os.uname()[1]
+                    + str(__version__)
                 ).hexdigest()
                 success = self.setup_status.get(module_hash, None)
                 dependencies = list(chain(*preloaded["deps"].values()))

--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -460,7 +460,12 @@ class ModuleLoader:
     def load_modules(self, module_names):
         modules = {}
         for module_name in module_names:
-            module = self.load_module(module_name)
+            try:
+                module = self.load_module(module_name)
+            except ModuleNotFoundError as e:
+                raise BBOTError(
+                    f"Error loading module {module_name}: {e}. You may have leftover artifacts from an older version of BBOT. Try deleting/renaming your '~/.bbot' directory."
+                ) from e
             modules[module_name] = module
         return modules
 


### PR DESCRIPTION
When a pip package is missing, it's usually because the user has artifacts leftover in `~/.bbot` from an older version. This improves the error message.

It also adds the BBOT version to the cache key, which should help prevent this error to begin with.

FYSA @pjhartlieb 