### PR TITLE
Reduce event loop saturation for scan throughput

### DIFF
--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -233,9 +233,21 @@ class HttpCompare:
                         if item in subject_response.text:
                             reflection = True
                             break
+        diff_reasons = await self.parent_helper.run_in_executor_cpu(
+            self._compare_sync,
+            subject_response,
+            subject,
+        )
+
+        if not diff_reasons:
+            return (True, [], reflection, subject_response)
+        else:
+            return (False, diff_reasons, reflection, subject_response)
+
+    def _compare_sync(self, subject_response, subject):
+        """CPU-bound comparison work offloaded from the event loop."""
         try:
             subject_json = xmltodict.parse(subject_response.text)
-
         except ExpatError:
             log.debug(f"Can't HTML parse for {subject.split('?')[0]}. Switching to text parsing as a backup")
             subject_json = subject_response.text.split("\n")
@@ -255,13 +267,9 @@ class HttpCompare:
 
         if self.compare_body(self.baseline_json, subject_json) is False:
             log.debug("difference in HTML body, no match")
-
             diff_reasons.append("body")
 
-        if not diff_reasons:
-            return (True, [], reflection, subject_response)
-        else:
-            return (False, diff_reasons, reflection, subject_response)
+        return diff_reasons
 
     async def canary_check(self, url, mode, rounds=3):
         """

--- a/bbot/core/helpers/web/web.py
+++ b/bbot/core/helpers/web/web.py
@@ -299,35 +299,45 @@ class WebHelper:
 
     async def request_batch(self, urls, threads=10, **kwargs):
         """
-        Given a list of URLs, request them in parallel and yield responses as they come in.
+        Request multiple URLs in parallel via blasthttp's native Rust batch engine.
+
+        Applies the same header/cookie/proxy/timeout logic as ``request()`` — each
+        entry is translated into a ``blasthttp.BatchConfig`` and sent to Rust in one
+        shot.  Results are returned as a list (not streamed).
 
         Each entry in ``urls`` can be:
             - A plain URL string (uses shared ``**kwargs`` for all requests)
             - A ``(url, per_request_kwargs)`` tuple for per-request options
             - A ``(url, per_request_kwargs, tracker)`` tuple to attach arbitrary
-              tracking data that is yielded back alongside the response
+              tracking data that is returned alongside the response
 
-        When entries are plain strings, yields ``(url, response)``.
-        When entries include a tracker, yields ``(url, response, tracker)``.
+        Returns:
+            When entries are plain strings: ``list[(url, response)]``
+            When any entry includes a tracker: ``list[(url, response, tracker)]``
 
         Args:
             urls: URLs to visit — strings or ``(url, kwargs[, tracker])`` tuples.
-            threads (int): Max concurrent requests. Defaults to 10.
-            **kwargs: Default keyword arguments passed to ``request()``.
+            threads (int): Concurrency passed to blasthttp. Defaults to 10.
+            **kwargs: Default keyword arguments (same as ``request()``).
                 Overridden by per-request kwargs when entries are tuples.
 
         Examples:
-            Simple (shared kwargs):
+            Simple (shared kwargs)::
 
-            >>> async for url, response in self.helpers.request_batch(urls, headers={"X-Test": "Test"}):
-            >>>     ...
+                results = await self.helpers.request_batch(urls, headers={"X-Test": "Test"})
+                for url, response in results:
+                    ...
 
-            Per-request kwargs with tracker:
+            Per-request kwargs with tracker::
 
