### PR TITLE
Strip HTTP response bodies after all modules finish processing

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -697,19 +697,9 @@ class BaseEvent:
         Called when a module is done processing this event.
 
         Decrements the consumer count. When no modules are left waiting to
-        process this event, heavy payload data (e.g. HTTP response bodies)
-        is stripped to free memory.
-
-        The event object stays alive (for parent-chain references, etc.)
-        but large fields like HTTP response bodies and raw headers are removed.
-
-        So basically, the parent becomes dead inside for the sake of the children.
-        Just like real life.
+        process this event, heavy payload data is stripped to free memory.
         """
         self._module_consumers = max(0, self._module_consumers - 1)
-        if self._module_consumers <= 0 and isinstance(self._data, dict):
-            self._data.pop("body", None)
-            self._data.pop("raw_header", None)
 
     def clone(self):
         # Create a shallow copy of the event first
@@ -1593,6 +1583,12 @@ class HTTP_RESPONSE(URL_UNVERIFIED):
 
     def _pretty_string(self):
         return f"{self.data['hash']['header_mmh3']}:{self.data['hash']['body_mmh3']}"
+
+    def _minimize(self):
+        super()._minimize()
+        if self._module_consumers <= 0:
+            self._data.pop("body", None)
+            self._data.pop("raw_header", None)
 
     @property
     def raw_response(self):

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -710,6 +710,9 @@ class BaseEvent:
 
         The event object stays alive (for parent-chain references, etc.)
         but large fields like HTTP response bodies and raw headers are removed.
+
+        So basically, the parent becomes dead inside for the sake of the children.
+        Just like real life.
         """
         if isinstance(self._data, dict):
             self._data.pop("body", None)

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -692,21 +692,13 @@ class BaseEvent:
             e = parent
         return parents
 
-    def _release(self):
+    def _minimize(self):
         """
         Called when a module is done processing this event.
 
         Decrements the consumer count. When no modules are left waiting to
         process this event, heavy payload data (e.g. HTTP response bodies)
         is stripped to free memory.
-        """
-        self._module_consumers = max(0, self._module_consumers - 1)
-        if self._module_consumers <= 0:
-            self._minimize()
-
-    def _minimize(self):
-        """
-        Strip heavy payload data from the event to free memory.
 
         The event object stays alive (for parent-chain references, etc.)
         but large fields like HTTP response bodies and raw headers are removed.
@@ -714,7 +706,8 @@ class BaseEvent:
         So basically, the parent becomes dead inside for the sake of the children.
         Just like real life.
         """
-        if isinstance(self._data, dict):
+        self._module_consumers = max(0, self._module_consumers - 1)
+        if self._module_consumers <= 0 and isinstance(self._data, dict):
             self._data.pop("body", None)
             self._data.pop("raw_header", None)
 

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -164,6 +164,8 @@ class BaseEvent:
         "dns_resolve_distance",
         # Host metadata (cloud providers, ASN, whois, etc.)
         "_host_metadata",
+        # Memory management
+        "_module_consumers",
         # Public attributes
         "module",
         "scan",
@@ -224,6 +226,7 @@ class BaseEvent:
         self.dns_children = {}
         self.raw_dns_records = {}
         self._discovery_context = ""
+        self._module_consumers = 0
 
         # for creating one-off events without enforcing parent requirement
         self._dummy = _dummy
@@ -688,6 +691,29 @@ class BaseEvent:
             parents.append(parent)
             e = parent
         return parents
