### PR TITLE
improve padding oracle detection

### DIFF
--- a/bbot/modules/lightfuzz/submodules/crypto.py
+++ b/bbot/modules/lightfuzz/submodules/crypto.py
@@ -232,37 +232,56 @@ class crypto(BaseLightfuzz):
         else:
             baseline_byte = b"\x00"  # set the baseline byte to 0x00
             starting_pos = 1  # set the starting position to 1
-        # first obtain
+
+        baseline_probe_value = self.format_agnostic_encode(
+            ivblock + paddingblock[:-1] + baseline_byte + datablock, encoding
+        )
         baseline = self.compare_baseline(
             self.event.data["type"],
-            self.format_agnostic_encode(ivblock + paddingblock[:-1] + baseline_byte + datablock, encoding),
+            baseline_probe_value,
             cookies,
         )
         differ_count = 0
         # for each possible byte value, send a probe and check if the response is different
         for i in range(starting_pos, starting_pos + 254):
             byte = bytes([i])
+            probe_value = self.format_agnostic_encode(ivblock + paddingblock[:-1] + byte + datablock, encoding)
             oracle_probe = await self.compare_probe(
                 baseline,
                 self.event.data["type"],
-                self.format_agnostic_encode(ivblock + paddingblock[:-1] + byte + datablock, encoding),
+                probe_value,
                 cookies,
             )
             # oracle_probe[0] will be false if the response is different - oracle_probe[1] stores what aspect of the response is different (headers, body, code)
             if oracle_probe[0] is False and "body" in oracle_probe[1]:
+                # When the server reflects submitted values or reveals decrypted data, every probe will differ in the body. Strip the known probe values from both responses and re-compare.
+                stripped_baseline = baseline.baseline.text
+                stripped_probe = oracle_probe[3].text
+                for encoded_baseline, encoded_probe in [
+                    (baseline_probe_value, probe_value),
+                    (baseline_probe_value.replace("+", " "), probe_value.replace("+", " ")),
+                    (quote(baseline_probe_value), quote(probe_value)),
+                ]:
+                    stripped_baseline = stripped_baseline.replace(encoded_baseline, "")
+                    stripped_probe = stripped_probe.replace(encoded_probe, "")
+                if stripped_baseline == stripped_probe:
+                    continue
+                # If the server reveals decrypted data, the response may differ by only a few bytes (the varying decrypted byte). Tolerate small character-level differences.
+                if len(stripped_baseline) == len(stripped_probe):
+                    char_diffs = sum(1 for a, b in zip(stripped_baseline, stripped_probe) if a != b)
+                    if char_diffs <= 5:
+                        continue
                 differ_count += 1
-
-                if i == 2:
-                    if possible_first_byte is True:
-                        # Thats two results which appear "different". Since this is the first run, it's entirely possible \x00 was the correct padding.
-                        # We will break from this loop and redo it with the last byte as the baseline instead of the first
-                        return None
-                    else:
-                        # Now that we have tried the run twice, we know it can't be because the first byte was the correct padding, and we know it is not vulnerable
-                        return False
-        # A padding oracle vulnerability will produce exactly one different response, and no more, so this is likely a real padding oracle
-        if differ_count == 1:
+        self.debug(f"padding_oracle_execute: finished loop. differ_count={differ_count}")
+        # A padding oracle vulnerability can produce a small number of different responses.
+        # The correct \x01 padding byte always differs, but also, multi-byte padding values (\x02\x02, \x03\x03\x03, etc.) can also produce valid padding if the intermediate state randomly aligns. At most 'block_size' of such values are possible.
+        if 1 <= differ_count <= block_size:
             return True
