### PR TITLE
Fix docs pipeline, again

### DIFF
--- a/.github/workflows/docs_updater.yml
+++ b/.github/workflows/docs_updater.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
       - name: Generate docs
         run: |
-          uv run bbot/scripts/docs.py
+          uv run --no-sync bbot/scripts/docs.py
       - name: Create or Update Pull Request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install dependencies
-        run: uv sync --frozen --only-group docs
+        run: uv sync --frozen --group docs
       - name: Configure Git
         run: |
           git config user.name github-actions
@@ -255,11 +255,11 @@ jobs:
       - name: Generate docs (stable branch)
         if: github.ref == 'refs/heads/stable'
         run: |
-          uv run --frozen mike deploy Stable
+          uv run --no-sync mike deploy Stable
       - name: Generate docs (dev branch)
         if: github.ref == 'refs/heads/dev'
         run: |
-          uv run --frozen mike deploy Dev
+          uv run --no-sync mike deploy Dev
       - name: Publish docs
         run: |
           git switch gh-pages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,11 +255,11 @@ jobs:
       - name: Generate docs (stable branch)
         if: github.ref == 'refs/heads/stable'
         run: |
-          uv run mike deploy Stable
+          uv run --frozen mike deploy Stable
       - name: Generate docs (dev branch)
         if: github.ref == 'refs/heads/dev'
         run: |
-          uv run mike deploy Dev
+          uv run --frozen mike deploy Dev
       - name: Publish docs
         run: |
           git switch gh-pages


### PR DESCRIPTION
## Summary

Fix the `publish_docs` CI job, which has been failing on every merge to `dev`/`stable` with:

```
error: Your local changes to the following files would be overwritten by checkout:
	uv.lock
```

at the final `git switch gh-pages` step.

## Root cause

Two steps in the `publish_docs` job invoke `uv` in ways that rewrite `uv.lock`:

1. `uv sync --only-group docs` — without `--frozen`, `uv sync` will update the lockfile if it detects drift from `pyproject.toml`.
2. `uv run mike deploy …` — `uv run` performs an implicit sync before executing. Because mike/mkdocs imports `bbot` for API doc generation via griffe, this sync expands the venv from docs-only (46 pkgs) to full project (84 pkgs), and without `--frozen` that sync can also rewrite `uv.lock`.

The working tree ends up with an uncommitted `uv.lock` change, and `git switch gh-pages` refuses to clobber it.

The upstream cause is `docs_updater.yml`: that bot runs `uv sync --group dev` before `create-pull-request`, so a rewritten `uv.lock` gets swept into the automated docs PR. That PR (#3055) is what put the divergent lockfile onto `dev` in the first place.

## Fix

- `publish_docs`: install the project + docs group once with `uv sync --frozen --group docs`, then run mike with `uv run --no-sync` so there's no second implicit sync. Single install, zero lockfile writes.
- `docs_updater.yml`: same pattern — `uv sync --frozen --group dev` + `uv run --no-sync`. The bot's job is to update docs content, not dependencies; lockfile bumps should come from a separate channel (dependabot, manual PRs).

`--frozen` is the principled choice for both: neither job has any business resolving dependencies.

## Test plan

- [ ] Merge to `dev`; confirm `publish_docs` reaches and passes the `Publish docs` step.
- [ ] Confirm `gh-pages` receives the new `Dev` docs commit and is pushed.
- [ ] Sanity check the rendered docs site for the `Dev` version.
- [ ] Next scheduled `docs_updater` run produces a PR that modifies only docs content, not `uv.lock`.
