### PR TITLE
Fix benchmark report: uv.lock conflict, duplicate comments, broken formatting

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,100 +68,84 @@ jobs:
         script: |
           const fs = require('fs');
 
-          try {
-            const report = fs.readFileSync('benchmark_report.md', 'utf8');
-
-            // Find existing benchmark comment (with pagination)
+          // Helper: find existing benchmark comments on this PR
+          async function findBenchmarkComments() {
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              per_page: 100, // Get more comments per page
+              per_page: 100,
             });
 
-            // Debug: log all comments to see what we're working with
             console.log(`Found ${comments.data.length} comments on this PR`);
-            comments.data.forEach((comment, index) => {
-              console.log(`Comment ${index}: user=${comment.user.login}, body preview="${comment.body.substring(0, 100)}..."`);
-            });
 
-            const existingComments = comments.data.filter(comment =>
+            const benchmarkComments = comments.data.filter(comment =>
               comment.body.toLowerCase().includes('performance benchmark') &&
               comment.user.login === 'github-actions[bot]'
             );
 
-            console.log(`Found ${existingComments.length} existing benchmark comments`);
+            console.log(`Found ${benchmarkComments.length} existing benchmark comments`);
+            return benchmarkComments;
+          }
 
-            if (existingComments.length > 0) {
-              // Sort comments by creation date to find the most recent
-              const sortedComments = existingComments.sort((a, b) =>
+          // Helper: post or update the benchmark comment
+          async function upsertComment(body) {
+            const existing = await findBenchmarkComments();
+
+            if (existing.length > 0) {
+              const sorted = existing.sort((a, b) =>
                 new Date(b.created_at) - new Date(a.created_at)
               );
-
-              const mostRecentComment = sortedComments[0];
-              console.log(`Updating most recent benchmark comment: ${mostRecentComment.id} (created: ${mostRecentComment.created_at})`);
 
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: mostRecentComment.id,
-                body: report
+                comment_id: sorted[0].id,
+                body: body
               });
-              console.log('Updated existing benchmark comment');
+              console.log(`Updated benchmark comment: ${sorted[0].id}`);
 
-              // Delete any older duplicate comments
-              if (existingComments.length > 1) {
-                console.log(`Deleting ${existingComments.length - 1} older duplicate comments`);
-                for (let i = 1; i < sortedComments.length; i++) {
-                  const commentToDelete = sortedComments[i];
-                  console.log(`Attempting to delete comment ${commentToDelete.id} (created: ${commentToDelete.created_at})`);
-
-                  try {
-                    await github.rest.issues.deleteComment({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      comment_id: commentToDelete.id
-                    });
-                    console.log(`Successfully deleted duplicate comment: ${commentToDelete.id}`);
-                  } catch (error) {
-                    console.error(`Failed to delete comment ${commentToDelete.id}: ${error.message}`);
-                    console.error(`Error details:`, error);
-                  }
+              // Clean up older duplicates
+              for (let i = 1; i < sorted.length; i++) {
+                try {
+                  await github.rest.issues.deleteComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: sorted[i].id
+                  });
+                  console.log(`Deleted duplicate comment: ${sorted[i].id}`);
+                } catch (e) {
+                  console.error(`Failed to delete comment ${sorted[i].id}: ${e.message}`);
                 }
               }
             } else {
-              // Create new comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: report
+                body: body
               });
               console.log('Created new benchmark comment');
             }
-          } catch (error) {
-            console.error('Failed to post benchmark results:', error);
-
-            // Post a fallback comment
-            const fallbackMessage = [
-              '## Performance Benchmark Report',
-              '',
-              '> ⚠️ **Failed to generate detailed benchmark comparison**',
-              '> ',
-              '> The benchmark comparison failed to run. This might be because:',
-              '> - Benchmark tests don\'t exist on the base branch yet',
-              '> - Dependencies are missing',
-              '> - Test execution failed',
-              '> ',
-              '> Please check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.',
-              '> ',
-              '> 📁 Benchmark artifacts may be available for download from the workflow run.'
-            ].join('\\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: fallbackMessage
-            });
           }
+
+          let report;
+          try {
+            report = fs.readFileSync('benchmark_report.md', 'utf8');
+          } catch (e) {
+            console.error('Failed to read benchmark report:', e.message);
+            report = `## Performance Benchmark Report
+
+          > **Failed to generate detailed benchmark comparison**
+          >
+          > The benchmark comparison failed to run. This might be because:
+          > - Benchmark tests don't exist on the base branch yet
+          > - Dependencies are missing
+          > - Test execution failed
+          >
+          > Please check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+          >
+          > Benchmark artifacts may be available for download from the workflow run.`;
+          }
+
+          await upsertComment(report);

--- a/bbot/scripts/benchmark_report.py
+++ b/bbot/scripts/benchmark_report.py
@@ -37,7 +37,7 @@ def checkout_branch(branch: str, repo_path: Path = None):
     # Remove untracked files before checkout. Without this, files generated
     # by one branch's toolchain (e.g. uv.lock from `uv run` on a Poetry
     # branch) block checkout to a branch that tracks those same files.
-    print(f"Cleaning untracked files before checkout")
+    print("Cleaning untracked files before checkout")
     run_command(["git", "clean", "-fd"], cwd=repo_path)
     print(f"Checking out branch: {branch}")
     run_command(["git", "checkout", branch], cwd=repo_path)

--- a/bbot/scripts/benchmark_report.py
+++ b/bbot/scripts/benchmark_report.py
@@ -33,7 +33,12 @@ def get_current_branch() -> str:
 
 
 def checkout_branch(branch: str, repo_path: Path = None):
-    """Checkout a git branch."""
+    """Checkout a git branch, cleaning up generated files first."""
+    # Remove untracked files before checkout. Without this, files generated
+    # by one branch's toolchain (e.g. uv.lock from `uv run` on a Poetry
+    # branch) block checkout to a branch that tracks those same files.
+    print(f"Cleaning untracked files before checkout")
+    run_command(["git", "clean", "-fd"], cwd=repo_path)
     print(f"Checking out branch: {branch}")
     run_command(["git", "checkout", branch], cwd=repo_path)
 
@@ -376,9 +381,6 @@ def main():
         temp_path = Path(temp_dir)
         base_results_file = temp_path / "base_results.json"
         current_results_file = temp_path / "current_results.json"
-
-        base_data = {}
-        current_data = {}
 
         base_data = {}
         current_data = {}


### PR DESCRIPTION
## Summary
- **uv.lock conflict**: `git clean -fd` before branch checkouts so generated lock files (e.g. `uv.lock` created by `uv run` on a Poetry branch) don't block switching back to branches that track those files
- **Duplicate comments**: Extracted comment find/update logic into shared `upsertComment()` helper so both success and failure paths search for existing comments before posting — previously the fallback always called `createComment()`, which is how PR #2900 accumulated 6 duplicate comments
- **Broken formatting**: Replaced `.join('\\n')` with a template literal — in the YAML `|` block, `'\\n'` produced literal backslash-n characters instead of newlines, rendering the fallback comment as one long unformatted line

## Test plan
- [ ] Open a PR against 3.0 that touches `bbot/**/*.py` to trigger the benchmark workflow
- [ ] Verify the benchmark report renders correctly with proper markdown formatting
- [ ] Push again to the same PR and verify the existing comment is updated (not a new one created)
- [ ] If the report script fails, verify the fallback message also updates the existing comment and renders with proper newlines