+
+    def _release(self):
+        """
+        Called when a module is done processing this event.
+
+        Decrements the consumer count. When no modules are left waiting to
+        process this event, heavy payload data (e.g. HTTP response bodies)
+        is stripped to free memory.
+        """
+        self._module_consumers = max(0, self._module_consumers - 1)
+        if self._module_consumers <= 0:
+            self._minimize()
+
+    def _minimize(self):
+        """
+        Strip heavy payload data from the event to free memory.
+
+        The event object stays alive (for parent-chain references, etc.)
+        but large fields like HTTP response bodies and raw headers are removed.
+        """
+        if isinstance(self._data, dict):
+            self._data.pop("body", None)
+            self._data.pop("raw_header", None)
 
     def clone(self):
         # Create a shallow copy of the event first

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -494,6 +494,9 @@ class BaseModule:
                     await self.run_task(self.handle_batch(*events), context, n=len(events))
                 except asyncio.CancelledError:
                     self.debug(f"{context} was cancelled")
+                finally:
+                    for event in events:
+                        event._release()
                 self.verbose(f"Finished handling batch of {len(events):,} events")
         if finish:
             context = f"{self.name}.finish()"
@@ -663,11 +666,14 @@ class BaseModule:
                 if acceptable:
                     if event.type == "FINISHED":
                         finish = True
+                        event._release()
                     else:
                         events.append(event)
                         self.scan.stats.event_consumed(event, self)
-                elif reason:
-                    self.debug(f"Not accepting {event} because {reason}")
+                else:
+                    event._release()
+                    if reason:
+                        self.debug(f"Not accepting {event} because {reason}")
             except asyncio.queues.QueueEmpty:
                 break
         return events, finish
@@ -761,28 +767,31 @@ class BaseModule:
                         except asyncio.queues.QueueEmpty:
                             continue
                         self.debug(f"Got {event} from {getattr(event, 'module', 'unknown_module')}")
-                        async with self._task_counter.count(f"event_postcheck({event})"):
-                            acceptable, reason = await self._event_postcheck(event)
-                        if acceptable:
-                            if event.type == "FINISHED":
-                                context = f"{self.name}.finish()"
-                                try:
-                                    await self.run_task(self.finish(), context)
-                                except asyncio.CancelledError:
-                                    self.debug(f"{context} was cancelled")
-                                    continue
+                        try:
+                            async with self._task_counter.count(f"event_postcheck({event})"):
+                                acceptable, reason = await self._event_postcheck(event)
+                            if acceptable:
+                                if event.type == "FINISHED":
+                                    context = f"{self.name}.finish()"
+                                    try:
+                                        await self.run_task(self.finish(), context)
+                                    except asyncio.CancelledError:
+                                        self.debug(f"{context} was cancelled")
+                                        continue
+                                else:
+                                    context = f"{self.name}.handle_event({event})"
+                                    self.scan.stats.event_consumed(event, self)
+                                    self.debug(f"Handling {event}")
+                                    try:
+                                        await self.run_task(self.handle_event(event), context)
+                                    except asyncio.CancelledError:
+                                        self.debug(f"{context} was cancelled")
+                                        continue
+                                    self.debug(f"Finished handling {event}")
                             else:
-                                context = f"{self.name}.handle_event({event})"
-                                self.scan.stats.event_consumed(event, self)
-                                self.debug(f"Handling {event}")
-                                try:
-                                    await self.run_task(self.handle_event(event), context)
-                                except asyncio.CancelledError:
-                                    self.debug(f"{context} was cancelled")
-                                    continue
-                                self.debug(f"Finished handling {event}")
-                        else:
-                            self.debug(f"Not accepting {event} because {reason}")
+                                self.debug(f"Not accepting {event} because {reason}")
+                        finally:
+                            event._release()
         except asyncio.CancelledError:
             # this trace was used for debugging leaked CancelledErrors from inside httpx
             # self.log.trace("Worker cancelled")
@@ -1022,6 +1031,7 @@ class BaseModule:
                 self.debug(f"Queueing {event} because {reason}")
             try:
                 self.incoming_event_queue.put_nowait(event)
+                event._module_consumers += 1
                 async with self.event_received:
                     self.event_received.notify()
                 if event.type != "FINISHED":

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -496,7 +496,7 @@ class BaseModule:
                     self.debug(f"{context} was cancelled")
                 finally:
                     for event in events:
