### PR TITLE
Update nuclei to 3.6.2

### DIFF
--- a/bbot/modules/nuclei.py
+++ b/bbot/modules/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.6.1",
+        "version": "3.6.2",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/nuclei.py."

# Release notes:
## What's Changed

### ✨ New Features

* Enabled TLS session caching in the client pool to improve connection reuse and reduce handshake overhead _(internal)_ by @dwisiswant0 in #6713
* Added support for providing a custom Jira server URL (`site-url`) when using OAuth authentication by @Ice3man543 in #6716

### 🐞 Bug Fixes

* Improved duplicate issue detection by properly paginating Gitea issue searches by @leonjza in #6707
* Restored JavaScript template execution when the `Port` argument is not provided by @dwisiswant0 in #6709
* Added pagination support when searching for duplicate issues in GitLab by @dwisiswant0 in #6712
* Corrected an incorrect PostgreSQL execution call signature in the JavaScript engine by @Mzack9999 in #6731
* Fixed a MySQL panic caused by a missing `executionId` in the execution context by @dwisiswant0 in #6735
* Fixed a segmentation fault in flow execution related to `hasMatchers` by @dwisiswant0 in #6739

### ⚡ Performance Improvements

* Optimized the `MergeMaps` generator to reduce memory allocations by @dwisiswant0 in #6718

### 🔧 Maintenance

* Updated `projectdiscovery/utils` to v0.8.0 to fix a deadlock in `httputil.ResponseChain` by @dwisiswant0 in #6723
* Introduced a PowerShell integration test to improve cross-platform test coverage by @Mzack9999 in #6724
* Updated multiple Go module dependencies across two dependency refreshes by @dependabot[bot] in #6729 & #6741

### Other Changes

* Updated issue and pull request templates by @dwisiswant0 in #6673
* Refactored CI workflows by @dwisiswant0 in #6728, this includes:
  * Shipping binaries with Green Tea GC enabled via `GOEXPERIMENT`
  * Shipping binaries built with profile-guided optimization (PGO)
  * Fixing an auto-merge workflow that never triggered
* Switched release tests to use a stable Go version by @dwisiswant0 in #6737
* Upgraded `actions/download-artifact` from v6 to v7 in GitHub workflows by @dependabot[bot] in #6742
* Updated compatibility checks to use a stable Go version by @dwisiswant0 in #6743

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.6.1...v3.6.2