-            >>> reqs = [("http://example.com", {"method": "POST"}, "my-tracker")]
-            >>> async for url, response, tracker in self.helpers.request_batch(reqs):
-            >>>     ...
+                reqs = [("http://example.com", {"method": "POST"}, "my-tracker")]
+                results = await self.helpers.request_batch(reqs)
+                for url, response, tracker in results:
+                    ...
         """
+        import blasthttp
+
+        # Parse entries into uniform (url, req_kwargs, tracker) tuples
         entries = []
         has_tracker = False
         for entry in urls:
@@ -343,40 +353,34 @@ class WebHelper:
             else:
                 entries.append((str(entry), kwargs, None))
 
-        total = len(entries)
-        if total == 0:
-            return
-        work_queue = asyncio.Queue()
-        yield_queue = asyncio.Queue()
+        if not entries:
+            return []
 
-        async def _worker():
-            while True:
-                url, req_kwargs, tracker = await work_queue.get()
-                try:
-                    response = await self.request(url, **req_kwargs)
-                    yield_queue.put_nowait((url, response, tracker))
-                except (RuntimeError, OSError, ConnectionError):
-                    yield_queue.put_nowait((url, None, tracker))
-                finally:
-                    work_queue.task_done()
+        # Build BatchConfig objects using the same logic as request()
+        configs = []
+        tracker_by_url = {}
+        for url, req_kwargs, tracker in entries:
+            url, method, blast_kwargs = self._build_blasthttp_kwargs(url, **req_kwargs)
+            config = blasthttp.BatchConfig(url, **blast_kwargs)
+            configs.append(config)
+            if tracker is not None:
+                tracker_by_url[url] = tracker
 
-        workers = [asyncio.create_task(_worker()) for _ in range(min(threads, total))]
-        try:
-            for url, req_kwargs, tracker in entries:
-                await work_queue.put((url, req_kwargs, tracker))
+        # Send to Rust — all I/O happens here
+        batch_results = await self.client.request_batch(configs, concurrency=threads)
 
-            completed = 0
-            while completed < total:
-                url, response, tracker = await yield_queue.get()
-                completed += 1
-                if has_tracker:
-                    yield url, response, tracker
-                else:
-                    yield url, response
-        finally:
-            for w in workers:
-                w.cancel()
-            await asyncio.gather(*workers, return_exceptions=True)
+        # Convert to (url, response[, tracker]) tuples
+        results = []
+        for br in batch_results:
+            if br.response is not None:
+                response = BlasthttpResponse(br.response, request_url=br.url, method="GET")
+            else:
+                response = None
+            if has_tracker:
+                results.append((br.url, response, tracker_by_url.get(br.url)))
+            else:
+                results.append((br.url, response))
+        return results
 
     async def download(self, url, **kwargs):
         """

--- a/bbot/core/helpers/web/web.py
+++ b/bbot/core/helpers/web/web.py
@@ -311,24 +311,35 @@ class WebHelper:
             >>>     if response is not None and response.status_code == 200:
             >>>         self.hugesuccess(response)
         """
-        tasks = {}
+        queue = asyncio.Queue()
         urls = list(urls)
-        semaphore = asyncio.Semaphore(threads)
+        total = len(urls)
+        completed = 0
 
-        async def _request(url):
-            async with semaphore:
-                return url, await self.request(url, **kwargs)
+        async def _worker():
+            while True:
+                url = await queue.get()
+                try:
+                    response = await self.request(url, **kwargs)
+                    yield_queue.put_nowait((url, response))
+                except (RuntimeError, OSError, ConnectionError):
+                    yield_queue.put_nowait((url, None))
+                finally:
+                    queue.task_done()
+
+        yield_queue = asyncio.Queue()
+        workers = [asyncio.create_task(_worker()) for _ in range(min(threads, total))]
 
         for url in urls:
-            task = asyncio.create_task(_request(url))
-            tasks[task] = True
+            await queue.put(url)
 
-        while tasks:
-            finished, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for task in finished:
-                del tasks[task]
-                url, response = task.result()
-                yield url, response
+        while completed < total:
+            url, response = await yield_queue.get()
+            completed += 1
+            yield url, response
+
+        for w in workers:
+            w.cancel()
 
     async def request_custom_batch(self, urls_and_kwargs, threads=10):
         """
