### PR TITLE
(Hopefully) Improving Task Cleanup

### DIFF
--- a/bbot/core/helpers/async_helpers.py
+++ b/bbot/core/helpers/async_helpers.py
@@ -133,6 +133,15 @@ def async_to_sync_gen(async_gen):
             yield loop.run_until_complete(async_gen.__anext__())
     except StopAsyncIteration:
         pass
+    finally:
+        # Cancel any remaining pending tasks to prevent
+        # "Task was destroyed but it is pending!" warnings
+        pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+        for t in pending:
+            t.cancel()
+        if pending:
+            with suppress(BaseException):
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 
 
 def async_cachedmethod(cache, key=keys.hashkey):

--- a/bbot/core/helpers/async_helpers.py
+++ b/bbot/core/helpers/async_helpers.py
@@ -134,6 +134,11 @@ def async_to_sync_gen(async_gen):
     except StopAsyncIteration:
         pass
     finally:
+        # Explicitly close the async generator so its finally block
+        # (e.g. Scanner.async_start's cleanup) runs while the loop
+        # is still alive, not deferred to interpreter shutdown.
+        with suppress(BaseException):
+            loop.run_until_complete(async_gen.aclose())
         # Cancel any remaining pending tasks to prevent
         # "Task was destroyed but it is pending!" warnings
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
@@ -141,7 +146,12 @@ def async_to_sync_gen(async_gen):
             t.cancel()
         if pending:
             with suppress(BaseException):
-                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+                loop.run_until_complete(
+                    asyncio.wait_for(
+                        asyncio.gather(*pending, return_exceptions=True),
+                        timeout=5,
+                    )
+                )
 
 
 def async_cachedmethod(cache, key=keys.hashkey):

--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -4,7 +4,6 @@ import base64
 import random
 import asyncio
 import logging
-import contextlib
 import traceback
 from uuid import uuid4
 

--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -196,8 +196,10 @@ class Interactsh:
 
         if self._poll_task is not None:
             self._poll_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            try:
                 await self._poll_task
+            except (asyncio.CancelledError, Exception):
+                pass
 
         if "success" not in getattr(r, "text", ""):
             raise InteractshError(f"Failed to de-register with interactsh server {self.server}")

--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -331,7 +331,8 @@ class ModuleLoader:
         config = {}
         options_desc = {}
         disable_auto_module_deps = False
-        python_code = open(module_file).read()
+        with open(module_file) as f:
+            python_code = f.read()
         # take a hash of the code so we can keep track of when it changes
         module_hash = sha1(python_code).hexdigest()
         parsed_code = ast.parse(python_code)

--- a/bbot/modules/subdomainradar.py
+++ b/bbot/modules/subdomainradar.py
@@ -64,6 +64,8 @@ class SubdomainRadar(subdomain_enum_apikey):
 
         self.enum_tasks = {}
         self.poll_task = asyncio.create_task(self.task_poll_loop())
+        # Track poll_task so _cancel_tasks() picks it up during shutdown
+        self._tasks.append(self.poll_task)
 
         return True
 

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -257,6 +257,7 @@ class Scanner:
 
         self.init_events_task = None
         self.ticker_task = None
+        self._stop_task = None
         self.dispatcher_tasks = []
 
         self._stopping = False
@@ -428,10 +429,12 @@ class Scanner:
             yield scan_finish_event
             tasks = self._cancel_tasks()
             self.debug(f"Awaiting {len(tasks):,} tasks")
-            for task in tasks:
-                # self.debug(f"Awaiting {task}")
+            if tasks:
                 with contextlib.suppress(BaseException):
-                    await asyncio.wait_for(task, timeout=0.1)
+                    await asyncio.wait_for(
+                        asyncio.gather(*tasks, return_exceptions=True),
+                        timeout=2,
+                    )
             self.debug(f"Awaited {len(tasks):,} tasks")
             await self._report()
             await self._cleanup()
@@ -783,7 +786,7 @@ class Scanner:
             await self._set_status(SCAN_STATUS_ABORTED)
 
     def stop(self):
