### PR TITLE
Skip gateway error codes in IIS shortnames detection

### DIFF
--- a/bbot/modules/iis_shortnames.py
+++ b/bbot/modules/iis_shortnames.py
@@ -32,6 +32,9 @@ class iis_shortnames(BaseModule):
 
     _module_threads = 8
 
+    # Gateway error codes from reverse proxies / CDNs — not IIS shortname signals
+    gateway_error_codes = {502, 503, 504}
+
     async def detect(self, target):
         technique = None
         detections = []
@@ -47,6 +50,13 @@ class iis_shortnames(BaseModule):
                 control_result = await self.helpers.request(control_url, **kwargs)
                 test_result = await self.helpers.request(test_url, **kwargs)
                 if control_result and test_result:
+                    # Skip gateway errors (502/503/504) — these come from CDNs/reverse proxies, not IIS
+                    if {control_result.status_code, test_result.status_code} & self.gateway_error_codes:
+                        self.debug(
+                            f"Skipping {method} detection on {target}: gateway error code "
+                            f"({control_result.status_code}/{test_result.status_code})"
+                        )
+                        break
                     if control_result.status_code != test_result.status_code:
                         confirmations += 1
                         self.debug(f"New detection on {target}, number of confirmations: [{str(confirmations)}]")

--- a/bbot/test/test_step_2/module_tests/test_module_iis_shortnames.py
+++ b/bbot/test/test_step_2/module_tests/test_module_iis_shortnames.py
@@ -104,3 +104,27 @@ class TestIIS_Shortnames(ModuleTestBase):
         assert magicurl_findingEmitted
         assert url_hintEmitted
         assert zip_findingEmitted
+
+
+class TestIIS_Shortnames_GatewayError(ModuleTestBase):
+    """Negative test: server returns 502 gateway errors. Should NOT detect IIS shortnames."""
+
+    targets = ["http://127.0.0.1:8888"]
+    modules_overrides = ["httpx", "iis_shortnames"]
+
+    async def setup_after_prep(self, module_test):
+        module_test.httpserver.no_handler_status_code = 404
+
+        expect_args = {"method": "GET", "uri": "/"}
+        respond_args = {"response_data": "alive", "status": 200}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+        # Control URL returns 404, test URL returns 502 (gateway error from CDN)
+        expect_args = {"method": "GET", "uri": "/*~1*/a.aspx"}
+        respond_args = {"response_data": "Bad Gateway", "status": 502}
+        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+
+    def check(self, module_test, events):
+        for e in events:
+            if e.type == "FINDING" and "IIS Shortname" in e.data.get("description", ""):
+                raise AssertionError("IIS Shortname finding should NOT be emitted when gateway errors are present")


### PR DESCRIPTION
## Summary

- Skip 502/503/504 gateway error codes in `iis_shortnames.detect()` — these come from CDNs and reverse proxies, not IIS, and were causing false positives on CDN-fronted non-IIS hosts
- Add negative test confirming no FINDING is emitted when the server returns 502