### PR TITLE
Improve URL event stdout display format

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1363,6 +1363,22 @@ class URL_UNVERIFIED(DictHostEvent):
     def pretty_string(self):
         return self.url
 
+    def _data_human(self):
+        parts = []
+        status = self.http_status
+        if status:
+            parts.append(f"[{status}]")
+        parts.append(self.url)
+        if status and str(status).startswith("3"):
+            location = self.data.get("redirect_location", "")
+            if location:
+                parts.append(f"-> {location}")
+        else:
+            title = self.http_title
+            if title:
+                parts.append(f"- [{title}]")
+        return " ".join(parts)
+
     def add_tag(self, tag):
         self_url = getattr(self, "parsed_url", "")
         self_host = getattr(self, "host", "")
@@ -1426,6 +1442,14 @@ class URL_UNVERIFIED(DictHostEvent):
     @http_title.setter
     def http_title(self, value):
         self.data["http_title"] = value
+
+    @property
+    def redirect_location(self):
+        return self.data.get("redirect_location", "")
+
+    @redirect_location.setter
+    def redirect_location(self, value):
+        self.data["redirect_location"] = value
 
 
 class URL(URL_UNVERIFIED):

--- a/bbot/modules/httpx.py
+++ b/bbot/modules/httpx.py
@@ -206,6 +206,9 @@ class httpx(BaseModule):
                 title = j.get("title", "")
                 if title:
                     url_event.http_title = title
+                location = j.get("header", {}).get("location", "")
+                if location:
+                    url_event.redirect_location = location
                 if url_event != parent_event:
                     await self.emit_event(url_event)
                 # HTTP response


### PR DESCRIPTION
## Summary

- URL events now display as `[status] url` instead of raw JSON dict
- Titles shown as `[200] https://example.com - [Page Title]`
- Redirects show target: `[302] https://old.com -> https://new.com`
- Unverified URLs display as bare URL (no status code yet)
- Added `redirect_location` property to URL events, populated by httpx

Closes #3020