### PR TITLE
Filter out useless PTRs by default

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -68,7 +68,9 @@ dns:
   # Skip DNS requests for a certain domain and rdtype after encountering this many timeouts or SERVFAILs
   # This helps prevent faulty DNS servers from hanging up the scan
   abort_threshold: 50
-  # Don't show PTR records containing IP addresses
+  # Treat hostnames discovered via PTR records as affiliates instead of in-scope
+  # This prevents rDNS results (e.g. 1-2-3-4.ptr.example.com) from triggering
+  # subdomain enumeration against unrelated domains when scanning IP ranges
   filter_ptrs: true
   # Enable/disable debug messages for DNS queries
   debug: false

--- a/bbot/modules/internal/dnsresolve.py
+++ b/bbot/modules/internal/dnsresolve.py
@@ -75,9 +75,7 @@ class DNSResolve(BaseInterceptModule):
                 # this prevents rDNS results from triggering subdomain enumeration against unrelated domains
                 # (e.g. scanning 1.2.3.0/24 would otherwise enumerate every PTR parent like randomothercorp.com)
                 if self.filter_ptrs and "ptr" in main_host_event.tags:
-                    self.debug(
-                        f"Not making {main_host_event} in-scope: PTR-derived hostname (filter_ptrs=true)"
-                    )
+                    self.debug(f"Not making {main_host_event} in-scope: PTR-derived hostname (filter_ptrs=true)")
                 else:
                     self.debug(
                         f"Making {main_host_event} in-scope because it resolves to an in-scope resource (A/AAAA)"

--- a/bbot/modules/internal/dnsresolve.py
+++ b/bbot/modules/internal/dnsresolve.py
@@ -38,6 +38,8 @@ class DNSResolve(BaseInterceptModule):
         self.dns_search_distance = max(0, int(self.dns_config.get("search_distance", 1)))
         self._emit_raw_records = None
 
+        self.filter_ptrs = self.dns_config.get("filter_ptrs", True)
+
         self.host_module = self.HostModule(self.scan)
         self.children_emitted = set()
         self.children_emitted_raw = set()
@@ -69,8 +71,18 @@ class DNSResolve(BaseInterceptModule):
             # are any of its IPs in target scope or blacklisted?
             in_target, blacklisted = self.check_scope(main_host_event)
             if in_target and main_host_event.scope_distance > 0:
-                self.debug(f"Making {main_host_event} in-scope because it resolves to an in-scope resource (A/AAAA)")
-                main_host_event.scope_distance = 0
+                # when filter_ptrs is enabled, don't promote PTR-derived hostnames to in-scope
+                # this prevents rDNS results from triggering subdomain enumeration against unrelated domains
+                # (e.g. scanning 1.2.3.0/24 would otherwise enumerate every PTR parent like randomothercorp.com)
+                if self.filter_ptrs and "ptr" in main_host_event.tags:
+                    self.debug(
+                        f"Not making {main_host_event} in-scope: PTR-derived hostname (filter_ptrs=true)"
+                    )
+                else:
+                    self.debug(
+                        f"Making {main_host_event} in-scope because it resolves to an in-scope resource (A/AAAA)"
+                    )
+                    main_host_event.scope_distance = 0
 
         # abort if the event resolves to something blacklisted
         if blacklisted:
@@ -194,6 +206,10 @@ class DNSResolve(BaseInterceptModule):
                 except ValidationError as e:
                     self.warning(f'Event validation failed for DNS child of {event}: "{child_host}" ({rdtype}): {e}')
                     continue
+
+                # tag PTR-derived children so downstream logic can identify them
+                if rdtype == "PTR":
+                    child_event.add_tag("ptr")
 
                 child_hash = hash(f"{event.host}:{module}:{child_host}")
                 # if we haven't emitted this one before

--- a/bbot/test/test_step_2/module_tests/test_module_affiliates.py
+++ b/bbot/test/test_step_2/module_tests/test_module_affiliates.py
@@ -3,7 +3,7 @@ from .base import ModuleTestBase
 
 class TestAffiliates(ModuleTestBase):
     targets = ["8.8.8.8"]
-    config_overrides = {"dns": {"minimal": False}}
+    config_overrides = {"dns": {"minimal": False, "filter_ptrs": False}}
 
     async def setup_after_prep(self, module_test):
         await module_test.mock_dns(

--- a/bbot/test/test_step_2/module_tests/test_module_dnsresolve.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dnsresolve.py
@@ -65,7 +65,10 @@ class TestDNSResolveFilterPTRs(ModuleTestBase):
 
     module_name = "dnsresolve"
     targets = ["192.168.0.1"]
-    config_overrides = {"dns": {"minimal": False, "filter_ptrs": True, "search_distance": 1}, "scope": {"report_distance": 1, "search_distance": 0}}
+    config_overrides = {
+        "dns": {"minimal": False, "filter_ptrs": True, "search_distance": 1},
+        "scope": {"report_distance": 1, "search_distance": 0},
+    }
 
     async def setup_after_prep(self, module_test):
         await module_test.mock_dns(
@@ -77,9 +80,7 @@ class TestDNSResolveFilterPTRs(ModuleTestBase):
 
     def check(self, module_test, events):
         # the PTR-derived hostname should have the ptr tag
-        ptr_events = [
-            e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"
-        ]
+        ptr_events = [e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"]
         assert len(ptr_events) == 1, f"Expected exactly 1 PTR-derived DNS_NAME, got {len(ptr_events)}"
         ptr_event = ptr_events[0]
         assert "ptr" in ptr_event.tags, f"PTR-derived event should have 'ptr' tag, has: {ptr_event.tags}"
@@ -88,7 +89,9 @@ class TestDNSResolveFilterPTRs(ModuleTestBase):
             f"PTR-derived hostname should not be promoted to in-scope when filter_ptrs=true, "
             f"got scope_distance={ptr_event.scope_distance}"
         )
-        assert "affiliate" in ptr_event.tags, f"PTR-derived hostname should be tagged as affiliate, has: {ptr_event.tags}"
+        assert "affiliate" in ptr_event.tags, (
+            f"PTR-derived hostname should be tagged as affiliate, has: {ptr_event.tags}"
+        )
 
 
 class TestDNSResolveFilterPTRsDisabled(ModuleTestBase):
@@ -96,7 +99,10 @@ class TestDNSResolveFilterPTRsDisabled(ModuleTestBase):
 
     module_name = "dnsresolve"
     targets = ["192.168.0.1"]
-    config_overrides = {"dns": {"minimal": False, "filter_ptrs": False, "search_distance": 1}, "scope": {"report_distance": 1, "search_distance": 0}}
+    config_overrides = {
+        "dns": {"minimal": False, "filter_ptrs": False, "search_distance": 1},
+        "scope": {"report_distance": 1, "search_distance": 0},
+    }
 
     async def setup_after_prep(self, module_test):
         await module_test.mock_dns(
@@ -108,9 +114,7 @@ class TestDNSResolveFilterPTRsDisabled(ModuleTestBase):
 
     def check(self, module_test, events):
         # with filter_ptrs disabled, PTR-derived hostname should be promoted to in-scope
-        ptr_events = [
-            e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"
-        ]
+        ptr_events = [e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"]
         assert len(ptr_events) == 1, f"Expected exactly 1 PTR-derived DNS_NAME, got {len(ptr_events)}"
         ptr_event = ptr_events[0]
         assert "ptr" in ptr_event.tags, f"PTR-derived event should have 'ptr' tag, has: {ptr_event.tags}"

--- a/bbot/test/test_step_2/module_tests/test_module_dnsresolve.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dnsresolve.py
@@ -58,3 +58,64 @@ class TestDNSREsolve(ModuleTestBase):
                 and e.scope_distance == 1
             ]
         )
+
+
+class TestDNSResolveFilterPTRs(ModuleTestBase):
+    """Test that PTR-derived hostnames stay as affiliates when filter_ptrs is enabled (default)."""
+
+    module_name = "dnsresolve"
+    targets = ["192.168.0.1"]
+    config_overrides = {"dns": {"minimal": False, "filter_ptrs": True, "search_distance": 1}, "scope": {"report_distance": 1, "search_distance": 0}}
+
+    async def setup_after_prep(self, module_test):
+        await module_test.mock_dns(
+            {
+                "1.0.168.192.in-addr.arpa": {"PTR": ["ptr-host.othercorp.com"]},
+                "ptr-host.othercorp.com": {"A": ["192.168.0.1"]},
+            }
+        )
+
+    def check(self, module_test, events):
+        # the PTR-derived hostname should have the ptr tag
+        ptr_events = [
+            e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"
+        ]
+        assert len(ptr_events) == 1, f"Expected exactly 1 PTR-derived DNS_NAME, got {len(ptr_events)}"
+        ptr_event = ptr_events[0]
+        assert "ptr" in ptr_event.tags, f"PTR-derived event should have 'ptr' tag, has: {ptr_event.tags}"
+        # it should NOT be promoted to in-scope (scope_distance should stay > 0)
+        assert ptr_event.scope_distance > 0, (
+            f"PTR-derived hostname should not be promoted to in-scope when filter_ptrs=true, "
+            f"got scope_distance={ptr_event.scope_distance}"
+        )
+        assert "affiliate" in ptr_event.tags, f"PTR-derived hostname should be tagged as affiliate, has: {ptr_event.tags}"
+
+
+class TestDNSResolveFilterPTRsDisabled(ModuleTestBase):
+    """Test that PTR-derived hostnames ARE promoted to in-scope when filter_ptrs is disabled."""
+
+    module_name = "dnsresolve"
+    targets = ["192.168.0.1"]
+    config_overrides = {"dns": {"minimal": False, "filter_ptrs": False, "search_distance": 1}, "scope": {"report_distance": 1, "search_distance": 0}}
+
+    async def setup_after_prep(self, module_test):
+        await module_test.mock_dns(
+            {
+                "1.0.168.192.in-addr.arpa": {"PTR": ["ptr-host.othercorp.com"]},
+                "ptr-host.othercorp.com": {"A": ["192.168.0.1"]},
+            }
+        )
+
+    def check(self, module_test, events):
+        # with filter_ptrs disabled, PTR-derived hostname should be promoted to in-scope
+        ptr_events = [
+            e for e in events if e.type == "DNS_NAME" and e.data == "ptr-host.othercorp.com"
+        ]
+        assert len(ptr_events) == 1, f"Expected exactly 1 PTR-derived DNS_NAME, got {len(ptr_events)}"
+        ptr_event = ptr_events[0]
+        assert "ptr" in ptr_event.tags, f"PTR-derived event should have 'ptr' tag, has: {ptr_event.tags}"
+        # it SHOULD be promoted to in-scope
+        assert ptr_event.scope_distance == 0, (
+            f"PTR-derived hostname should be promoted to in-scope when filter_ptrs=false, "
+            f"got scope_distance={ptr_event.scope_distance}"
+        )


### PR DESCRIPTION
## Summary
- Wire up the existing (but dead) `dns.filter_ptrs` config option to prevent PTR-derived hostnames from being promoted to in-scope
- When scanning IP ranges (e.g. `1.2.3.0/24`), rDNS results like `1-2-3-4.ptr.randomothercorp.com` now stay as affiliates (scope_distance=1) instead of being treated as fully in-scope, preventing subdomain enumeration modules from blowing up against every unrelated PTR parent domain
- PTR-derived events are tagged with `ptr` for easy identification
- Behavior can be disabled with `dns.filter_ptrs: false` to restore the old behavior