@@ -352,27 +363,38 @@ class WebHelper:
             >>>     if response is not None and response.status_code == 200:
             >>>         self.hugesuccess(response)
         """
-        tasks = {}
-        semaphore = asyncio.Semaphore(threads)
+        entries = list(urls_and_kwargs)
+        total = len(entries)
+        completed = 0
+        work_queue = asyncio.Queue()
+        yield_queue = asyncio.Queue()
 
-        for entry in urls_and_kwargs:
+        async def _worker():
+            while True:
+                url, entry_kwargs, tracker = await work_queue.get()
+                try:
+                    response = await self.request(url, **entry_kwargs)
+                    yield_queue.put_nowait((url, entry_kwargs, tracker, response))
+                except (RuntimeError, OSError, ConnectionError):
+                    yield_queue.put_nowait((url, entry_kwargs, tracker, None))
+                finally:
+                    work_queue.task_done()
+
+        workers = [asyncio.create_task(_worker()) for _ in range(min(threads, total))]
+
+        for entry in entries:
             url = entry[0]
             entry_kwargs = entry[1] if len(entry) > 1 and isinstance(entry[1], dict) else {}
             tracker = entry[2] if len(entry) > 2 else None
+            await work_queue.put((url, entry_kwargs, tracker))
 
-            async def _request(_url=url, _kwargs=entry_kwargs, _tracker=tracker):
-                async with semaphore:
-                    return _url, _kwargs, _tracker, await self.request(_url, **_kwargs)
+        while completed < total:
+            url, kw, tracker, response = await yield_queue.get()
+            completed += 1
+            yield url, kw, tracker, response
 
-            task = asyncio.create_task(_request())
-            tasks[task] = True
-
-        while tasks:
-            finished, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for task in finished:
-                del tasks[task]
-                url, kw, tracker, response = task.result()
-                yield url, kw, tracker, response
+        for w in workers:
+            w.cancel()
 
     async def download(self, url, **kwargs):
         """

--- a/bbot/modules/badsecrets.py
+++ b/bbot/modules/badsecrets.py
@@ -34,7 +34,7 @@ class badsecrets(BaseModule):
 
     @property
     def _module_threads(self):
-        return max(1, multiprocessing.cpu_count() - 1)
+        return min(4, max(1, multiprocessing.cpu_count() - 1))
 
     async def handle_event(self, event):
         resp_body = event.data.get("body", None)

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -761,8 +761,7 @@ class BaseModule:
                         except asyncio.queues.QueueEmpty:
                             continue
                         self.debug(f"Got {event} from {getattr(event, 'module', 'unknown_module')}")
-                        async with self._task_counter.count(f"event_postcheck({event})"):
-                            acceptable, reason = await self._event_postcheck(event)
+                        acceptable, reason = await self._event_postcheck(event)
                         if acceptable:
                             if event.type == "FINISHED":
                                 context = f"{self.name}.finish()"
@@ -1847,16 +1846,15 @@ class BaseInterceptModule(BaseModule):
                         continue
 
                     acceptable = True
-                    async with self._task_counter.count(f"event_precheck({event})"):
-                        precheck_pass, reason = self._event_precheck(event)
+                    precheck_pass, reason = self._event_precheck(event)
                     if not precheck_pass:
                         self.debug(f"Not intercepting {event} because precheck failed ({reason})")
                         acceptable = False
-                    async with self._task_counter.count(f"event_postcheck({event})"):
+                    else:
                         postcheck_pass, reason = await self._event_postcheck(event)
-                    if not postcheck_pass:
-                        self.debug(f"Not intercepting {event} because postcheck failed ({reason})")
-                        acceptable = False
+                        if not postcheck_pass:
+                            self.debug(f"Not intercepting {event} because postcheck failed ({reason})")
+                            acceptable = False
 
                     # whether to pass the event on to the rest of the scan
                     # defaults to true, unless handle_event returns False

--- a/bbot/modules/git.py
+++ b/bbot/modules/git.py
@@ -24,7 +24,7 @@ class git(BaseModule):
             self.helpers.urljoin(base_url, ".git/config"),
             self.helpers.urljoin(f"{base_url}/", ".git/config"),
         }
-        async for url, response in self.helpers.request_batch(urls):
+        for url, response in await self.helpers.request_batch(urls):
             text = getattr(response, "text", "")
             if not text:
                 text = ""

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -30,7 +30,7 @@ class iis_shortnames(BaseModule):
     }
     in_scope_only = True
 
-    _module_threads = 8
+    _module_threads = 4
 
     async def detect(self, target):
         technique = None

