### PR TITLE
Fix lightfuzz envelope cross-contamination between submodules

### DIFF
--- a/bbot/core/helpers/web/envelopes.py
+++ b/bbot/core/helpers/web/envelopes.py
@@ -166,6 +166,34 @@ class BaseEnvelope(metaclass=EnvelopeChildTracker):
                 data = data[segment]
         return data
 
+    def pack_value(self, value, key=None):
+        """
+        Pack a value through the envelope chain WITHOUT modifying internal state.
+        """
+        if key is None:
+            key = self.selected_subparam
+
+        inner = self.unpacked_data(recursive=False)
+
+        if hasattr(inner, "pack_value"):
+            # Inner is another envelope - delegate down the chain
+            data = inner.pack_value(value, key)
+        elif self.singleton:
+            # At the leaf singleton - use the new value directly
+            data = value
+        else:
+            # At the leaf non-singleton (JSON/XML) - copy the data and substitute
+            import copy
+
+            if key is None:
+                raise ValueError("No subparam selected for non-singleton envelope")
+            data = copy.deepcopy(inner)
+            target = data
+            for segment in key[:-1]:
+                target = target[segment]
+            target[key[-1]] = value
+        return self._pack(data)
+
     def set_subparam(self, key=None, value=None, recursive=True):
         envelope = self
         if recursive:

--- a/bbot/core/helpers/web/envelopes.py
+++ b/bbot/core/helpers/web/envelopes.py
@@ -188,9 +188,11 @@ class BaseEnvelope(metaclass=EnvelopeChildTracker):
             if key is None:
                 raise ValueError("No subparam selected for non-singleton envelope")
             data = copy.deepcopy(inner)
+            # In the loop: Traverse all the way down to the parent of the target value (all segments except the last),
             target = data
             for segment in key[:-1]:
                 target = target[segment]
+            # Use the final segment to actually assign the value.
             target[key[-1]] = value
         return self._pack(data)
 

--- a/bbot/modules/lightfuzz/submodules/base.py
+++ b/bbot/modules/lightfuzz/submodules/base.py
@@ -265,13 +265,16 @@ class BaseLightfuzz:
 
     def outgoing_probe_value(self, outgoing_probe_value):
         """
-        Transparently modifies the outgoing probe value (fuzz probe being sent to the target), given any envelopes that may have been identified, so that fuzzing within the envelopes can occur.
+        Transparently packs the outgoing probe value (fuzz probe being sent to the target) through
+        any envelopes that may have been identified, so that fuzzing within the envelopes can occur.
+
+        Uses pack_value() to avoid mutating the envelope's internal state, preventing cross-contamination
+        between submodules that share the same event/envelope object.
         """
         self.debug(f"outgoing_probe_value (before packing): {outgoing_probe_value} / {self.event}")
         envelopes = getattr(self.event, "envelopes", None)
         if envelopes is not None:
-            envelopes.set_subparam(value=outgoing_probe_value)
-            outgoing_probe_value = envelopes.pack()
+            outgoing_probe_value = envelopes.pack_value(outgoing_probe_value)
             self.debug(
                 f"outgoing_probe_value (after packing): {outgoing_probe_value} with envelopes [{envelopes}] / {self.event}"
             )

--- a/bbot/test/test_step_1/test_web_envelopes.py
+++ b/bbot/test/test_step_1/test_web_envelopes.py
@@ -341,3 +341,77 @@ async def test_web_envelopes():
 
     tiny_base64 = BaseEnvelope.detect("YWJi")
     assert isinstance(tiny_base64, TextEnvelope)