-                        event._release()
+                        event._minimize()
                 self.verbose(f"Finished handling batch of {len(events):,} events")
         if finish:
             context = f"{self.name}.finish()"
@@ -666,12 +666,12 @@ class BaseModule:
                 if acceptable:
                     if event.type == "FINISHED":
                         finish = True
-                        event._release()
+                        event._minimize()
                     else:
                         events.append(event)
                         self.scan.stats.event_consumed(event, self)
                 else:
-                    event._release()
+                    event._minimize()
                     if reason:
                         self.debug(f"Not accepting {event} because {reason}")
             except asyncio.queues.QueueEmpty:
@@ -791,7 +791,7 @@ class BaseModule:
                             else:
                                 self.debug(f"Not accepting {event} because {reason}")
                         finally:
-                            event._release()
+                            event._minimize()
         except asyncio.CancelledError:
             # this trace was used for debugging leaked CancelledErrors from inside httpx
             # self.log.trace("Worker cancelled")

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -271,3 +271,7 @@ class ScanEgress(BaseInterceptModule):
             # don't distribute events to intercept modules
             if not mod._intercept:
                 await mod.queue_event(event)
+
+        # if no module accepted this event, minimize it now
+        if event._module_consumers <= 0:
+            event._minimize()

--- a/bbot/test/benchmarks/test_scan_memory.py
+++ b/bbot/test/benchmarks/test_scan_memory.py
@@ -9,6 +9,7 @@ benchmark extra_info["total_memory_mb"].
 
 import subprocess
 import sys
+import textwrap
 
 import pytest
 
@@ -38,66 +39,66 @@ def _run_scan_subprocess(script: str) -> float:
 # 1) Web crawl -- httpx visits many pages, excavate processes bodies
 # ---------------------------------------------------------------------------
 
-_WEB_CRAWL_SCRIPT = """
-import gc, asyncio, threading, tracemalloc
-from http.server import HTTPServer, BaseHTTPRequestHandler
-from bbot.scanner import Scanner
+_WEB_CRAWL_SCRIPT = textwrap.dedent(f"""\
+    import gc, asyncio, threading, tracemalloc
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    from bbot.scanner import Scanner
 
-NUM_PAGES = NUM_PAGES_PLACEHOLDER
-BODY_SIZE = BODY_SIZE_PLACEHOLDER
+    NUM_PAGES = {NUM_PAGES}
+    BODY_SIZE = {BODY_SIZE}
 
