### PR TITLE
Add lightfuzz SSRF submodule, fix interactsh issues

### DIFF
--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -279,8 +279,10 @@ class Interactsh:
     async def _poll_loop(self, callback):
         consecutive_failures = 0
         max_failures = 5
+        log.debug(f"Starting interactsh poll loop (interval={self.poll_interval}s, server={self.server})")
         while 1:
             if self.parent_helper.scan.stopping:
+                log.debug("Stopping interactsh poll loop (scan is stopping)")
                 break
             data_list = []
             try:
@@ -297,13 +299,19 @@ class Interactsh:
                     log.debug(f"Interactsh poll failure #{consecutive_failures}: {e}")
                 log.trace(traceback.format_exc())
                 backoff = min(self.poll_interval * (2 ** (consecutive_failures - 1)), 300)
+                log.debug(f"Interactsh backing off for {backoff}s after failure #{consecutive_failures}")
                 await asyncio.sleep(backoff)
                 continue
             if not data_list:
+                log.debug(f"Interactsh poll returned no interactions, sleeping {self.poll_interval}s")
                 await asyncio.sleep(self.poll_interval)
                 continue
+            log.debug(f"Interactsh poll returned {len(data_list)} interaction(s)")
             for data in data_list:
                 if data:
+                    protocol = data.get("protocol", "unknown")
+                    full_id = data.get("full-id", "unknown")
+                    log.debug(f"Interactsh interaction: protocol={protocol}, full-id={full_id}")
                     await self.parent_helper.execute_sync_or_async(callback, data)
 
     def _decrypt(self, aes_key, data):

--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -4,6 +4,7 @@ import base64
 import random
 import asyncio
 import logging
+import contextlib
 import traceback
 from uuid import uuid4
 
@@ -195,6 +196,8 @@ class Interactsh:
 
         if self._poll_task is not None:
             self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
 
         if "success" not in getattr(r, "text", ""):
             raise InteractshError(f"Failed to de-register with interactsh server {self.server}")
@@ -274,16 +277,28 @@ class Interactsh:
             return await self._poll_loop(callback)
 
     async def _poll_loop(self, callback):
+        consecutive_failures = 0
+        max_failures = 5
         while 1:
             if self.parent_helper.scan.stopping:
-                await asyncio.sleep(1)
-                continue
+                break
             data_list = []
             try:
                 data_list = await self.poll()
+                consecutive_failures = 0
             except InteractshError as e:
-                log.warning(e)
+                consecutive_failures += 1
+                if consecutive_failures == 1:
+                    log.warning(e)
+                elif consecutive_failures >= max_failures:
+                    log.error(f"Interactsh poll failed {max_failures} consecutive times, giving up: {e}")
+                    break
+                else:
+                    log.debug(f"Interactsh poll failure #{consecutive_failures}: {e}")
                 log.trace(traceback.format_exc())
+                backoff = min(self.poll_interval * (2 ** (consecutive_failures - 1)), 300)
+                await asyncio.sleep(backoff)
+                continue
             if not data_list:
                 await asyncio.sleep(self.poll_interval)
                 continue