+
+
+async def test_web_envelope_pack_value():
+    """
+    Test pack_value() - encodes a value through the envelope chain without modifying internal state.
+    """
+    import base64
+    import json
+
+    from bbot.core.helpers.web.envelopes import BaseEnvelope
+
+    # Text envelope (singleton, transparent)
+    text_envelope = BaseEnvelope.detect("original_text")
+    assert text_envelope.pack_value("new_text") == "new_text"
+    assert text_envelope.get_subparam() == "original_text"
+
+    # Hex envelope (singleton chain: hex -> text)
+    hex_envelope = BaseEnvelope.detect("706172616d")  # "param" in hex
+    packed = hex_envelope.pack_value("modified")
+    assert packed == "modified".encode().hex()
+    assert hex_envelope.get_subparam() == "param"
+
+    # Base64 envelope (singleton chain: base64 -> text)
+    b64_envelope = BaseEnvelope.detect("cGFyYW0=")  # "param" in base64
+    packed = b64_envelope.pack_value("modified")
+    assert packed == base64.b64encode(b"modified").decode()
+    assert b64_envelope.get_subparam() == "param"
+
+    # Nested hex -> base64 -> text chain
+    nested_envelope = BaseEnvelope.detect("634746795957303d")  # hex(base64("param"))
+    packed = nested_envelope.pack_value("modified")
+    expected = base64.b64encode(b"modified").decode().encode().hex()
+    assert packed == expected
+    assert nested_envelope.get_subparam() == "param"
+
+    # URL envelope (singleton chain: url -> text)
+    url_envelope = BaseEnvelope.detect("a%20b%20c")
+    packed = url_envelope.pack_value("x y z")
+    assert packed == "x%20y%20z"
+    assert url_envelope.get_subparam() == "a b c"
+
+    # JSON inside base64 (non-singleton: base64 -> json) - only the selected subparam is substituted in the output
+    b64_json = BaseEnvelope.detect("eyJwYXJhbTEiOiAidmFsMSIsICJwYXJhbTIiOiB7InBhcmFtMyI6ICJ2YWwzIn19")
+    b64_json.selected_subparam = ["param2", "param3"]
+    packed = b64_json.pack_value("new_val3")
+    decoded_json = json.loads(base64.b64decode(packed).decode())
+    assert decoded_json["param1"] == "val1"
+    assert decoded_json["param2"]["param3"] == "new_val3"
+    assert b64_json.get_subparam() == "val3"
+    assert b64_json.get_subparam(["param1"]) == "val1"
+
+    # Repeated calls do not accumulate - each starts from the original state
+    hex_envelope = BaseEnvelope.detect("706172616d")
+    hex_envelope.pack_value("first_modification")
+    hex_envelope.pack_value("second_modification")
+    hex_envelope.pack_value("third_modification")
+    assert hex_envelope.get_subparam() == "param"
+
+    # Multiple callers sharing the same envelope each produce correct output independently
+    shared_envelope = BaseEnvelope.detect("706172616d")  # "param" in hex
+
+    probe_a = shared_envelope.pack_value("param' OR 1=1--")
+    assert probe_a == "param' OR 1=1--".encode().hex()
+    assert shared_envelope.get_subparam() == "param"
+
+    probe_b = shared_envelope.pack_value("param| echo 1234 |")
+    assert probe_b == "param| echo 1234 |".encode().hex()
+    assert shared_envelope.get_subparam() == "param"
+
+    probe_c = shared_envelope.pack_value("../../etc/passwd")
+    assert probe_c == "../../etc/passwd".encode().hex()
+
+    assert shared_envelope.get_subparam() == "param"
+    assert shared_envelope.pack() == "706172616d"

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1885,3 +1885,29 @@ class Test_Lightfuzz_esi(ModuleTestBase):
 
         assert web_parameter_emitted, "WEB_PARAMETER was not emitted"
         assert esi_finding_emitted, "ESI FINDING not emitted"
+
+
+# Envelope state isolation: crypto error detection with all submodules enabled.
+# Crypto runs after sqli/cmdi/xss/path/ssti. Each prior submodule calls outgoing_probe_value()
+# which must not corrupt the envelope state that crypto reads via incoming_probe_value().
+class Test_Lightfuzz_envelope_isolation_crypto(Test_Lightfuzz_crypto_error):
+    config_overrides = {
+        "interactsh_disable": True,
+        "modules": {
+            "lightfuzz": {
+                "enabled_submodules": ["sqli", "cmdi", "xss", "path", "ssti", "crypto", "serial", "esi"],
+            }
+        },
+    }
+
+
+# Envelope state isolation: padding oracle detection with all submodules enabled.
+class Test_Lightfuzz_envelope_isolation_paddingoracle(Test_Lightfuzz_PaddingOracleDetection):
+    config_overrides = {
+        "interactsh_disable": True,
+        "modules": {
+            "lightfuzz": {
+                "enabled_submodules": ["sqli", "cmdi", "xss", "path", "ssti", "crypto", "serial", "esi"],
+            }
+        },
+    }


### PR DESCRIPTION
## Lightfuzz Envelope Contamination Bug: Root Cause and Fix

Lightfuzz submodules (SQLi, CMDi, XSS, crypto, etc.) execute sequentially against the same event. When a parameter value is wrapped in an encoding layer (hex, Base64, etc.), the envelope system transparently encodes and decodes probe values so fuzzing occurs inside the encoding.

### Problem

`outgoing_probe_value()` encoded probes using:

    set_subparam() + pack()

This process mutated the envelope’s internal state.

**Failure sequence**

1. The SQLi module sent `' OR 1=1--` through the envelope.
2. The envelope stored this payload as the parameter value.
3. The CMDi module read the mutated value instead of the original.
4. By the time later modules ran, the "original" value had been fully contaminated by prior payloads.

### Root Cause

Envelope packing was stateful. Encoding a probe altered the stored parameter value, causing cross-module contamination.

### Fix

A new method was added:

    pack_value()

**Behavior**

- Encodes a value through the full envelope chain
- Supports nested encodings
- Does not modify internal state

`outgoing_probe_value()` now uses `pack_value()` instead of the mutating `set_subparam() + pack()` pattern.

### Result

- Each submodule receives the correct original value
- Probe encoding remains accurate
- Module isolation is preserved

### Test Coverage Improvements

New tests enable all submodules simultaneously to verify envelope isolation.

Previously, tests only exercised a single submodule at a time, allowing this issue to go undetected.