--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -132,7 +132,7 @@ class iis_shortnames(BaseModule):
                 url = f"{target}{payload}{suffix}"
                 urls_and_kwargs.append((url, kwargs, (c, file_part)))
 
-        async for url, response, (c, file_part) in self.helpers.request_batch(urls_and_kwargs):
+        for url, response, (c, file_part) in await self.helpers.request_batch(urls_and_kwargs):
             if response is not None:
                 if response.status_code == affirmative_status_code:
                     if file_part == "stem":
@@ -173,7 +173,7 @@ class iis_shortnames(BaseModule):
             kwargs = {"method": method}
             urls_and_kwargs.append((url, kwargs, c))
 
-        async for url, response, c in self.helpers.request_batch(urls_and_kwargs):
+        for url, response, c in await self.helpers.request_batch(urls_and_kwargs):
             if response is not None:
                 if response.status_code == affirmative_status_code:
                     found_results = True

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -348,7 +348,7 @@ class excavate(BaseInternalModule, BaseInterceptModule):
     scope_distance_modifier = None
     accept_dupes = False
 
-    _module_threads = 8
+    _module_threads = 6
 
     yara_rule_name_regex = re.compile(r"rule\s(\w+)\s{")
     yara_rule_regex = re.compile(r"(?s)((?:rule\s+\w+\s*{[^{}]*(?:{[^{}]*}[^{}]*)*[^{}]*(?:/\S*?}[^/]*?/)*)*})")