--- a/bbot/modules/lightfuzz/lightfuzz.py
+++ b/bbot/modules/lightfuzz/lightfuzz.py
@@ -11,7 +11,7 @@ class lightfuzz(BaseModule):
 
     options = {
         "force_common_headers": False,
-        "enabled_submodules": ["sqli", "cmdi", "xss", "path", "ssti", "crypto", "serial", "esi"],
+        "enabled_submodules": ["sqli", "cmdi", "xss", "path", "ssti", "crypto", "serial", "esi", "ssrf"],
         "disable_post": False,
         "try_post_as_get": False,
         "try_get_as_post": False,
@@ -80,15 +80,22 @@ class lightfuzz(BaseModule):
                 details = self.interactsh_subdomain_tags.get(full_id.split(".")[0])
                 if not details["event"]:
                     return
-                # currently, this is only used by the cmdi submodule. Later, when other modules use it, we will need to store description data in the interactsh_subdomain_tags dictionary
+                protocol = r.get("protocol", "dns").lower()
+                severity = details.get("severity", "HIGH")
+                confidence = details.get("confidence", "CONFIRMED")
+                # Allow submodules to specify alternative severity/confidence for DNS-only interactions
+                if protocol == "dns":
+                    severity = details.get("severity_dns", severity)
+                    confidence = details.get("confidence_dns", confidence)
+                description = f"{details['description']} Interaction Protocol: [{protocol}]"
                 await self.emit_event(
                     {
-                        "severity": "CRITICAL",
-                        "confidence": "CONFIRMED",
+                        "severity": severity,
+                        "confidence": confidence,
                         "host": str(details["event"].host),
                         "url": details["event"].data["url"],
-                        "name": "Lightfuzz - OS Command Injection",
-                        "description": f"OS Command Injection (OOB Interaction) Type: [{details['type']}] Parameter Name: [{details['name']}] Probe: [{details['probe']}]",
+                        "name": f"Lightfuzz - {details['name']}",
+                        "description": description,
                     },
                     "FINDING",
                     details["event"],
@@ -197,9 +204,15 @@ class lightfuzz(BaseModule):
 
     async def finish(self):
         if self.interactsh_instance:
+            self.debug("finish(): sleeping 5s before final interactsh poll")
             await self.helpers.sleep(5)
             try:
-                for r in await self.interactsh_instance.poll():
+                results = await self.interactsh_instance.poll()
+                self.debug(f"finish(): interactsh poll returned {len(results)} interaction(s)")
+                for r in results:
+                    protocol = r.get("protocol", "unknown")
+                    full_id = r.get("full-id", "unknown")
+                    self.debug(f"finish(): interactsh interaction: protocol={protocol}, full-id={full_id}")
                     await self.interactsh_callback(r)
             except InteractshError as e:
                 self.debug(f"Error in interact.sh: {e}")

--- a/bbot/modules/lightfuzz/submodules/cmdi.py
+++ b/bbot/modules/lightfuzz/submodules/cmdi.py
@@ -89,9 +89,10 @@ class cmdi(BaseLightfuzz):
                 subdomain_tag = self.lightfuzz.helpers.rand_string(4, digits=False)
                 self.lightfuzz.interactsh_subdomain_tags[subdomain_tag] = {
                     "event": self.event,
-                    "type": self.event.data["type"],
-                    "name": self.event.data["name"],
-                    "probe": p,
+                    "name": "OS Command Injection",
+                    "description": f"OS Command Injection (OOB Interaction) Type: [{self.event.data['type']}] Parameter Name: [{self.event.data['name']}] Probe: [{p}]",
+                    "severity": "CRITICAL",
+                    "confidence": "CONFIRMED",
                 }
                 # payload is an nslookup command that includes the interactsh domain prepended the previously generated subdomain tag
                 interactsh_probe = f"{p} nslookup {subdomain_tag}.{self.lightfuzz.interactsh_domain} {p}"

--- a/bbot/modules/lightfuzz/submodules/ssrf.py
+++ b/bbot/modules/lightfuzz/submodules/ssrf.py
@@ -1,0 +1,47 @@
+from .base import BaseLightfuzz
+
+
+class ssrf(BaseLightfuzz):
+    """
+    Detects Server-Side Request Forgery (SSRF) vulnerabilities.
+
+    Techniques:
+
+    * OOB (Out-of-Band) Detection:
+       - Injects URLs pointing to an Interactsh server as parameter values
+       - Tries multiple URL schemes (http://, https://)
+       - Detects SSRF through DNS/HTTP interaction callbacks via Interactsh
+    """
+
+    friendly_name = "Server-Side Request Forgery"
+    uses_interactsh = True
+
+    async def fuzz(self):
+        if not self.lightfuzz.interactsh_instance:
+            return
+
+        cookies = self.event.data.get("assigned_cookies", {})
+        # Try with explicit schemes and bare domain (for cases where the server prepends the scheme)
+        prefixes = ["http://", "https://", ""]
+
+        for prefix in prefixes:
+            subdomain_tag = self.lightfuzz.helpers.rand_string(4, digits=False)
+            interactsh_url = f"{prefix}{subdomain_tag}.{self.lightfuzz.interactsh_domain}"
+            probe_label = prefix if prefix else "no scheme"
+
+            self.lightfuzz.interactsh_subdomain_tags[subdomain_tag] = {
+                "event": self.event,
+                "name": "Server-Side Request Forgery",
+                "description": f"Server-Side Request Forgery (OOB Interaction) Type: [{self.event.data['type']}] Parameter Name: [{self.event.data['name']}] Probe: [{probe_label}]",
+                "severity": "HIGH",
+                "confidence": "CONFIRMED",
+                "severity_dns": "HIGH",
+                "confidence_dns": "MODERATE",
+            }
+
+            await self.standard_probe(
+                self.event.data["type"],
+                cookies,
+                interactsh_url,
+                timeout=15,
+            )

--- a/bbot/presets/web/lightfuzz-heavy.yml
+++ b/bbot/presets/web/lightfuzz-heavy.yml
@@ -12,7 +12,7 @@ modules:
 config:
   modules:
     lightfuzz:
-      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi]
+      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi,ssrf]
       disable_post: False
       try_post_as_get: True
       try_get_as_post: True

--- a/bbot/presets/web/lightfuzz-medium.yml
+++ b/bbot/presets/web/lightfuzz-medium.yml
@@ -11,5 +11,5 @@ modules:
 config:
   modules:
     lightfuzz:
-      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi]
+      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi,ssrf]
       try_post_as_get: True