-class H(BaseHTTPRequestHandler):
-    def do_GET(self):
-        if self.path == "/":
-            links = "".join(f'<a href="/page{i}">page{i}</a>' for i in range(NUM_PAGES))
-            body = "<html><body>" + links + "</body></html>"
-        elif self.path.startswith("/page"):
-            i = self.path.replace("/page", "")
-            links = f'<a href="/data{i}/info">info</a><a href="/data{i}/details">details</a>'
-            body = "<html><body><h1>Page " + i + "</h1>" + links + "A" * BODY_SIZE + "</body></html>"
-        elif self.path.startswith("/data"):
-            body = "<html><body>data endpoint</body></html>"
-        else:
-            self.send_response(404); self.end_headers(); return
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html")
-        self.end_headers()
-        self.wfile.write(body.encode())
-    def log_message(self, *a): pass
+    class H(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/":
+                links = "".join(f'<a href="/page{{i}}">page{{i}}</a>' for i in range(NUM_PAGES))
+                body = f"<html><body>{{links}}</body></html>"
+            elif self.path.startswith("/page"):
+                i = self.path.replace("/page", "")
+                links = f'<a href="/data{{i}}/info">info</a><a href="/data{{i}}/details">details</a>'
+                body = f"<html><body><h1>Page {{i}}</h1>{{links}}{{"A" * BODY_SIZE}}</body></html>"
+            elif self.path.startswith("/data"):
+                body = "<html><body>data endpoint</body></html>"
+            else:
+                self.send_response(404); self.end_headers(); return
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(body.encode())
+        def log_message(self, *a): pass
 
-server = HTTPServer(("127.0.0.1", 0), H)
-port = server.server_address[1]
-threading.Thread(target=server.serve_forever, daemon=True).start()
+    server = HTTPServer(("127.0.0.1", 0), H)
+    port = server.server_address[1]
+    threading.Thread(target=server.serve_forever, daemon=True).start()
 
-scan = Scanner(
-    f"http://127.0.0.1:{port}/",
-    modules=["httpx"], output_modules=["python"],
-    config={
-        "dns": {"disable": True},
-        "scope": {"search_distance": 0},
-        "web": {"spider_distance": 10, "spider_depth": 10, "spider_links_per_page": NUM_PAGES},
-        "speculate": True, "excavate": True, "aggregate": False, "cloudcheck": False,
-        "modules": {"httpx": {"batch_size": 25}},
-    },
-    force_start=True,
-)
+    scan = Scanner(
+        f"http://127.0.0.1:{{port}}/",
+        modules=["httpx"], output_modules=["python"],
+        config={{
+            "dns": {{"disable": True}},
+            "scope": {{"search_distance": 0}},
+            "web": {{"spider_distance": 10, "spider_depth": 10, "spider_links_per_page": NUM_PAGES}},
+            "speculate": True, "excavate": True, "aggregate": False, "cloudcheck": False,
+            "modules": {{"httpx": {{"batch_size": 25}}}},
+        }},
+        force_start=True,
+    )
 
-async def run():
-    await scan._prep()
-    gc.collect()
-    if tracemalloc.is_tracing():
-        tracemalloc.stop()
-    tracemalloc.start()
-    events = []
-    async for event in scan.async_start():
-        events.append(event)
+    async def run():
+        await scan._prep()
+        gc.collect()
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+        tracemalloc.start()
+        events = []
+        async for event in scan.async_start():
+            events.append(event)
 
-asyncio.run(run())
-_, peak = tracemalloc.get_traced_memory()
-tracemalloc.stop()
-server.shutdown()
-print(f"PEAK_MB:{round(peak / 1024 / 1024, 2)}")
-""".replace("NUM_PAGES_PLACEHOLDER", str(NUM_PAGES)).replace("BODY_SIZE_PLACEHOLDER", str(BODY_SIZE))
+    asyncio.run(run())
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    server.shutdown()
+    print(f"PEAK_MB:{{round(peak / 1024 / 1024, 2)}}")
+""")
 
 
 class TestWebCrawlMemory:
@@ -115,51 +116,51 @@ class TestWebCrawlMemory:
 # 2) Subdomain enum -- many DNS_NAME events, no heavy bodies
 # ---------------------------------------------------------------------------
 
-_SUBDOMAIN_ENUM_SCRIPT = """
-import gc, asyncio, tracemalloc
-from bbot.scanner import Scanner
+_SUBDOMAIN_ENUM_SCRIPT = textwrap.dedent(f"""\
+    import gc, asyncio, tracemalloc
+    from bbot.scanner import Scanner
 
-SUBDOMAIN_ENUM_COUNT = SUBDOMAIN_COUNT_PLACEHOLDER
+    SUBDOMAIN_ENUM_COUNT = {SUBDOMAIN_ENUM_COUNT}
 
-scan = Scanner(
-    "blacklanternsecurity.com",
-    modules=[], output_modules=["python"],
-    config={
-        "dns": {"disable": True},
-        "scope": {"search_distance": 0},
-        "web": {"spider_distance": 0, "spider_depth": 0},
-        "speculate": False, "excavate": True, "aggregate": False, "cloudcheck": False,
-    },
-    force_start=True,
-)
+    scan = Scanner(
+        "blacklanternsecurity.com",
+        modules=[], output_modules=["python"],
+        config={{
+            "dns": {{"disable": True}},
+            "scope": {{"search_distance": 0}},
+            "web": {{"spider_distance": 0, "spider_depth": 0}},
+            "speculate": False, "excavate": True, "aggregate": False, "cloudcheck": False,
+        }},
+        force_start=True,
+    )
 
