### PR TITLE
Excavate: extract IPv6 URLs (#1815)

### DIFF
--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -864,7 +864,7 @@ class excavate(BaseInternalModule, BaseInterceptModule):
                         tags = "spider-danger"
                         description = "contains full URL"
                     strings:
-                        $url_full = /https?:\/\/([\w\.-]+)(:\d{1,5})?([\/\w\.-]*)/
+                        $url_full = /https?:\/\/(\[[0-9a-fA-F:]+\]|[\w\.-]+)(:\d{1,5})?([\/\w\.-]*)/
                     condition:
                         $url_full
                 }
@@ -884,8 +884,12 @@ class excavate(BaseInternalModule, BaseInterceptModule):
                 """
             ),
         }
-        full_url_regex = re.compile(r"(https?)://(\w(?:[\w-]+\.?)+(?::\d{1,5})?(?:/[-\w\.\(\)]*[-\w\.]+)*/?)")
-        full_url_regex_strict = re.compile(r"^(https?):\/\/([\w.-]+)(?::\d{1,5})?(\/[\w\/\.-]*)?(\?[^\s]+)?$")
+        full_url_regex = re.compile(
+            r"(https?)://((?:\[[0-9a-fA-F:]+\]|\w(?:[\w-]+\.?)+)(?::\d{1,5})?(?:/[-\w\.\(\)]*[-\w\.]+)*/?)"
+        )
+        full_url_regex_strict = re.compile(
+            r"^(https?):\/\/(\[[0-9a-fA-F:]+\]|[\w.-]+)(?::\d{1,5})?(\/[\w\/\.-]*)?(\?[^\s]+)?$"
+        )
         tag_attribute_regex = bbot_regexes.tag_attribute_regex
 
         async def process(self, yara_results, event, yara_rule_settings, discovery_context):

--- a/bbot/test/test_step_1/test_excavate_url_regexes.py
+++ b/bbot/test/test_step_1/test_excavate_url_regexes.py
@@ -51,27 +51,19 @@ def test_full_url_regex_still_matches_existing_patterns():
 
 def test_full_url_regex_strict_matches_ipv6():
     for url in IPV6_URLS:
-        assert full_url_regex_strict.match(url) is not None, (
-            f"full_url_regex_strict should match IPv6 URL {url!r}"
-        )
+        assert full_url_regex_strict.match(url) is not None, f"full_url_regex_strict should match IPv6 URL {url!r}"
 
 
 def test_full_url_regex_strict_still_matches_existing_patterns():
     for url in NON_IPV6_URLS:
-        assert full_url_regex_strict.match(url) is not None, (
-            f"regression: full_url_regex_strict broke for {url!r}"
-        )
+        assert full_url_regex_strict.match(url) is not None, f"regression: full_url_regex_strict broke for {url!r}"
 
 
 def test_yara_url_rule_matches_ipv6():
     for url in IPV6_URLS:
-        assert yara_url_rule.match(data=url.encode()), (
-            f"YARA url_full rule should match IPv6 URL {url!r}"
-        )
+        assert yara_url_rule.match(data=url.encode()), f"YARA url_full rule should match IPv6 URL {url!r}"
 
 
 def test_yara_url_rule_still_matches_existing_patterns():
     for url in NON_IPV6_URLS:
-        assert yara_url_rule.match(data=url.encode()), (
-            f"regression: YARA url_full rule broke for {url!r}"
-        )
+        assert yara_url_rule.match(data=url.encode()), f"regression: YARA url_full rule broke for {url!r}"

--- a/bbot/test/test_step_1/test_excavate_url_regexes.py
+++ b/bbot/test/test_step_1/test_excavate_url_regexes.py
@@ -1,0 +1,77 @@
+"""Unit tests for the URL regexes used by the excavate URLExtractor.
+
+These tests pin behaviour of the IPv6 host parsing in the YARA rule and the
+two Python regex post-filters (``full_url_regex`` / ``full_url_regex_strict``).
+
+They cover the regression in issue #1815: the original patterns rejected
+``http://[2001:db8::1]/`` and other IPv6 URLs because the host alternative
+only matched word characters and dots.
+"""
+
+import yara
+
+from bbot.modules.internal.excavate import excavate
+
+
+full_url_regex = excavate.URLExtractor.full_url_regex
+full_url_regex_strict = excavate.URLExtractor.full_url_regex_strict
+yara_url_rule = yara.compile(source=excavate.URLExtractor.yara_rules["url_full"])
+
+
+IPV6_URLS = [
+    "http://[2001:db8::1]/api",
+    "https://[2001:db8::1]:8443/api",
+    "http://[::1]/",
+    "http://[::1]:8080/path",
+    "https://[fe80::dead:beef]/foo/bar.html",
+    "http://[fe80::1234:5678:9abc:def0]:80/",
+]
+
+NON_IPV6_URLS = [
+    "http://example.com/",
+    "https://www.example.com:8080/path",
+    "http://127.0.0.1:8888/",
+    "https://asdffoo.test.notreal/some/path",
+]
+
+
+def test_full_url_regex_matches_ipv6():
+    for url in IPV6_URLS:
+        m = full_url_regex.search(url)
+        assert m is not None, f"full_url_regex should match IPv6 URL {url!r}"
+        # The captured host should retain the surrounding brackets so the
+        # downstream URL parser recognises it as IPv6.
+        assert m.group(2).startswith("["), f"host capture missing leading [ for {url!r}: {m.group(2)!r}"
+
+
+def test_full_url_regex_still_matches_existing_patterns():
+    for url in NON_IPV6_URLS:
+        assert full_url_regex.search(url) is not None, f"regression: full_url_regex broke for {url!r}"
+
+
+def test_full_url_regex_strict_matches_ipv6():
+    for url in IPV6_URLS:
+        assert full_url_regex_strict.match(url) is not None, (
+            f"full_url_regex_strict should match IPv6 URL {url!r}"
+        )
+
+
+def test_full_url_regex_strict_still_matches_existing_patterns():
+    for url in NON_IPV6_URLS:
+        assert full_url_regex_strict.match(url) is not None, (
+            f"regression: full_url_regex_strict broke for {url!r}"
+        )
+
+
+def test_yara_url_rule_matches_ipv6():
+    for url in IPV6_URLS:
+        assert yara_url_rule.match(data=url.encode()), (
+            f"YARA url_full rule should match IPv6 URL {url!r}"
+        )
+
+
+def test_yara_url_rule_still_matches_existing_patterns():
+    for url in NON_IPV6_URLS:
+        assert yara_url_rule.match(data=url.encode()), (
+            f"regression: YARA url_full rule broke for {url!r}"
+        )


### PR DESCRIPTION
## Summary

Closes #1815 (\"Excavate IPv6 URLs\", filed by @TheTechromancer).

The `url_full` YARA rule and the two Python post-filters (`full_url_regex` / `full_url_regex_strict`) all only accepted word-character / dotted hostnames in the host slot, so URLs with bracketed IPv6 hosts were dropped at extraction time:

- `http://[2001:db8::1]/api`
- `http://[::1]:8080/path`
- `https://[fe80::dead:beef]/foo/bar.html`

This PR adds a `\\[[0-9a-fA-F:]+\\]` alternative to the host part of all three patterns. The bracketed form is preserved in the captured host so downstream parsers (urllib, etc.) still recognise the URL as IPv6.

## Tests

`bbot/test/test_step_1/test_excavate_url_regexes.py` — 6 cases:

- `test_full_url_regex_matches_ipv6` — accepts 6 representative IPv6 URLs and verifies the captured host keeps the leading `[`.
- `test_full_url_regex_still_matches_existing_patterns` — regression guard for plain DNS-name + IPv4 URLs.
- Two corresponding pairs for `full_url_regex_strict`.
- Two corresponding pairs for the YARA `url_full` rule (compiled directly from `excavate.URLExtractor.yara_rules['url_full']`).

```
$ pytest bbot/test/test_step_1/test_excavate_url_regexes.py -v
test_full_url_regex_matches_ipv6                              PASSED
test_full_url_regex_still_matches_existing_patterns           PASSED
test_full_url_regex_strict_matches_ipv6                       PASSED
test_full_url_regex_strict_still_matches_existing_patterns    PASSED
test_yara_url_rule_matches_ipv6                               PASSED
test_yara_url_rule_still_matches_existing_patterns            PASSED
```

## Notes

- No behavioural change for existing DNS-name / IPv4 URLs: the original alternation is preserved as the second branch of the alternation.
- The new patterns accept IPv6-shaped tokens regardless of whether they are valid addresses; downstream URL validation still runs (`validators.validate_url_parsed`) before the URL becomes a URL_UNVERIFIED event, so malformed inputs still get rejected one stage later.