### PR TITLE
Pin kreuzberg <4.5 for Ubuntu 22.04 compat, fix distro test HOME

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -65,9 +65,12 @@ jobs:
         run: echo "OS_NAME=${{ matrix.os }}" | sed 's|[:/]|_|g' >> $GITHUB_ENV
       - name: Run tests
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          export PATH="$HOME/.pyenv/shims:$PATH"
+          # Preserve pyenv/pipx paths installed under the GitHub-set HOME
+          export PATH="/github/home/.local/bin:$PATH"
+          export PATH="/github/home/.pyenv/bin:$PATH"
+          export PATH="/github/home/.pyenv/shims:$PATH"
+          # Fix HOME to match euid (root) so rustup/cargo don't refuse to build
+          export HOME="$(getent passwd $(whoami) | cut -d: -f6)"
           export BBOT_DISTRO_TESTS=true
           uv python pin 3.11
           uv sync --group dev

--- a/bbot/modules/kreuzberg.py
+++ b/bbot/modules/kreuzberg.py
@@ -66,7 +66,7 @@ class kreuzberg(BaseModule):
         "extensions": "File extensions to parse",
     }
 
-    deps_pip = ["kreuzberg~=4.3", "pypdfium2~=5.0"]
+    deps_pip = ["kreuzberg>=4.3,<4.5", "pypdfium2~=5.0"]
     scope_distance_modifier = 1
 
     async def setup(self):


### PR DESCRIPTION
## Summary

- Pin kreuzberg to <4.5 — version 4.5+ ships only `manylinux_2_39` wheels (glibc 2.39+) due to ONNX Runtime 1.24.1, which is incompatible with Ubuntu 22.04 (glibc 2.35). Without a compatible wheel, uv falls back to building from source, which fails without cmake/Rust toolchain.
- Fix HOME mismatch in distro CI — GitHub Actions sets `HOME=/github/home` inside Docker containers, but the container runs as root (`/root`). This causes rustup/cargo to refuse to build. Hardcode pyenv/pipx paths and reset HOME to the euid home.