-async def run():
-    await scan._prep()
-    gc.collect()
-    if tracemalloc.is_tracing():
-        tracemalloc.stop()
-    tracemalloc.start()
-    events = []
-    injected = False
-    async for event in scan.async_start():
-        events.append(event)
-        if event.type == "SCAN" and not injected:
-            injected = True
-            root_event = scan.root_event
-            for i in range(SUBDOMAIN_ENUM_COUNT):
-                dns_event = scan.make_event(
-                    f"sub{i}.blacklanternsecurity.com",
-                    "DNS_NAME",
-                    parent=root_event,
-                    context=f"benchmark DNS_NAME {i}",
-                )
-                await scan.ingress_module.queue_event(dns_event, {})
+    async def run():
+        await scan._prep()
+        gc.collect()
+        if tracemalloc.is_tracing():
+            tracemalloc.stop()
+        tracemalloc.start()
+        events = []
+        injected = False
+        async for event in scan.async_start():
+            events.append(event)
+            if event.type == "SCAN" and not injected:
+                injected = True
+                root_event = scan.root_event
+                for i in range(SUBDOMAIN_ENUM_COUNT):
+                    dns_event = scan.make_event(
+                        f"sub{{i}}.blacklanternsecurity.com",
+                        "DNS_NAME",
+                        parent=root_event,
+                        context=f"benchmark DNS_NAME {{i}}",
+                    )
+                    await scan.ingress_module.queue_event(dns_event, {{}})
 
-asyncio.run(run())
-_, peak = tracemalloc.get_traced_memory()
-tracemalloc.stop()
-print(f"PEAK_MB:{round(peak / 1024 / 1024, 2)}")
-""".replace("SUBDOMAIN_COUNT_PLACEHOLDER", str(SUBDOMAIN_ENUM_COUNT))
+    asyncio.run(run())
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    print(f"PEAK_MB:{{round(peak / 1024 / 1024, 2)}}")
+""")
 
 
 class TestSubdomainEnumMemory:

--- a/bbot/test/benchmarks/test_scan_memory.py
+++ b/bbot/test/benchmarks/test_scan_memory.py
@@ -9,7 +9,6 @@ benchmark extra_info["total_memory_mb"].
 
 import subprocess
 import sys
-import textwrap
 
 import pytest
 
@@ -39,66 +38,66 @@ def _run_scan_subprocess(script: str) -> float:
 # 1) Web crawl -- httpx visits many pages, excavate processes bodies
 # ---------------------------------------------------------------------------
 
