### PR TITLE
Reduce padding oracle false positives in lightfuzz crypto module

### DIFF
--- a/bbot/core/helpers/interactsh.py
+++ b/bbot/core/helpers/interactsh.py
@@ -4,6 +4,7 @@ import base64
 import random
 import asyncio
 import logging
+import contextlib
 import traceback
 from uuid import uuid4
 
@@ -195,6 +196,8 @@ class Interactsh:
 
         if self._poll_task is not None:
             self._poll_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._poll_task
 
         if "success" not in getattr(r, "text", ""):
             raise InteractshError(f"Failed to de-register with interactsh server {self.server}")
@@ -274,16 +277,28 @@ class Interactsh:
             return await self._poll_loop(callback)
 
     async def _poll_loop(self, callback):
+        consecutive_failures = 0
+        max_failures = 5
         while 1:
             if self.parent_helper.scan.stopping:
-                await asyncio.sleep(1)
-                continue
+                break
             data_list = []
             try:
                 data_list = await self.poll()
+                consecutive_failures = 0
             except InteractshError as e:
-                log.warning(e)
+                consecutive_failures += 1
+                if consecutive_failures == 1:
+                    log.warning(e)
+                elif consecutive_failures >= max_failures:
+                    log.error(f"Interactsh poll failed {max_failures} consecutive times, giving up: {e}")
+                    break
+                else:
+                    log.debug(f"Interactsh poll failure #{consecutive_failures}: {e}")
                 log.trace(traceback.format_exc())
+                backoff = min(self.poll_interval * (2 ** (consecutive_failures - 1)), 300)
+                await asyncio.sleep(backoff)
+                continue
             if not data_list:
                 await asyncio.sleep(self.poll_interval)
                 continue

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -262,6 +262,7 @@ parameter_blacklist:
 parameter_blacklist_prefixes:
   - TS01
   - BIGipServer
+  - f5avr
   - incap_
   - visid_incap_
   - AWSALB

--- a/bbot/modules/lightfuzz/submodules/crypto.py
+++ b/bbot/modules/lightfuzz/submodules/crypto.py
@@ -84,6 +84,22 @@ class crypto(BaseLightfuzz):
         return _compiled_rules_cache
 
     @staticmethod
