### PR TITLE
Fix retirejs crash on URL_UNVERIFIED parent events from gowitness

### DIFF
--- a/bbot/modules/retirejs.py
+++ b/bbot/modules/retirejs.py
@@ -188,7 +188,7 @@ class retirejs(BaseModule):
                                     "severity": severity,
                                     "confidence": "HIGH",
                                     "component": component,
-                                    "url": event.parent.data["url"],
+                                    "url": event.parent.parsed_url.geturl(),
                                 }
                                 await self.emit_event(
                                     data,

--- a/bbot/test/test_step_2/module_tests/test_module_retirejs.py
+++ b/bbot/test/test_step_2/module_tests/test_module_retirejs.py
@@ -132,6 +132,8 @@ return Handlebars;
         for finding in retirejs_findings:
             assert "description" in finding.data, "Finding should have description"
             assert "url" in finding.data, "Finding should have url"
+            # url field should point to the page that loaded the JS, not the JS file itself
+            assert finding.data["url"] == "http://127.0.0.1:8888/", "url should be the parent page URL"
             assert finding.parent.type == "URL_UNVERIFIED", "Parent should be URL_UNVERIFIED"
 
 


### PR DESCRIPTION
## Summary
- Fix `string indices must be integers, not 'str'` crash in `retirejs.handle_event()` at line 191
- `event.parent.data["url"]` assumed the parent event's data was a dict, but URL_UNVERIFIED parents (e.g. from gowitness) have string data
- Changed to `event.parent.parsed_url.geturl()` which works for all URL-bearing parent types (URL, URL_UNVERIFIED, HTTP_RESPONSE)
- Added test assertion verifying the `url` field points to the parent page, not the JS file itself