+        # If too many probes differ, the baseline byte may have been the correct padding byte (1/255 chance).
+        # In that case, the baseline response represents "valid padding" and nearly all probes appear different.
+        # Retry with a different baseline byte to rule this out.
+        if possible_first_byte and differ_count > block_size:
+            return None
         return False
 
     async def padding_oracle(self, probe_value, cookies):

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1735,11 +1735,17 @@ class Test_Lightfuzz_PaddingOracleDetection_Reflecting(Test_Lightfuzz_PaddingOra
                 if "HTTP Extracted Parameter [encrypted_data] (POST Form" in e.data["description"]:
                     web_parameter_extracted = True
             if e.type == "FINDING":
-                if "Probable Cryptographic Parameter." in e.data["description"] and "encrypted_data" in e.data["description"]:
+                if (
+                    "Probable Cryptographic Parameter." in e.data["description"]
+                    and "encrypted_data" in e.data["description"]
+                ):
                     cryptographic_parameter_finding = True
 
             if e.type == "VULNERABILITY":
-                if "Padding Oracle Vulnerability. Block size: [16]" in e.data["description"] and "encrypted_data" in e.data["description"]:
+                if (
+                    "Padding Oracle Vulnerability. Block size: [16]" in e.data["description"]
+                    and "encrypted_data" in e.data["description"]
+                ):
                     padding_oracle_detected = True
 
         assert web_parameter_extracted, "Web parameter was not extracted"
@@ -1806,7 +1812,10 @@ class Test_Lightfuzz_PaddingOracleDetection_Noisy(Test_Lightfuzz_PaddingOracleDe
                 if "HTTP Extracted Parameter [encrypted_data] (POST Form" in e.data["description"]:
                     web_parameter_extracted = True
             if e.type == "FINDING":
-                if "Probable Cryptographic Parameter." in e.data["description"] and "encrypted_data" in e.data["description"]:
+                if (
+                    "Probable Cryptographic Parameter." in e.data["description"]
+                    and "encrypted_data" in e.data["description"]
+                ):
                     cryptographic_parameter_finding = True
             if e.type == "VULNERABILITY":
                 if "Padding Oracle" in e.data["description"]:
@@ -1814,7 +1823,9 @@ class Test_Lightfuzz_PaddingOracleDetection_Noisy(Test_Lightfuzz_PaddingOracleDe
 
         assert web_parameter_extracted, "Web parameter was not extracted"
         assert cryptographic_parameter_finding, "Cryptographic parameter not detected"
-        assert not padding_oracle_detected, "Padding oracle should NOT be detected when 30 probes differ (exceeds block size)"
+        assert not padding_oracle_detected, (
+            "Padding oracle should NOT be detected when 30 probes differ (exceeds block size)"
+        )
 
 
 class Test_Lightfuzz_XSS_jsquotecontext(ModuleTestBase):

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1691,6 +1691,132 @@ class Test_Lightfuzz_PaddingOracleDetection(ModuleTestBase):
         assert padding_oracle_detected, "Padding oracle vulnerability was not detected"
 
 
+class Test_Lightfuzz_PaddingOracleDetection_Reflecting(Test_Lightfuzz_PaddingOracleDetection):
+    """Padding oracle test where the server reflects the submitted value in the response body.
+    Without reflection-stripping logic, every probe body differs and detection always fails."""
+
+    def request_handler(self, request):
+        encrypted_value = quote(
+            "dplyorsu8VUriMW/8DqVDU6kRwL/FDk3Q+4GXVGZbo0CTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg=="
+        )
+        default_html_response = f"""
+        <html>
+            <body>
+                <form action="/decrypt" method="post">
+                    <input type="hidden" name="encrypted_data" value="{encrypted_value}" />
+                    <button type="submit">Decrypt</button>
+                </form>
+            </body>
+        </html>
+        """
+
+        if "/decrypt" in request.url and request.method == "POST":
+            if request.form and request.form["encrypted_data"]:
+                encrypted_data = request.form["encrypted_data"]
+                if "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALwAgLKWJi2nWKbh9ag5rnhm" in encrypted_data:
+                    response_content = f"Padding error detected. Input: {encrypted_data}"
+                elif "4GXVGZbo0DTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg" in encrypted_data:
+                    response_content = f"DIFFERENT CRYPTOGRAPHIC ERROR. Input: {encrypted_data}"
+                elif "AAAAAAA" in encrypted_data:
+                    response_content = f"YET DIFFERENT CRYPTOGRAPHIC ERROR. Input: {encrypted_data}"
+                else:
+                    response_content = f"Decryption failed. Input: {encrypted_data}"
+
+            return Response(response_content, status=200)
+        else:
+            return Response(default_html_response, status=200)
+
+    def check(self, module_test, events):
+        web_parameter_extracted = False
+        cryptographic_parameter_finding = False
+        padding_oracle_detected = False
+        for e in events:
+            if e.type == "WEB_PARAMETER":
+                if "HTTP Extracted Parameter [encrypted_data] (POST Form" in e.data["description"]:
+                    web_parameter_extracted = True
+            if e.type == "FINDING":
+                if "Probable Cryptographic Parameter." in e.data["description"] and "encrypted_data" in e.data["description"]:
+                    cryptographic_parameter_finding = True
+
+            if e.type == "VULNERABILITY":
+                if "Padding Oracle Vulnerability. Block size: [16]" in e.data["description"] and "encrypted_data" in e.data["description"]:
+                    padding_oracle_detected = True
+
+        assert web_parameter_extracted, "Web parameter was not extracted"
+        assert cryptographic_parameter_finding, "Cryptographic parameter not detected"
+        assert padding_oracle_detected, "Padding oracle vulnerability was not detected"
+
+
+class Test_Lightfuzz_PaddingOracleDetection_Noisy(Test_Lightfuzz_PaddingOracleDetection):
+    """Padding oracle negative test: the server returns different responses for ~30 byte values,
+    which exceeds any valid block size. This should NOT produce a VULNERABILITY."""
+
+    def request_handler(self, request):
+        encrypted_value = quote(
+            "dplyorsu8VUriMW/8DqVDU6kRwL/FDk3Q+4GXVGZbo0CTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg=="
+        )
+        default_html_response = f"""
+        <html>
+            <body>
+                <form action="/decrypt" method="post">
+                    <input type="hidden" name="encrypted_data" value="{encrypted_value}" />
+                    <button type="submit">Decrypt</button>
+                </form>
+            </body>
+        </html>
+        """
+
+        if "/decrypt" in request.url and request.method == "POST":
+            if request.form and request.form["encrypted_data"]:
+                encrypted_data = request.form["encrypted_data"]
+                # Check for the data block from the original ciphertext (mutate/truncate probes)
+                if "4GXVGZbo0DTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg" in encrypted_data:
+                    response_content = "DIFFERENT CRYPTOGRAPHIC ERROR"
+                # Padding oracle probes: null IV + padding blocks produce long runs of A's in base64
+                elif encrypted_data.startswith("AAAAAAAAAAAAAAAA"):
+                    try:
+                        decoded = base64.b64decode(encrypted_data)
+                        if len(decoded) >= 32:
+                            varying_byte = decoded[31]
+                            # 30 byte values produce a different response - way over any block size
+                            if 100 <= varying_byte <= 129:
+                                response_content = "Noisy error type A"
+                            else:
+                                response_content = "Decryption failed"
+                        else:
+                            response_content = "Decryption failed"
+                    except Exception:
+                        response_content = "Decryption failed"
+                # Arbitrary probe
+                elif "AAAAAAA" in encrypted_data:
+                    response_content = "YET DIFFERENT CRYPTOGRAPHIC ERROR"
+                else:
+                    response_content = "Decryption failed"
+
+            return Response(response_content, status=200)
+        else:
+            return Response(default_html_response, status=200)
+
+    def check(self, module_test, events):
+        web_parameter_extracted = False
+        cryptographic_parameter_finding = False
+        padding_oracle_detected = False
+        for e in events:
+            if e.type == "WEB_PARAMETER":
+                if "HTTP Extracted Parameter [encrypted_data] (POST Form" in e.data["description"]:
+                    web_parameter_extracted = True
+            if e.type == "FINDING":
+                if "Probable Cryptographic Parameter." in e.data["description"] and "encrypted_data" in e.data["description"]:
+                    cryptographic_parameter_finding = True
+            if e.type == "VULNERABILITY":
+                if "Padding Oracle" in e.data["description"]:
+                    padding_oracle_detected = True
+
+        assert web_parameter_extracted, "Web parameter was not extracted"
+        assert cryptographic_parameter_finding, "Cryptographic parameter not detected"
+        assert not padding_oracle_detected, "Padding oracle should NOT be detected when 30 probes differ (exceeds block size)"
+
+
 class Test_Lightfuzz_XSS_jsquotecontext(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["httpx", "lightfuzz", "excavate", "paramminer_getparams"]
@@ -1903,6 +2029,18 @@ class Test_Lightfuzz_envelope_isolation_crypto(Test_Lightfuzz_crypto_error):
 
 # Envelope state isolation: padding oracle detection with all submodules enabled.
 class Test_Lightfuzz_envelope_isolation_paddingoracle(Test_Lightfuzz_PaddingOracleDetection):
+    config_overrides = {
+        "interactsh_disable": True,
+        "modules": {
+            "lightfuzz": {
+                "enabled_submodules": ["sqli", "cmdi", "xss", "path", "ssti", "crypto", "serial", "esi"],
+            }
+        },
+    }
+
+
+# Envelope state isolation: reflecting padding oracle detection with all submodules enabled.
+class Test_Lightfuzz_envelope_isolation_paddingoracle_reflecting(Test_Lightfuzz_PaddingOracleDetection_Reflecting):
     config_overrides = {
         "interactsh_disable": True,
         "modules": {


### PR DESCRIPTION
This PR improves padding oracle detection, by increasing the number of scenarios where it will be successfully detected. For example, in a situation where the input, or the decrypted input, is reflected on to the page, the validation process is now looser to account for these situations, but should still be narrow enough to prevent false positives.