### PR TITLE
Add Linktree to social module (#2399)

### DIFF
--- a/bbot/modules/social.py
+++ b/bbot/modules/social.py
@@ -26,6 +26,8 @@ class social(BaseModule):
         "docker": (r"hub.docker.com/[ru]/([a-zA-Z0-9_-]+)", False),
         "huggingface": (r"huggingface.co/([a-zA-Z0-9_-]+)", False),
         "postman": (r"www.postman.com/([a-zA-Z0-9_-]+)", False),
+        # Linktree usernames are 3–30 chars of [a-z0-9._] (case-insensitive in URLs).
+        "linktree": (r"linktr\.ee/([a-zA-Z0-9._]{3,30})", False),
     }
 
     scope_distance_modifier = 1

--- a/bbot/test/test_step_2/module_tests/test_module_social.py
+++ b/bbot/test/test_step_2/module_tests/test_module_social.py
@@ -15,13 +15,14 @@ class TestSocial(ModuleTestBase):
                 <a href="https://hub.docker.com/r/blacklanternsecurity/bbot"/>
                 <a href="https://hub.docker.com/r/blacklanternSECURITY/bbot"/>
                 <a href="https://www.postman.com/blacklanternsecurity/bbot"/>
+                <a href="https://linktr.ee/blacklanternsecurity"/>
             </html>
             """
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     def check(self, module_test, events):
-        assert 4 == len([e for e in events if e.type == "SOCIAL"])
+        assert 5 == len([e for e in events if e.type == "SOCIAL"])
         assert 1 == len(
             [
                 e
@@ -54,5 +55,15 @@ class TestSocial(ModuleTestBase):
                 if e.type == "SOCIAL"
                 and e.data["platform"] == "postman"
                 and e.data["profile_name"] == "blacklanternsecurity"
+            ]
+        )
+        assert 1 == len(
+            [
+                e
+                for e in events
+                if e.type == "SOCIAL"
+                and e.data["platform"] == "linktree"
+                and e.data["profile_name"] == "blacklanternsecurity"
+                and e.data["url"] == "https://linktr.ee/blacklanternsecurity"
             ]
         )


### PR DESCRIPTION
## Summary

Closes #2399 (\"Add Social: Linktree\", filed by @TheTechromancer).

Adds a Linktree entry to `bbot/modules/social.py`'s `social_media_platforms` table so the `social` module emits a `SOCIAL` event for `linktr.ee/<username>` URLs alongside the existing platforms.

```python
\"linktree\": (r\"linktr\\.ee/([a-zA-Z0-9._]{3,30})\", False),
```

The pattern follows Linktree's own username constraints (3–30 chars of letters/digits/`_`/`.`).

## Test

`test_module_social.TestSocial`:

- adds `<a href=\"https://linktr.ee/blacklanternsecurity\"/>` to the response fixture,
- bumps the SOCIAL event count from 4 → 5,
- asserts platform/profile/url for the new Linktree event.

```
$ pytest bbot/test/test_step_2/module_tests/test_module_social.py -v
TestSocial::test_module_run PASSED
1 passed in 10.45s
```