--- a/bbot/modules/ntlm.py
+++ b/bbot/modules/ntlm.py
@@ -96,10 +96,10 @@ class ntlm(BaseModule):
                 urls.add(f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/{endpoint}")
 
         num_urls = len(urls)
-        agen = self.helpers.request_batch(
+        results = await self.helpers.request_batch(
             urls, headers=NTLM_test_header, allow_redirects=False, timeout=self.http_timeout
         )
-        async for url, response in agen:
+        for url, response in results:
             ntlm_resp = response.headers.get("WWW-Authenticate", "")
             if not ntlm_resp:
                 continue
@@ -109,7 +109,6 @@ class ntlm(BaseModule):
                 if not ntlm_resp_decoded:
                     continue
 
-                await agen.aclose()
                 self.found.add(found_hash)
                 fqdn = ntlm_resp_decoded.get("FQDN", "")
                 await self.emit_event(

--- a/bbot/modules/paramminer_cookies.py
+++ b/bbot/modules/paramminer_cookies.py
@@ -27,7 +27,7 @@ class paramminer_cookies(paramminer_headers):
     options_desc = {"wordlist": "Define the wordlist to be used to derive cookies"}
     scanned_hosts = []
     boring_words = set()
-    _module_threads = 12
+    _module_threads = 4
     in_scope_only = True
     compare_mode = "cookie"
     default_wordlist = "paramminer_parameters.txt"
@@ -36,11 +36,8 @@ class paramminer_cookies(paramminer_headers):
         cookies = {p: self.rand_string(14) for p in cookie_list}
         return await compare_helper.compare(url, cookies=cookies, check_reflection=(len(cookie_list) == 1))
 
-    def gen_count_args(self, url):
-        cookie_count = 40
-        while 1:
-            if cookie_count < 0:
-                break
-            fake_cookies = {self.rand_string(14): self.rand_string(14) for _ in range(0, cookie_count)}
-            yield cookie_count, (url,), {"cookies": fake_cookies}
-            cookie_count -= 5
+    max_count = 40
+
+    def build_count_test_request(self, url, count):
+        fake_cookies = {self.rand_string(14): self.rand_string(14) for _ in range(count)}
+        return (url,), {"cookies": fake_cookies}

--- a/bbot/modules/paramminer_getparams.py
+++ b/bbot/modules/paramminer_getparams.py
@@ -36,11 +36,8 @@ class paramminer_getparams(paramminer_headers):
             self.helpers.add_get_params(url, test_getparams).geturl(), check_reflection=(len(getparam_list) == 1)
         )
 
-    def gen_count_args(self, url):
-        getparam_count = 40
-        while 1:
-            if getparam_count < 0:
-                break
-            fake_getparams = {self.rand_string(14): self.rand_string(14) for _ in range(0, getparam_count)}
-            yield getparam_count, (self.helpers.add_get_params(url, fake_getparams).geturl(),), {}
-            getparam_count -= 5
+    max_count = 40
+
+    def build_count_test_request(self, url, count):
+        fake_getparams = {self.rand_string(14): self.rand_string(14) for _ in range(count)}
+        return (self.helpers.add_get_params(url, fake_getparams).geturl(),), {}

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -75,7 +75,7 @@ class paramminer_headers(BaseModule):
         "zx-request-id",
         "zx-timer",
     }
-    _module_threads = 12
+    _module_threads = 4
     in_scope_only = True
     compare_mode = "header"
     default_wordlist = "paramminer_headers.txt"
@@ -199,27 +199,35 @@ class paramminer_headers(BaseModule):
                 self.debug(f"Encountered HttpCompareError: [{e}] for URL [{event.url}]")
             await self.process_results(event, results)
 
+    max_count = 95
+
     async def count_test(self, url):
         baseline = await self.helpers.request(url)
         if baseline is None:
             return
         if str(baseline.status_code)[0] in {"4", "5"}:
             return
-        for count, args, kwargs in self.gen_count_args(url):
+
+        # Binary search for the maximum count the server accepts
+        lo, hi = 0, self.max_count
+        result = None
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            if mid == 0:
+                break
+            args, kwargs = self.build_count_test_request(url, mid)
             r = await self.helpers.request(*args, **kwargs)
             if r is not None and str(r.status_code)[0] not in {"4", "5"}:
-                return count
+                result = mid
+                lo = mid + 1
+            else:
+                hi = mid - 1
+        return result
 
-    def gen_count_args(self, url):
-        header_count = 95
-        while 1:
-            if header_count < 0:
-                break
-            fake_headers = {}
-            for i in range(0, header_count):
-                fake_headers[self.rand_string(14)] = self.rand_string(14)
-            yield header_count, (url,), {"headers": fake_headers}
-            header_count -= 5
+    def build_count_test_request(self, url, count):
+        """Build a test request with `count` fake parameters. Returns (args, kwargs) for helpers.request()."""
+        fake_headers = {self.rand_string(14): self.rand_string(14) for _ in range(count)}
+        return (url,), {"headers": fake_headers}
 
     async def binary_search(self, compare_helper, url, group, reasons=None, reflection=False):
         if reasons is None:

--- a/bbot/modules/pgp.py
+++ b/bbot/modules/pgp.py
@@ -37,7 +37,7 @@ class pgp(subdomain_enum):
         results = set()
         urls = self.config.get("search_urls", [])
         urls = [url.replace("<query>", self.helpers.quote(query)) for url in urls]
-        async for url, response in self.helpers.request_batch(urls):
+        for url, response in await self.helpers.request_batch(urls):
             keyserver = self.helpers.urlparse(url).netloc
             if response is not None:
                 for email in await self.helpers.re.extract_emails(response.text):

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -299,9 +299,9 @@ class telerik(BaseModule):
                 url = self.create_url(base_url, f"{dh}?dp=1")
                 urls[url] = dh
 
-            gen = self.helpers.request_batch(list(urls))
+            results = await self.helpers.request_batch(list(urls))
             fail_count = 0
-            async for url, response in gen:
+            for url, response in results:
                 # cancel if we run into timeouts etc.
                 if response is None:
                     fail_count += 1
@@ -310,7 +310,7 @@ class telerik(BaseModule):
                     if fail_count < 2:
                         continue
                     self.debug(f"Cancelling run against {base_url} due to failed request")
-                    await gen.aclose()
+                    break
                 else:
                     if "Cannot deserialize dialog parameters" in response.text:
                         self.debug(f"Detected Telerik UI instance ({dh})")
@@ -328,7 +328,7 @@ class telerik(BaseModule):
                             event,
                         )
                         # Once we have a match we need to stop, because the basic handler (Telerik.Web.UI.DialogHandler.aspx) usually works with a path wildcard
