### PR TITLE
Fix omitted event types leaking to console output

### DIFF
--- a/bbot/modules/output/base.py
+++ b/bbot/modules/output/base.py
@@ -46,6 +46,9 @@ class BaseOutputModule(BaseModule):
             else:
                 return False, "its type is omitted in the config"
 
+        if event.always_emit:
+            return True, "event is always emitted"
+
         # internal events like those from speculate, ipneighbor
         # or events that are over our report distance
         if event._internal:

--- a/bbot/modules/output/base.py
+++ b/bbot/modules/output/base.py
@@ -38,9 +38,6 @@ class BaseOutputModule(BaseModule):
         if self._is_graph_important(event):
             return True, "event is critical to the graph"
 
-        if event.always_emit:
-            return True, "event is always emitted"
-
         # omit certain event types
         if event._omit:
             if event.type in self.get_watched_events():

--- a/bbot/test/test_step_1/test_modules_basic.py
+++ b/bbot/test/test_step_1/test_modules_basic.py
@@ -90,7 +90,13 @@ async def test_modules_basic_checks(events, httpx_mock):
     assert url._omit is True
 
     # omitted always_emit events should still be omitted
-    finding_data = {"host": "evilcorp.com", "description": "test", "severity": "LOW", "confidence": "LOW", "name": "test"}
+    finding_data = {
+        "host": "evilcorp.com",
+        "description": "test",
+        "severity": "LOW",
+        "confidence": "LOW",
+        "name": "test",
+    }
     finding = scan.make_event(finding_data, "FINDING", parent=scan.root_event)
     assert finding.always_emit is True
     finding._omit = True
@@ -99,7 +105,13 @@ async def test_modules_basic_checks(events, httpx_mock):
     assert reason == "its type is omitted in the config"
 
     # always_emit should bypass the internal check
-    finding_data2 = {"host": "evilcorp.com", "description": "test2", "severity": "LOW", "confidence": "LOW", "name": "test2"}
+    finding_data2 = {
+        "host": "evilcorp.com",
+        "description": "test2",
+        "severity": "LOW",
+        "confidence": "LOW",
+        "name": "test2",
+    }
     finding2 = scan.make_event(finding_data2, "FINDING", parent=scan.root_event)
     assert finding2.always_emit is True
     finding2._internal = True

--- a/bbot/test/test_step_1/test_modules_basic.py
+++ b/bbot/test/test_step_1/test_modules_basic.py
@@ -89,6 +89,24 @@ async def test_modules_basic_checks(events, httpx_mock):
     await egress_module.handle_event(url)
     assert url._omit is True
 
+    # omitted always_emit events should still be omitted
+    finding_data = {"host": "evilcorp.com", "description": "test", "severity": "LOW", "confidence": "LOW", "name": "test"}
+    finding = scan.make_event(finding_data, "FINDING", parent=scan.root_event)
+    assert finding.always_emit is True
+    finding._omit = True
+    result, reason = base_output_module_2._event_precheck(finding)
+    assert result is False
+    assert reason == "its type is omitted in the config"
+
+    # always_emit should bypass the internal check
+    finding_data2 = {"host": "evilcorp.com", "description": "test2", "severity": "LOW", "confidence": "LOW", "name": "test2"}
+    finding2 = scan.make_event(finding_data2, "FINDING", parent=scan.root_event)
+    assert finding2.always_emit is True
+    finding2._internal = True
+    result, reason = base_output_module_2._event_precheck(finding2)
+    assert result is True
+    assert reason == "event is always emitted"
+
     # common event filtering tests
     for module_class in (BaseModule, BaseOutputModule, BaseReportModule, BaseInternalModule):
         base_module = module_class(scan)


### PR DESCRIPTION
## Summary

- HTTP_RESPONSE, URL_UNVERIFIED, and DNS_NAME_UNRESOLVED were showing up in console output despite being in `omit_event_types`

## Root Cause

In `7b271f33b` ("ruffed"), the `always_emit` check in `BaseOutputModule._event_precheck()` was moved from **inside** the `_omit` block (where it was an `elif`, only applying to already-omitted events) to **before** it as a standalone short-circuit. This changed the semantics: any event with `always_emit=True` (i.e. events with `affiliate`/`seed` tags, or no host) now bypassed the `_omit` filter entirely, causing omitted event types to print to console.

The `always_emit` check is unnecessary in the output precheck since `ScanEgress` already handles it by preventing `always_emit` events from being marked `_internal`.