### PR TITLE
Fix install_core_deps running ansible on every test invocation

### DIFF
--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -460,6 +460,23 @@ class DepsInstaller:
                 else:
                     log.warning("Incorrect password")
 
+    def _core_dep_satisfied(self, command):
+        """Check if a core dependency is satisfied.
+
+        For normal binary deps, check if the command exists on PATH.
+        For special entries like openssl_dev_headers, use a custom check.
+        """
+        if command == "openssl_dev_headers":
+            # check for openssl headers by looking for the pkg-config file or header
+            return any(
+                Path(p).exists()
+                for p in [
+                    "/usr/include/openssl/ssl.h",
+                    "/usr/local/include/openssl/ssl.h",
+                ]
+            ) or bool(self.parent_helper.which("openssl"))
+        return bool(self.parent_helper.which(command))
+
     async def install_core_deps(self):
         # skip if we've already successfully installed core deps for this definition
         core_deps_hash = str(mmh3.hash(orjson.dumps(self.CORE_DEPS, option=orjson.OPT_SORT_KEYS)))
@@ -471,31 +488,15 @@ class DepsInstaller:
         to_install = set()
         to_install_friendly = set()
         playbook = []
-        self._install_sudo_askpass()
-        # ensure tldextract data is cached
-        self.parent_helper.tldextract("evilcorp.co.uk")
-        # install any missing commands
+        # check which commands are missing
         for command, package_name_or_playbook in self.CORE_DEPS.items():
-            if not self.parent_helper.which(command):
-                to_install_friendly.add(command)
-                if isinstance(package_name_or_playbook, str):
-                    to_install.add(package_name_or_playbook)
-                else:
-                    playbook.extend(package_name_or_playbook)
-        # install ansible community.general collection
-        overall_success = True
-        if not self.setup_status.get("ansible:community.general", False):
-            log.info("Installing Ansible Community General Collection")
-            try:
-                command = ["ansible-galaxy", "collection", "install", "community.general"]
-                await self.parent_helper.run(command, check=True)
-                self.setup_status["ansible:community.general"] = True
-                log.info("Successfully installed Ansible Community General Collection")
-            except CalledProcessError as err:
-                log.warning(
-                    f"Failed to install Ansible Community.General Collection (return code {err.returncode}): {err.stderr}"
-                )
-                overall_success = False
+            if self._core_dep_satisfied(command):
+                continue
+            to_install_friendly.add(command)
+            if isinstance(package_name_or_playbook, str):
+                to_install.add(package_name_or_playbook)
+            else:
+                playbook.extend(package_name_or_playbook)
         # construct ansible playbook
         if to_install:
             playbook.append(
@@ -505,8 +506,26 @@ class DepsInstaller:
                     "become": True,
                 }
             )
-        # run playbook
+        # only run ansible if there's actually something to install
+        overall_success = True
         if playbook:
+            self._install_sudo_askpass()
+            # ensure tldextract data is cached
+            self.parent_helper.tldextract("evilcorp.co.uk")
+            # install ansible community.general collection if needed
+            if not self.setup_status.get("ansible:community.general", False):
+                log.info("Installing Ansible Community General Collection")
+                try:
+                    command = ["ansible-galaxy", "collection", "install", "community.general"]
+                    await self.parent_helper.run(command, check=True)
+                    self.setup_status["ansible:community.general"] = True
+                    log.info("Successfully installed Ansible Community General Collection")
+                except CalledProcessError as err:
+                    log.warning(
+                        f"Failed to install Ansible Community.General Collection (return code {err.returncode}): {err.stderr}"
+                    )
+                    overall_success = False
+            # run playbook
             log.info(f"Installing core BBOT dependencies: {','.join(sorted(to_install_friendly))}")
             self.ensure_root()
             success, _ = self.ansible_run(tasks=playbook)


### PR DESCRIPTION
## Summary
- `openssl_dev_headers` in `CORE_DEPS` is not a real binary, so `which()` always returns None, causing the full ansible playbook + `ansible-galaxy collection install community.general` to run on every invocation where the cache file is missing (~15s)
- Ansible, tldextract, and sudo setup ran unconditionally even when no deps were missing — moved them inside `if playbook:` so they only run when something actually needs installing
- Added `_core_dep_satisfied()` method that checks for actual OpenSSL header files instead of a nonexistent binary

## Test plan
- [x] Single module test time verified: ~17s → ~2s
- [ ] Full step_1 test suite
- [ ] Full step_2 module test suite
- [ ] CI passes