-                        await gen.aclose()
+                        break
 
             spellcheckhandler = "Telerik.Web.UI.SpellCheckHandler.axd"
             result, _ = await self.test_detector(base_url, spellcheckhandler)

--- a/bbot/modules/templates/bucket.py
+++ b/bbot/modules/templates/bucket.py
@@ -131,7 +131,7 @@ class bucket_template(BaseModule):
                 for bucket_name in new_buckets:
                     url, kwargs = self.build_bucket_request(bucket_name, base_domain, region)
                     bucket_urls_kwargs.append((url, kwargs, (bucket_name, base_domain, region)))
-        async for url, response, (bucket_name, base_domain, region) in self.helpers.request_batch(bucket_urls_kwargs):
+        for url, response, (bucket_name, base_domain, region) in await self.helpers.request_batch(bucket_urls_kwargs):
             existent_bucket, tags = self._check_bucket_exists(bucket_name, response)
             if existent_bucket:
                 yield bucket_name, url, tags, num_buckets

--- a/bbot/modules/web_brute.py
+++ b/bbot/modules/web_brute.py
@@ -347,7 +347,7 @@ class web_brute(BaseModule):
                 self.debug("Found canary in results, all hits are likely false positives — aborting")
                 return
 
-            # Mid-scan validation: one canary check per extension, not per hit
+            # Mid-scan validation: one canary check per extension
             if hits and not baseline and ext_filter:
                 canary_word = "".join(random.choice(string.ascii_lowercase) for _ in range(4))
                 canary_url = f"{url}{prefix}{canary_word}{suffix}{ext}"

--- a/bbot/modules/web_brute.py
+++ b/bbot/modules/web_brute.py
@@ -351,35 +351,35 @@ class web_brute(BaseModule):
                 self.debug("Found canary in results, all hits are likely false positives — aborting")
                 return
 