-        asyncio.create_task(self.async_stop())
+        self._stop_task = asyncio.create_task(self.async_stop())
 
     async def finish(self):
         """Finalizes the scan by invoking the `finished()` method on all active modules if new activity is detected.
@@ -854,6 +857,9 @@ class Scanner:
         # ticker
         if self.ticker_task:
             tasks.append(self.ticker_task)
+        # stop task
+        if self._stop_task:
+            tasks.append(self._stop_task)
 
         self.helpers.cancel_tasks_sync(tasks)
         # process pool

--- a/bbot/test/test_step_1/test_python_api.py
+++ b/bbot/test/test_step_1/test_python_api.py
@@ -82,6 +82,27 @@ def test_python_api_sync():
     assert os.environ["BBOT_TOOLS"] == str(Path(bbot_home) / "tools")
 
 
+def test_python_api_sync_no_pending_tasks():
+    """Test that no asyncio tasks remain pending after a sync scan completes.
+
+    Regression test for https://github.com/blacklanternsecurity/bbot/issues/2508
+    When using BBOT as a library (e.g. from Celery), orphaned asyncio tasks
+    would cause "Task was destroyed but it is pending!" warnings on shutdown.
+    """
+    import asyncio
+    from bbot.scanner import Scanner
+    from bbot.core.helpers.async_helpers import get_event_loop
+
+    scan = Scanner("127.0.0.1")
+    events = list(scan.start())
+    assert any(e.type == "IP_ADDRESS" and e.data == "127.0.0.1" for e in events)
+
+    # After the sync generator is exhausted, no tasks should remain pending
+    loop = get_event_loop()
+    pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+    assert len(pending) == 0, f"Found {len(pending)} pending tasks after scan: {pending}"
+
+
 def test_python_api_validation():
     from bbot.scanner import Scanner, Preset
 


### PR DESCRIPTION
When BBOT is used as a library, orphaned asyncio tasks accumulate on the event loop after a scan finishes. When the process eventually shuts down, Python's garbage collector prints "Task was destroyed but it is pending!" for each one, often 100+ warnings. This is especially bad when the scan generator is abandoned early (e.g. Celery task timeout), which causes the scanner's finally block to crash with RuntimeError: no running event loop, meaning tasks are never cancelled at all. This is described in https://github.com/blacklanternsecurity/bbot/issues/2508

The root cause is that async_to_sync_gen(), which powers the synchronous scan.start() API, never cleaned up remaining tasks after the generator was exhausted. Additionally, the scanner's shutdown logic awaited cancelled tasks sequentially with a 0.1s timeout each. Any task that didn't respond in time was silently abandoned.

  The primary fix adds a finally block to async_to_sync_gen() that:
  1. Calls aclose() on the async generator so the scanner's cleanup (_cancel_tasks, _report, _cleanup) runs while the event loop is still alive, not deferred to interpreter shutdown.
  2. Cancels and awaits any remaining pending tasks as a safety net, with a 5-second timeout.

  On the scanner side, the sequential wait_for(task, 0.1) loop is replaced with a single asyncio.gather() call with a 2-second timeout, giving all tasks a reasonable concurrent window to shut down cleanly.

  Several task-tracking gaps were also closed:

  - Scanner.stop() was firing off async_stop() as a fire-and-forget create_task() with no reference. It's now stored as self._stop_task and included in _cancel_tasks().
  - SubdomainRadar's poll_task is now appended to the module's _tasks list so the scanner picks it up during shutdown (previously it was only cancelled in finish(), which doesn't run on abort).
  - Interactsh's deregister() now awaits the poll task after cancelling it, ensuring it fully terminates before returning.
  - A regression test verifies that zero asyncio tasks remain pending after a sync scan completes.

  @TheTechromancer although this was primarily an AI-driven fix, i thoroughly tested this. I had a script setup to simulate an early exit with a library-imported bbot scan. Sure enough, walls upon walls of errors before the fix, almost all gone after. I can provide this script for you if you want to take a look or try it yourself.