--- a/bbot/presets/web/lightfuzz-superheavy.yml
+++ b/bbot/presets/web/lightfuzz-superheavy.yml
@@ -8,7 +8,7 @@ config:
   modules:
     lightfuzz:
       force_common_headers: True # Fuzz common headers like X-Forwarded-For even if they're not observed on the target
-      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi]
+      enabled_submodules: [cmdi,crypto,path,serial,sqli,ssti,xss,esi,ssrf]
       avoid_wafs: False
     excavate:
       speculate_params: True # speculate potential parameters extracted from JSON/XML web responses

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1465,6 +1465,91 @@ class Test_Lightfuzz_cmdi_interactsh(Test_Lightfuzz_cmdi):
         assert cmdi_interacttsh_finding_emitted, "interactsh CMDi FINDING not emitted"
 
 
+# SSRF interactsh
+class Test_Lightfuzz_ssrf(ModuleTestBase):
+    targets = ["http://127.0.0.1:8888"]
+    modules_overrides = ["httpx", "lightfuzz", "excavate"]
+
+    @staticmethod
+    def extract_subdomain_tag(data):
+        # Try both URL-encoded and non-encoded forms
+        for pattern in [
+            r"url=https?%3A%2F%2F(.+?)\.fakedomain\.fakeinteractsh\.com",
+            r"url=https?://(.+?)\.fakedomain\.fakeinteractsh\.com",
+        ]:
+            match = re.search(pattern, data)
+            if match:
+                return match.group(1)
+
+    config_overrides = {
+        "interactsh_disable": False,
+        "modules": {
+            "lightfuzz": {
+                "enabled_submodules": ["ssrf"],
+            }
+        },
+    }
+
+    def request_handler(self, request):
+        qs = str(request.query_string.decode())
+
+        parameter_block = """
+        <section class=search>
+            <form action=/ method=GET>
+                <input type=text placeholder='Enter URL...' name=url>
+                <button type=submit class=button>Fetch</button>
+            </form>
+        </section>
+        """
+
+        if "url=" in qs:
+            subdomain_tag = self.extract_subdomain_tag(request.full_path)
+
+            if subdomain_tag:
+                self.interactsh_mock_instance.mock_interaction(subdomain_tag)
+        return Response(parameter_block, status=200)
+
+    async def setup_before_prep(self, module_test):
+        self.interactsh_mock_instance = module_test.mock_interactsh("lightfuzz")
+
+        module_test.monkeypatch.setattr(
+            module_test.scan.helpers, "interactsh", lambda *args, **kwargs: self.interactsh_mock_instance
+        )
+
+    async def setup_after_prep(self, module_test):
+        expect_args = re.compile("/")
+        module_test.set_expect_requests_handler(expect_args=expect_args, request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        web_parameter_emitted = False
+        ssrf_dns_finding_emitted = False
+        ssrf_http_finding_emitted = False
+        for e in events:
+            if e.type == "WEB_PARAMETER":
+                if "HTTP Extracted Parameter [url]" in e.data["description"]:
+                    web_parameter_emitted = True
+
+            if e.type == "FINDING":
+                if (
+                    "Server-Side Request Forgery (OOB Interaction) Type: [GETPARAM] Parameter Name: [url]"
+                    in e.data["description"]
+                ):
+                    if "Interaction Protocol: [dns]" in e.data["description"]:
+                        ssrf_dns_finding_emitted = True
+                        assert e.data["confidence"] == "MODERATE", (
+                            f"DNS SSRF should be MODERATE, got {e.data['confidence']}"
+                        )
+                    elif "Interaction Protocol: [http]" in e.data["description"]:
+                        ssrf_http_finding_emitted = True
+                        assert e.data["confidence"] == "CONFIRMED", (
+                            f"HTTP SSRF should be CONFIRMED, got {e.data['confidence']}"
+                        )
+
+        assert web_parameter_emitted, "WEB_PARAMETER was not emitted"
+        assert ssrf_dns_finding_emitted, "interactsh SSRF DNS FINDING not emitted"
+        assert ssrf_http_finding_emitted, "interactsh SSRF HTTP FINDING not emitted"
+
+
 class Test_Lightfuzz_speculative(ModuleTestBase):
     targets = ["http://127.0.0.1:8888/"]
     modules_overrides = ["httpx", "excavate", "paramminer_getparams", "lightfuzz"]


### PR DESCRIPTION
- Fixes interactsh issues, such as those reported in https://github.com/blacklanternsecurity/bbot/issues/1053, and others
- New SSRF lightfuzz submodule
- Generalized the interactsh callback so any lightfuzz submodule (not just cmdi) can store its own name/description/severity/confidence in the subdomain tag dict
- Protocol-aware findings: DNS-only interactions → HIGH/MODERATE, HTTP interactions → HIGH/CONFIRMED
- Added debug logging to interactsh poll loop and lightfuzz `finish()` poll