### PR TITLE
Install pip inside the bbot venv

### DIFF
--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -268,24 +268,6 @@ class DepsInstaller:
         packages_str = ",".join(packages)
         log.info(f"Installing the following pip packages: {packages_str}")
 
-        # Ensure pip is available in the environment
-        try:
-            check_pip_command = [sys.executable, "-m", "pip", "--version"]
-            await self.parent_helper.run(check_pip_command, check=True)
-        except CalledProcessError:
-            # pip is not available, try to install it with ensurepip
-            log.info("pip not found in virtual environment, attempting to install with ensurepip")
-            try:
-                ensurepip_command = [sys.executable, "-m", "ensurepip", "--upgrade"]
-                await self.parent_helper.run(ensurepip_command, check=True)
-                log.info("Successfully installed pip with ensurepip")
-            except CalledProcessError as err:
-                log.warning(
-                    f"Failed to install pip with ensurepip (return code {err.returncode}): {err.stderr}. "
-                    f"If using uv, create the virtual environment with 'uv venv --seed' or set UV_VENV_SEED=1"
-                )
-                return False
-
         command = [sys.executable, "-m", "pip", "install", "--upgrade"] + packages
 
         # if no custom constraints are provided, use the constraints of the currently installed version of bbot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Topic :: Security",
 ]
 dependencies = [
+    "pip",
     "omegaconf>=2.3.0,<3",
     "psutil>=5.9.4,<8.0.0",
     "wordninja>=2.0.0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,7 @@ dependencies = [
     { name = "mmh3" },
     { name = "omegaconf" },
     { name = "orjson" },
+    { name = "pip" },
     { name = "psutil" },
     { name = "puremagic" },
     { name = "pycryptodome" },
@@ -273,6 +274,7 @@ requires-dist = [
     { name = "mmh3", specifier = ">=4.1,<6.0" },
     { name = "omegaconf", specifier = ">=2.3.0,<3" },
     { name = "orjson", specifier = ">=3.10.12,<4" },
+    { name = "pip" },
     { name = "psutil", specifier = ">=5.9.4,<8.0.0" },
     { name = "puremagic", specifier = ">=1.28,<2" },
     { name = "pycryptodome", specifier = ">=3.17,<4" },
@@ -1705,6 +1707,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pip"
+version = "26.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Since `uv tool install` doesn't install `pip` inside the virtualenv, we need to explicitly specify it in bbot's deps.