### PR TITLE
Skip CLA check for bot accounts

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -50,9 +50,31 @@ jobs:
             -f context="CLAAssistant" \
             -f description="CLA check skipped — author is an org member"
 
+      - name: Check if author is a bot
+        id: bot-check
+        if: github.event_name == 'pull_request_target'
+        run: |
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+          if [[ "$AUTHOR" == *"[bot]" ]]; then
+            echo "is_bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_bot=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip CLA for bots
+        if: steps.bot-check.outputs.is_bot == 'true' && github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method POST "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=success \
+            -f context="CLAAssistant" \
+            -f description="CLA check skipped — author is a bot"
+
       - name: "CLA Assistant"
         if: |
           (steps.membership.outputs.is_member != 'true') &&
+          (steps.bot-check.outputs.is_bot != 'true') &&
           ((github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@v2.6.1
         env:


### PR DESCRIPTION
## Summary

Fixes CLA check failures on automated PRs from bot accounts (e.g. dependabot, renovate).

The existing `allowlist` field in the CLA assistant action was not matching bot authors correctly, causing PRs like #3009 to fail the CLA check. This adds an explicit bot detection step that:

1. Checks if the PR author's login ends with `[bot]`
2. Sets a success commit status for `CLAAssistant` when a bot is detected
3. Skips the CLA assistant action entirely via an additional `if` condition

This is in addition to the existing org membership skip and the CLA assistant's own allowlist, providing a reliable fallback.

## Test plan

- [ ] Merge this PR, then re-run the CLA check on #3009 (dependabot PR) and verify it passes
- [ ] Verify normal CLA flow still works for non-bot, non-member PRs
- [ ] Once validated here, roll out to other org repos