### PR TITLE
Bound DNS engine caches with LRU eviction

### DIFF
--- a/bbot/core/helpers/dns/engine.py
+++ b/bbot/core/helpers/dns/engine.py
@@ -72,7 +72,7 @@ class DNSEngine(EngineServer):
             self.wildcard_ignore = []
         self.wildcard_ignore = tuple([str(d).strip().lower() for d in self.wildcard_ignore])
         self.wildcard_tests = self.dns_config.get("wildcard_tests", 5)
-        self._wildcard_cache = {}
+        self._wildcard_cache = LRUCache(maxsize=10000)
         # since wildcard detection takes some time, This is to prevent multiple
         # modules from kicking off wildcard detection for the same domain at the same time
         self._wildcard_lock = NamedLock()
@@ -81,10 +81,10 @@ class DNSEngine(EngineServer):
         self._last_dns_success = None
         self._last_connectivity_warning = time.time()
         # keeps track of warnings issued for wildcard detection to prevent duplicate warnings
-        self._dns_warnings = set()
-        self._errors = {}
+        self._dns_warnings = LRUCache(maxsize=10000)
+        self._errors = LRUCache(maxsize=10000)
         self._debug = self.dns_config.get("debug", False)
-        self._dns_cache = LRUCache(maxsize=10000)
+        self._dns_cache = LRUCache(maxsize=100000)
 
     async def resolve(self, query, **kwargs):
         """Resolve DNS names and IP addresses to their corresponding results.
@@ -221,7 +221,7 @@ class DNSEngine(EngineServer):
                                 self.log.verbose(
                                     f'Aborting future {rdtype} queries to "{parent}" because error count ({error_count:,}) exceeded abort threshold ({self.abort_threshold:,})'
                                 )
-                            self._dns_warnings.add(parent_hash)
+                            self._dns_warnings[parent_hash] = True
                             return results, errors
                     results = await self._catch(self.resolver.resolve, query, **kwargs)
                     if use_cache:


### PR DESCRIPTION
## Summary

The DNS engine maintains several in-memory caches that previously used unbounded `dict` and `set` types. On long-running scans these grow without limit.

This replaces them with `cachetools.LRUCache`:

- `_dns_cache`: **10,000 → 100,000** entries (~18 MB) -- main resolution cache, bumped up since the original was too small
- `_wildcard_cache`: unbounded `dict` → **LRU 10,000** entries -- wildcard detection results
- `_dns_warnings`: unbounded `set` → **LRU 10,000** entries -- duplicate warning suppression
- `_errors`: unbounded `dict` → **LRU 10,000** entries -- per-domain error counters

Eviction behavior is safe for all four: evicted DNS entries get re-resolved, evicted wildcard entries get re-checked, evicted warnings may print a duplicate log line, and evicted error counters reset (allowing retries, which is actually desirable in long scans where transient issues may have resolved).