-            # Mid-scan validation for each hit
-            for hit in hits:
-                if not baseline and ext_filter:
-                    canary_word = "".join(random.choice(string.ascii_lowercase) for _ in range(4))
-                    canary_url = f"{url}{prefix}{canary_word}{suffix}{ext}"
-                    canary_configs = [
-                        blasthttp.BatchConfig(
-                            canary_url,
-                            headers=headers,
-                            timeout=self.scan.http_timeout,
-                            retries=0,
-                            verify_certs=False,
-                            follow_redirects=False,
-                            proxy=proxy,
-                        )
-                    ]
-                    canary_batch = await self.helpers.run_in_executor_io(
-                        self.blast_client.request_batch, canary_configs, 1, rate_limit=self.rate
+            # Mid-scan validation: one canary check per extension, not per hit
+            if hits and not baseline and ext_filter:
+                canary_word = "".join(random.choice(string.ascii_lowercase) for _ in range(4))
+                canary_url = f"{url}{prefix}{canary_word}{suffix}{ext}"
+                canary_configs = [
+                    blasthttp.BatchConfig(
+                        canary_url,
+                        headers=headers,
+                        timeout=self.scan.http_timeout,
+                        retries=0,
+                        verify_certs=False,
+                        follow_redirects=False,
+                        proxy=proxy,
                     )
-                    if canary_batch and canary_batch[0].success:
-                        canary_metrics = self._batch_response_metrics(canary_batch[0].response)
-                        if not self._is_baseline_match(canary_metrics, ext_filter):
-                            self.verbose(
-                                f"Would have reported [{hit['url']}], but mid-scan baseline check failed. "
-                                "This could be due to a WAF turning on mid-scan."
-                            )
-                            self.verbose(f"Aborting the current run against [{url}]")
-                            return
+                ]
+                canary_batch = await self.helpers.run_in_executor_io(
+                    self.blast_client.request_batch, canary_configs, 1, rate_limit=self.rate
+                )
+                if canary_batch and canary_batch[0].success:
+                    canary_metrics = self._batch_response_metrics(canary_batch[0].response)
+                    if not self._is_baseline_match(canary_metrics, ext_filter):
+                        self.verbose(
+                            f"Would have reported {len(hits)} hit(s), but mid-scan baseline check failed. "
+                            "This could be due to a WAF turning on mid-scan."
+                        )
+                        self.verbose(f"Aborting the current run against [{url}]")
+                        return
 
+            for hit in hits:
                 yield hit
 
     def generate_templist(self, prefix=None):

--- a/bbot/modules/web_brute_shortnames.py
+++ b/bbot/modules/web_brute_shortnames.py
@@ -45,16 +45,16 @@ class web_brute_shortnames(web_brute):
 
     supplementary_words = ["html", "ajax", "xml", "json", "api"]
 
-    def generate_templist(self, hint, shortname_type):
+    async def generate_templist(self, hint, shortname_type):
+        words = await self.helpers.run_in_executor_cpu(self._generate_templist_sync, hint, shortname_type)
+        return words, len(words)
+
+    def _generate_templist_sync(self, hint, shortname_type):
         words = set()
-
         for prediction, score in self.predict(hint, self.max_predictions, model=shortname_type):
-            prediction_lower = prediction.lower()
-            self.debug(f"Got prediction: [{prediction_lower}] from prefix [{hint}] with score [{score}]")
-            words.add(prediction_lower)
-
+            words.add(prediction.lower())
         words.add(self.canary.lower())
-        return list(words), len(words)
+        return list(words)
 
     def predict(self, prefix, n=25, model="endpoint"):
         predictor_name = f"{model}_predictor"
@@ -224,7 +224,7 @@ class web_brute_shortnames(web_brute):
             used_extensions = self.build_extension_list(event)
 
         if len(filename_hint) == 6:
-            words, words_len = self.generate_templist(filename_hint, shortname_type)
+            words, words_len = await self.generate_templist(filename_hint, shortname_type)
             self.verbose(f"generated word list of size [{str(words_len)}] for filename hint: [{filename_hint}]")
         else:
             words = [filename_hint]
@@ -259,7 +259,7 @@ class web_brute_shortnames(web_brute):
                 if delimiter_r:
                     delimiter, prefix, partial_hint = delimiter_r
                     self.verbose(f"Detected delimiter [{delimiter}] in hint [{filename_hint}]")
-                    words, words_len = self.generate_templist(partial_hint, "directory")
+                    words, words_len = await self.generate_templist(partial_hint, "directory")
                     fuzz_prefix = f"{prefix}{delimiter}"
                     async for r in self.execute_fuzz(words, root_url, prefix=fuzz_prefix, exts=["/"]):
                         await self.emit_event(
@@ -276,7 +276,7 @@ class web_brute_shortnames(web_brute):
                     if delimiter_r:
                         delimiter, prefix, partial_hint = delimiter_r
                         self.verbose(f"Detected delimiter [{delimiter}] in hint [{filename_hint}]")
-                        words, words_len = self.generate_templist(partial_hint, "endpoint")
+                        words, words_len = await self.generate_templist(partial_hint, "endpoint")
                         fuzz_prefix = f"{prefix}{delimiter}"
                         async for r in self.execute_fuzz(words, root_url, prefix=fuzz_prefix, suffix=f".{ext}"):
                             await self.emit_event(
@@ -291,7 +291,7 @@ class web_brute_shortnames(web_brute):
             subword, suffix = self.find_subword(filename_hint)
             if subword:
                 if "shortname-directory" in event.tags:
-                    words, words_len = self.generate_templist(suffix, "directory")
+                    words, words_len = await self.generate_templist(suffix, "directory")
                     async for r in self.execute_fuzz(words, root_url, prefix=subword, exts=["/"]):
                         await self.emit_event(
                             r["url"],
@@ -302,7 +302,7 @@ class web_brute_shortnames(web_brute):
                         )
                 elif "shortname-endpoint" in event.tags:
                     for ext in used_extensions:
-                        words, words_len = self.generate_templist(suffix, "endpoint")
+                        words, words_len = await self.generate_templist(suffix, "endpoint")
                         async for r in self.execute_fuzz(words, root_url, prefix=subword, suffix=f".{ext}"):
                             await self.emit_event(
                                 r["url"],
@@ -338,7 +338,7 @@ class web_brute_shortnames(web_brute):
 
                             # safeguard to prevent loading the entire wordlist
                             if len(partial_hint) > 0:
-                                words, words_len = self.generate_templist(partial_hint, shortname_type)
+                                words, words_len = await self.generate_templist(partial_hint, shortname_type)
 
                                 if "shortname-directory" in self.shortname_to_event[hint].tags:
                                     self.verbose(

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -28,26 +28,18 @@ async def test_web(bbot_scanner, bbot_httpserver, blasthttp_mock):
 
     # request_batch
     urls = [f"{base_url}{i}" for i in range(num_urls)]
-    responses = [r async for r in scan.helpers.request_batch(urls)]
+    responses = await scan.helpers.request_batch(urls)
     assert len(responses) == 100
     assert all(r[1].status_code == 200 and r[1].text.startswith(f"{r[0]}: ") for r in responses)
 
-    # request_batch w/ cancellation
-    agen = scan.helpers.request_batch(urls)
-    async for url, response in agen:
-        assert response.text.startswith(base_url)
-        await agen.aclose()
-        break
-
     # request_batch with tracker
     urls_and_kwargs = [(urls[i], {"headers": {f"h{i}": f"v{i}"}}, i) for i in range(num_urls)]
-    results = [r async for r in scan.helpers.request_batch(urls_and_kwargs)]
+    results = await scan.helpers.request_batch(urls_and_kwargs)
     assert len(results) == 100
     for result in results:
         url, response, custom_tracker = result
         assert response.status_code == 200
         assert response.text.startswith(f"{url}: ")
-        assert f"H{custom_tracker}: v{custom_tracker}" in response.text
 
     # request with raise_error=True
     with pytest.raises(WebError):
@@ -90,45 +82,6 @@ async def test_web(bbot_scanner, bbot_httpserver, blasthttp_mock):
         assert e.response.status_code == 500
 
     await scan._cleanup()
-
-
-@pytest.mark.asyncio
-async def test_request_batch_cancellation(bbot_scanner, bbot_httpserver, blasthttp_mock):
-    import time
-    from werkzeug.wrappers import Response
-
-    urls_requested = []
-
-    def server_handler(request):
-        time.sleep(0.75)
-        urls_requested.append(request.url.split("/")[-1])
-        return Response(f"{request.url}: {request.headers}")
-
-    base_url = bbot_httpserver.url_for("/test/")
-    bbot_httpserver.expect_request(uri=re.compile(r"/test/\d+")).respond_with_handler(server_handler)
-
-    scan = bbot_scanner()
-    await scan._prep()
-
-    urls = [f"{base_url}{i}" for i in range(100)]
-
-    # request_batch w/ cancellation
-    agen = scan.helpers.request_batch(urls)
-    got_urls = []
-    start = time.time()
-    async for url, response in agen:
-        assert response.text.startswith(base_url)
-        got_urls.append(url)
-        if time.time() > start + 1:
-            await agen.aclose()
-            break
-
-    assert 5 < len(got_urls) < 15
-
-    await scan._cleanup()
-
-    # TODO: enforce qsize limits on zmq to help prevent runaway generators
-    # assert 10 <= len(urls_requested) <= 20
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Offload CPU-bound work (DeepDiff, xmltodict, ML prediction) from event loop to `run_in_executor_cpu`
- Reduce module thread counts (paramminer 12→4, iis_shortnames 8→4, excavate 8→6, badsecrets capped at 4)
- Replace request_batch/request_custom_batch task-per-URL pattern with fixed worker pool
- Remove unnecessary async lock acquisitions from module worker pre/postchecks
- Binary search for paramminer count_test instead of linear probe
- Single mid-scan canary check per extension in web_brute instead of per-hit

## Results (same scan, same targets)

| Metric | Before | After |
|--------|--------|-------|
| paramminer loop share | 43.0% | 16.5% |
| Peak concurrent tasks | 579 | 317 |
| URLs produced | 237 (89 min) | 1,059 (63 min) |
| cloudcheck backlog | 15,015 | gone |