### PR TITLE
Don't auto-enable httpx on --exclude-cdn

### DIFF
--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -164,8 +164,10 @@ class ModuleLoader:
                         if module_dir.name in ("output", "internal"):
                             module_type = str(module_dir.name)
 
+                        disable_auto_module_deps = preloaded.get("disable_auto_module_deps", False)
+
                         # derive module dependencies from watched event types (only for scan modules)
-                        if module_type == "scan":
+                        if module_type == "scan" and not disable_auto_module_deps:
                             for event_type in preloaded["watched_events"]:
                                 if event_type in self.default_module_deps:
                                     deps_modules = set(preloaded.get("deps", {}).get("modules", []))
@@ -328,6 +330,7 @@ class ModuleLoader:
         ansible_tasks = []
         config = {}
         options_desc = {}
+        disable_auto_module_deps = False
         python_code = open(module_file).read()
         # take a hash of the code so we can keep track of when it changes
         module_hash = sha1(python_code).hexdigest()
@@ -352,8 +355,11 @@ class ModuleLoader:
             # look for classes
             if type(root_element) == ast.ClassDef:
                 for class_attr in root_element.body:
+                    if not type(class_attr) == ast.Assign:
+                        continue
+
                     # class attributes that are dictionaries
-                    if type(class_attr) == ast.Assign and type(class_attr.value) == ast.Dict:
+                    if type(class_attr.value) == ast.Dict:
                         # module options
                         if any(target.id == "options" for target in class_attr.targets):
                             config.update(ast.literal_eval(class_attr.value))
@@ -365,7 +371,7 @@ class ModuleLoader:
                             meta = ast.literal_eval(class_attr.value)
 
                     # class attributes that are lists
-                    if type(class_attr) == ast.Assign and type(class_attr.value) == ast.List:
+                    if type(class_attr.value) == ast.List:
                         # flags
                         if any(target.id == "flags" for target in class_attr.targets):
                             for flag in class_attr.value.elts:
@@ -414,6 +420,12 @@ class ModuleLoader:
                                 if type(dep_common.value) == str:
                                     deps_common.append(dep_common.value)
 
+                    # class attributes that are booleans
+                    if type(class_attr.value) == ast.Constant:
+                        if any(target.id == "_disable_auto_module_deps" for target in class_attr.targets):
+                            if type(class_attr.value.value) == bool:
+                                disable_auto_module_deps = class_attr.value.value
+
         for task in ansible_tasks:
             if "become" not in task:
                 task["become"] = False
@@ -440,6 +452,7 @@ class ModuleLoader:
                 "common": deps_common,
             },
             "sudo": len(deps_apt) > 0,
+            "disable_auto_module_deps": disable_auto_module_deps,
         }
         ansible_task_list = list(ansible_tasks)
         for dep_common in deps_common:

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -70,6 +70,8 @@ class BaseModule:
 
         _stats_exclude (bool): Whether to exclude this module from scan statistics. Default is False.
 
+        _disable_auto_module_deps (bool): Whether to disable automatic module dependencies. This is useful e.g. if the module consumes URLs, but you don't want to automatically enable the httpx module. Default is False.
+
         _qsize (int): Outgoing queue size (0 for infinite). Default is 0.
 
         _priority (int): Priority level of the module. Lower values are higher priority. Default is 3.
@@ -113,6 +115,7 @@ class BaseModule:
 
     _preserve_graph = False
     _stats_exclude = False
+    _disable_auto_module_deps = False
     _qsize = 1000
     _priority = 3
     _name = "base"

--- a/bbot/modules/portfilter.py
+++ b/bbot/modules/portfilter.py
@@ -19,6 +19,8 @@ class portfilter(BaseInterceptModule):
     }
 
     _priority = 4
+    # we consume URLs but we don't want to automatically enable httpx
+    _disable_auto_module_deps = True
 
     async def setup(self):
         self.cdn_tags = [t.strip() for t in self.config.get("cdn_tags", "").split(",")]

--- a/bbot/test/test_step_2/module_tests/test_module_portfilter.py
+++ b/bbot/test/test_step_2/module_tests/test_module_portfilter.py
@@ -43,6 +43,8 @@ class TestPortfilter_enabled(TestPortfilter_disabled):
     modules_overrides = ["portfilter"]
 
     def check(self, module_test, events):
+        # even though portfilter listens for URLs, enabling it should not automatically enable httpx
+        assert "httpx" not in module_test.scan.modules
         open_ports = {event.data for event in events if event.type == "OPEN_TCP_PORT"}
         # we should be missing the 8080 port because it's a CDN and not in portfilter's allowed list of open ports
         assert open_ports == {"www.blacklanternsecurity.com:443", "www.blacklanternsecurity.com:21"}


### PR DESCRIPTION
Since `portfilter` listens for URLs but doesn't require them, this PR adds a module option to accommodate that.