### PR TITLE
Fix interactsh decryption

### DIFF
--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -294,7 +294,7 @@ class Interactsh:
         Decrypts and returns the data received from the interact.sh server.
 
         Uses RSA and AES for decrypting the data. RSA with PKCS1_OAEP and SHA256 is used to decrypt the AES key,
-        and then AES (CFB mode) is used to decrypt the actual data payload.
+        and then AES (CTR mode) is used to decrypt the actual data payload.
 
         Parameters:
             aes_key (str): The AES key for decryption, encrypted with RSA and base64 encoded.
@@ -312,6 +312,7 @@ class Interactsh:
         decode = base64.b64decode(data)
         bs = AES.block_size
         iv = decode[:bs]
-        cryptor = AES.new(key=aes_plain_key, mode=AES.MODE_CFB, IV=iv, segment_size=128)
-        plain_text = cryptor.decrypt(decode)
-        return json.loads(plain_text[16:])
+        ciphertext = decode[bs:]
+        cryptor = AES.new(key=aes_plain_key, mode=AES.MODE_CTR, nonce=b"", initial_value=iv)
+        plain_text = cryptor.decrypt(ciphertext)
+        return json.loads(plain_text)


### PR DESCRIPTION
 The public interactsh OAST servers (oast.pro, oast.live, oast.site, oast.online, oast.fun, oast.me) were upgraded to interactsh v1.3.0, which switched the          
  server-side encryption from AES-CFB to AES-CTR. This broke BBOT's interactsh client — polling returns encrypted data that can't be decrypted with the old CFB mode, 
  producing garbled bytes and a UnicodeDecodeError
  
  Error polling interact.sh: 'utf-8' codec can't decode byte 0x8d in position 16: invalid start byte
  
 ###   Changes                                                                                                                                                             

  Updated _decrypt() in bbot/core/helpers/interactsh.py to match the new server-side encryption:

  - AES.MODE_CFB → AES.MODE_CTR with nonce=b"" and initial_value=iv
  - Separate IV from ciphertext before decryption instead of decrypting the whole blob and skipping 16 bytes after
  - Aligns with the official Go client's decryption logic in pkg/client/client.go

 ### References

  - https://github.com/projectdiscovery/interactsh/issues/1333
