### PR TITLE
fix(test): parse baddns submodule source from file (Py 3.13+ fix)

### DIFF
--- a/bbot/test/test_step_2/module_tests/test_module_baddns.py
+++ b/bbot/test/test_step_2/module_tests/test_module_baddns.py
@@ -16,7 +16,13 @@ def _extract_finding_values(module_cls):
 
     Returns (set of severity strings, set of confidence strings).
     """
-    source = inspect.getsource(module_cls)
+    # Parse the whole source file rather than inspect.getsource(cls): the
+    # latter relies on linecache heuristics that can mis-anchor on Python
+    # 3.13+ and return a partial/indented fragment that fails to parse.
+    # Each baddns submodule is one class per file, so this is equivalent.
+    source_file = inspect.getsourcefile(module_cls)
+    with open(source_file) as f:
+        source = f.read()
     tree = ast.parse(source)
 
     severities = set()


### PR DESCRIPTION
## Summary
- `test_baddns_max_severity_confidence` failed on Python 3.13/3.14 because `inspect.getsource(cls)` returned a single indented attribute line (e.g. `    description = "..."`), which `ast.parse` rejected with `IndentationError`. CPython 3.13's source-block heuristics regressed for that class.
- Each baddns submodule is exactly one class per file, so reading the whole file via `inspect.getsourcefile()` is equivalent and avoids the `inspect.getsource` heuristic entirely.
- Verified passing on 3.12, 3.13, and 3.14 locally.

Failure context: https://github.com/blacklanternsecurity/bbot/actions/runs/24939288537/job/73030154357