+    def is_plausible_base64_crypto(s):
+        """
+        Check if a string is plausibly base64-encoded cryptographic data.
+        Non-standard encodings like F5 BIG-IP's A-P nibble encoding use a narrow
+        consecutive character range that technically round-trips as base64 but is
+        not actual base64. Real base64 of encrypted/random bytes spans a wide
+        character range (typically 70+).
+        """
+        unique_chars = set(s) - set("=")
+        if len(s) >= 16 and unique_chars:
+            char_ords = [ord(c) for c in unique_chars]
+            if max(char_ords) - min(char_ords) <= 20:
+                return False
+        return True
+
+    @staticmethod
     def format_agnostic_decode(input_string, urldecode=False):
         """
         Decodes a string from either hex or base64 (without knowing which first), and optionally URL-decoding it first.
@@ -101,7 +117,7 @@ class crypto(BaseLightfuzz):
         if BaseLightfuzz.is_hex(input_string):
             data = bytes.fromhex(input_string)
             encoding = "hex"
-        elif BaseLightfuzz.is_base64(input_string):
+        elif BaseLightfuzz.is_base64(input_string) and crypto.is_plausible_base64_crypto(input_string):
             data = base64.b64decode(input_string)
             encoding = "base64"
         else:
@@ -300,6 +316,19 @@ class crypto(BaseLightfuzz):
                 )
 
             if padding_oracle_result is True:
+                # Confirmation round: re-run to rule out jitter-based false positives
+                self.debug(f"Initial padding oracle detection for block_size={block_size}, running confirmation round")
+                confirmation_result = await self.padding_oracle_execute(data, encoding, block_size, cookies)
+                if confirmation_result is None:
+                    confirmation_result = await self.padding_oracle_execute(
+                        data, encoding, block_size, cookies, possible_first_byte=False
+                    )
+                if confirmation_result is not True:
+                    self.debug(
+                        f"Confirmation round failed for block_size={block_size} - likely jitter false positive, suppressing"
+                    )
+                    continue
+
                 context = f"Lightfuzz Cryptographic Probe Submodule detected a probable padding oracle vulnerability after manipulating parameter: [{self.event.data['name']}]"
                 self.results.append(
                     {

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1829,6 +1829,137 @@ class Test_Lightfuzz_PaddingOracleDetection_Noisy(Test_Lightfuzz_PaddingOracleDe
         )
 
 
+class Test_Lightfuzz_PaddingOracleDetection_NarrowCharset(ModuleTestBase):
+    """Parameters with values that use a narrow consecutive character set (e.g. only A-P)
+    round-trip as valid base64 but are not actual cryptographic data.
+    The narrow charset check should reject these, preventing false findings."""
+
+    targets = ["http://127.0.0.1:8888"]
+    modules_overrides = ["httpx", "excavate", "lightfuzz"]
+    config_overrides = {
+        "interactsh_disable": True,
+        "modules": {
+            "lightfuzz": {
+                "enabled_submodules": ["crypto"],
+            }
+        },
+    }
+
+    # A-P only value: valid base64 round-trip, but narrow charset (span=15)
+    narrow_charset_value = "BPIDFOPFGNLIBNFGAEPBMIIKPHEFGOJKOMACMBJJLOPKFIGMKALJDBHCMAMHIKIMDOFDHIBAHEJBIIGMIDKANCMFGJAIEKLPCLFDMELEAGBILMHLAPFKNNBAMPPNDEEP"
+
+    def request_handler(self, request):
+        return Response("<html><body><p>Welcome</p></body></html>", status=200)
+
+    async def setup_after_prep(self, module_test):
+        module_test.set_expect_requests_handler(expect_args=re.compile(".*"), request_handler=self.request_handler)
+
+        parent_event = module_test.scan.make_event(
+            "http://127.0.0.1:8888/",
+            "URL",
+            module_test.scan.root_event,
+            module="httpx",
+            tags=["status-200", "distance-0"],
+        )
+
+        data = {
+            "host": "127.0.0.1",
+            "type": "COOKIE",
+            "name": "custom_session_cookie",
+            "original_value": self.narrow_charset_value,
+            "url": "http://127.0.0.1:8888/",
+            "description": "Test narrow charset cookie",
+        }
+        seed_event = module_test.scan.make_event(data, "WEB_PARAMETER", parent_event, tags=["distance-0"])
+        await module_test.scan.ingress_module.incoming_event_queue.put(seed_event)
+
+    def check(self, module_test, events):
+        crypto_finding = False
+        padding_oracle_finding = False
+        for e in events:
+            if e.type == "FINDING":
+                if "Cryptographic Parameter" in e.data["description"]:
+                    crypto_finding = True
+                if "Padding Oracle" in e.data["description"]:
+                    padding_oracle_finding = True
+
+        assert not crypto_finding, "Narrow-charset parameter should NOT be identified as cryptographic"
+        assert not padding_oracle_finding, "Narrow-charset parameter should NOT trigger padding oracle detection"
+
+
+class Test_Lightfuzz_PaddingOracleDetection_Jitter(Test_Lightfuzz_PaddingOracleDetection):
+    """Padding oracle negative test: the server produces inconsistent responses across rounds.
+    The first round may trigger detection, but the confirmation round should fail,
+    suppressing the jitter-based false positive."""
+
+    oracle_request_count = 0
+
+    def request_handler(self, request):
+        encrypted_value = quote(
+            "dplyorsu8VUriMW/8DqVDU6kRwL/FDk3Q+4GXVGZbo0CTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg=="
+        )
+        default_html_response = f"""
+        <html>
+            <body>
+                <form action="/decrypt" method="post">
+                    <input type="hidden" name="encrypted_data" value="{encrypted_value}" />
+                    <button type="submit">Decrypt</button>
+                </form>
+            </body>
+        </html>
+        """
+
+        if "/decrypt" in request.url and request.method == "POST":
+            if request.form and request.form["encrypted_data"]:
+                encrypted_data = request.form["encrypted_data"]
+
+                if "4GXVGZbo0DTh9YX1YvzZZJrYe4cHxvAICyliYtp1im4fWoOa54Zg" in encrypted_data:
+                    response_content = "DIFFERENT CRYPTOGRAPHIC ERROR"
+                elif encrypted_data.startswith("AAAAAAAAAAAAAAAA"):
+                    Test_Lightfuzz_PaddingOracleDetection_Jitter.oracle_request_count += 1
+                    # First 254 requests (round 1): produce oracle-like signal (1 differ)
+                    if Test_Lightfuzz_PaddingOracleDetection_Jitter.oracle_request_count <= 254:
+                        try:
+                            decoded = base64.b64decode(encrypted_data)
+                            if len(decoded) >= 32:
+                                varying_byte = decoded[31]
+                                if varying_byte == 100:
+                                    response_content = "Padding error detected"
+                                else:
+                                    response_content = "Decryption failed"
+                            else:
+                                response_content = "Decryption failed"
+                        except Exception:
+                            response_content = "Decryption failed"
+                    else:
+                        # Confirmation round: all responses identical (no oracle signal)
+                        response_content = "Decryption failed"
+                elif "AAAAAAA" in encrypted_data:
+                    response_content = "YET DIFFERENT CRYPTOGRAPHIC ERROR"
+                else:
+                    response_content = "Decryption failed"
+
+            return Response(response_content, status=200)
+        else:
+            return Response(default_html_response, status=200)
+
+    def check(self, module_test, events):
+        web_parameter_extracted = False
+        padding_oracle_detected = False
+        for e in events:
+            if e.type == "WEB_PARAMETER":
+                if "HTTP Extracted Parameter [encrypted_data] (POST Form" in e.data["description"]:
+                    web_parameter_extracted = True
+            if e.type == "FINDING":
+                if "Padding Oracle" in e.data["description"]:
+                    padding_oracle_detected = True
+
+        assert web_parameter_extracted, "Web parameter was not extracted"
+        assert not padding_oracle_detected, (
+            "Padding oracle should NOT be detected when confirmation round fails (jitter false positive)"
+        )
+
+
 class Test_Lightfuzz_XSS_jsquotecontext(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["httpx", "lightfuzz", "excavate", "paramminer_getparams"]


### PR DESCRIPTION
## Summary
- Add `f5avr` to parameter blacklist prefixes to filter F5 BIG-IP APM cookies early
- Reject narrow-charset strings (ASCII span ≤ 20) in `format_agnostic_decode()` that round-trip as valid base64 but aren't actual cryptographic data (e.g. A-P nibble encodings)
- Add confirmation round to padding oracle detection: re-run the test before emitting to filter jitter-based false positives