### PR TITLE
Update nuclei to 3.7.1

### DIFF
--- a/bbot/modules/nuclei.py
+++ b/bbot/modules/nuclei.py
@@ -15,7 +15,7 @@ class nuclei(BaseModule):
     }
 
     options = {
-        "version": "3.7.0",
+        "version": "3.7.1",
         "tags": "",
         "templates": "",
         "severity": "",


### PR DESCRIPTION
This PR uses https://api.github.com/repos/projectdiscovery/nuclei/releases/latest to obtain the latest version of nuclei and update the version in bbot/modules/nuclei.py."

# Release notes:
## What's Changed

### 🐞 Bug Fixes

* Fixed panic by replacing it with error handling in template loader (#6674) by @umer12-12 in https://github.com/projectdiscovery/nuclei/pull/7090
* Fixed cluster failure handling by @bf-rbrown in https://github.com/projectdiscovery/nuclei/pull/6843
* Fixed by avoiding cross-test chrome teardown races in headless by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/7053
* Fixed data race in evaluateVarsWithInteractsh by @yusei-wy in https://github.com/projectdiscovery/nuclei/pull/6828
* Fixed panic by replacing it with error handling in template loader by @bimakw in https://github.com/projectdiscovery/nuclei/pull/6825

### Other Changes
* Added memogen workflow by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/6736
* Removed double parsing in template loading by @dwisiswant0 in https://github.com/projectdiscovery/nuclei/pull/6796
* Bumped github.com/bytedance/sonic to 1.15.0 for Go 1.26 support by @stefanb in https://github.com/projectdiscovery/nuclei/pull/6841
* Improved API by exposing cluster ids mapping to template ids by @yaron12n in https://github.com/projectdiscovery/nuclei/pull/6788



## New Contributors
* @yusei-wy made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6828
* @yaron12n made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6788
* @bimakw made their first contribution in https://github.com/projectdiscovery/nuclei/pull/6825
* @umer12-12 made their first contribution in https://github.com/projectdiscovery/nuclei/pull/7090

**Full Changelog**: https://github.com/projectdiscovery/nuclei/compare/v3.7.0...v3.7.1