-_WEB_CRAWL_SCRIPT = textwrap.dedent(f"""\
-    import gc, asyncio, threading, tracemalloc
-    from http.server import HTTPServer, BaseHTTPRequestHandler
-    from bbot.scanner import Scanner
+_WEB_CRAWL_SCRIPT = """
+import gc, asyncio, threading, tracemalloc
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from bbot.scanner import Scanner
 
-    NUM_PAGES = {NUM_PAGES}
-    BODY_SIZE = {BODY_SIZE}
+NUM_PAGES = NUM_PAGES_PLACEHOLDER
+BODY_SIZE = BODY_SIZE_PLACEHOLDER
 
-    class H(BaseHTTPRequestHandler):
-        def do_GET(self):
-            if self.path == "/":
-                links = "".join(f'<a href="/page{{i}}">page{{i}}</a>' for i in range(NUM_PAGES))
-                body = f"<html><body>{{links}}</body></html>"
-            elif self.path.startswith("/page"):
-                i = self.path.replace("/page", "")
-                links = f'<a href="/data{{i}}/info">info</a><a href="/data{{i}}/details">details</a>'
-                body = f"<html><body><h1>Page {{i}}</h1>{{links}}{{"A" * BODY_SIZE}}</body></html>"
-            elif self.path.startswith("/data"):
-                body = "<html><body>data endpoint</body></html>"
-            else:
-                self.send_response(404); self.end_headers(); return
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            self.wfile.write(body.encode())
-        def log_message(self, *a): pass
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/":
+            links = "".join(f'<a href="/page{i}">page{i}</a>' for i in range(NUM_PAGES))
+            body = "<html><body>" + links + "</body></html>"
+        elif self.path.startswith("/page"):
+            i = self.path.replace("/page", "")
+            links = f'<a href="/data{i}/info">info</a><a href="/data{i}/details">details</a>'
+            body = "<html><body><h1>Page " + i + "</h1>" + links + "A" * BODY_SIZE + "</body></html>"
+        elif self.path.startswith("/data"):
+            body = "<html><body>data endpoint</body></html>"
+        else:
+            self.send_response(404); self.end_headers(); return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(body.encode())
+    def log_message(self, *a): pass
 
-    server = HTTPServer(("127.0.0.1", 0), H)
-    port = server.server_address[1]
-    threading.Thread(target=server.serve_forever, daemon=True).start()
+server = HTTPServer(("127.0.0.1", 0), H)
+port = server.server_address[1]
+threading.Thread(target=server.serve_forever, daemon=True).start()
 
-    scan = Scanner(
-        f"http://127.0.0.1:{{port}}/",
-        modules=["httpx"], output_modules=["python"],
-        config={{
-            "dns": {{"disable": True}},
-            "scope": {{"search_distance": 0}},
-            "web": {{"spider_distance": 10, "spider_depth": 10, "spider_links_per_page": NUM_PAGES}},
-            "speculate": True, "excavate": True, "aggregate": False, "cloudcheck": False,
-            "modules": {{"httpx": {{"batch_size": 25}}}},
-        }},
-        force_start=True,
-    )
+scan = Scanner(
+    f"http://127.0.0.1:{port}/",
+    modules=["httpx"], output_modules=["python"],
+    config={
+        "dns": {"disable": True},
+        "scope": {"search_distance": 0},
+        "web": {"spider_distance": 10, "spider_depth": 10, "spider_links_per_page": NUM_PAGES},
+        "speculate": True, "excavate": True, "aggregate": False, "cloudcheck": False,
+        "modules": {"httpx": {"batch_size": 25}},
+    },
+    force_start=True,
+)
 
-    async def run():
-        await scan._prep()
-        gc.collect()
-        if tracemalloc.is_tracing():
-            tracemalloc.stop()
-        tracemalloc.start()
-        events = []
-        async for event in scan.async_start():
-            events.append(event)
+async def run():
+    await scan._prep()
+    gc.collect()
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    tracemalloc.start()
+    events = []
+    async for event in scan.async_start():
+        events.append(event)
 
-    asyncio.run(run())
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    server.shutdown()
-    print(f"PEAK_MB:{{round(peak / 1024 / 1024, 2)}}")
-""")
+asyncio.run(run())
+_, peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+server.shutdown()
+print(f"PEAK_MB:{round(peak / 1024 / 1024, 2)}")
+""".replace("NUM_PAGES_PLACEHOLDER", str(NUM_PAGES)).replace("BODY_SIZE_PLACEHOLDER", str(BODY_SIZE))
 
 
 class TestWebCrawlMemory:
@@ -116,51 +115,51 @@ class TestWebCrawlMemory:
 # 2) Subdomain enum -- many DNS_NAME events, no heavy bodies
 # ---------------------------------------------------------------------------
 
-_SUBDOMAIN_ENUM_SCRIPT = textwrap.dedent(f"""\
-    import gc, asyncio, tracemalloc
-    from bbot.scanner import Scanner
+_SUBDOMAIN_ENUM_SCRIPT = """
+import gc, asyncio, tracemalloc
+from bbot.scanner import Scanner
 
-    SUBDOMAIN_ENUM_COUNT = {SUBDOMAIN_ENUM_COUNT}
+SUBDOMAIN_ENUM_COUNT = SUBDOMAIN_COUNT_PLACEHOLDER
 
-    scan = Scanner(
-        "blacklanternsecurity.com",
-        modules=[], output_modules=["python"],
-        config={{
-            "dns": {{"disable": True}},
-            "scope": {{"search_distance": 0}},
-            "web": {{"spider_distance": 0, "spider_depth": 0}},
-            "speculate": False, "excavate": True, "aggregate": False, "cloudcheck": False,
-        }},
-        force_start=True,
-    )
+scan = Scanner(
+    "blacklanternsecurity.com",
+    modules=[], output_modules=["python"],
+    config={
+        "dns": {"disable": True},
+        "scope": {"search_distance": 0},
+        "web": {"spider_distance": 0, "spider_depth": 0},
+        "speculate": False, "excavate": True, "aggregate": False, "cloudcheck": False,
+    },
+    force_start=True,
+)
 
-    async def run():
-        await scan._prep()
-        gc.collect()
-        if tracemalloc.is_tracing():
-            tracemalloc.stop()
-        tracemalloc.start()
-        events = []
-        injected = False
-        async for event in scan.async_start():
-            events.append(event)
-            if event.type == "SCAN" and not injected:
-                injected = True
-                root_event = scan.root_event
-                for i in range(SUBDOMAIN_ENUM_COUNT):
-                    dns_event = scan.make_event(
-                        f"sub{{i}}.blacklanternsecurity.com",
-                        "DNS_NAME",
-                        parent=root_event,
-                        context=f"benchmark DNS_NAME {{i}}",
-                    )
-                    await scan.ingress_module.queue_event(dns_event, {{}})
+async def run():
+    await scan._prep()
+    gc.collect()
+    if tracemalloc.is_tracing():
+        tracemalloc.stop()
+    tracemalloc.start()
+    events = []
+    injected = False
+    async for event in scan.async_start():
+        events.append(event)
+        if event.type == "SCAN" and not injected:
+            injected = True
+            root_event = scan.root_event
+            for i in range(SUBDOMAIN_ENUM_COUNT):
+                dns_event = scan.make_event(
+                    f"sub{i}.blacklanternsecurity.com",
+                    "DNS_NAME",
+                    parent=root_event,
+                    context=f"benchmark DNS_NAME {i}",
+                )
+                await scan.ingress_module.queue_event(dns_event, {})
 
-    asyncio.run(run())
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    print(f"PEAK_MB:{{round(peak / 1024 / 1024, 2)}}")
-""")
+asyncio.run(run())
+_, peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+print(f"PEAK_MB:{round(peak / 1024 / 1024, 2)}")
+""".replace("SUBDOMAIN_COUNT_PLACEHOLDER", str(SUBDOMAIN_ENUM_COUNT))
 
 
 class TestSubdomainEnumMemory:


### PR DESCRIPTION
## Summary

BBOT is essentially one big memory leak - this is unavoidable, because it is truly recursive, and the whole scan is essentially a giant tree that is formed throughout the scan. That tree includes HTTP_RESPONSE events, which include the full body of the response, which can be significantly large. Prior to this fix, every single one of those was sitting in memory for the entire scan. This change aims to alleviate that by removing the response body from HTTP_RESPONSE events after every module that wants to use it, has.

### How it works

- **`_module_consumers` counter on `BaseEvent`** — incremented when an event is queued to a module, decremented when the module finishes processing (via `_release()`)
- **`_minimize()`** — strips `body` and `raw_header` from the event's data dict when the counter reaches zero. The event object itself stays alive (parent chains, tags, metadata all preserved)
- All decrement paths covered: `handle_event`, `handle_batch`, events rejected by postcheck, `FINISHED` events, and a fallback in `ScanEgress.forward_event()` for events no module accepts