### PR TITLE
feat: avoid scanning cloudflare hosts

### DIFF
--- a/bbot/modules/portscan.py
+++ b/bbot/modules/portscan.py
@@ -92,6 +92,15 @@ class portscan(BaseModule):
             self.ipv6_support = False
         return True
 
+    async def filter_event(self, event):
+        if event.tags and any('cloudflare' in t for t in event.tags):
+            self.info(f"Skipping portscan due to Cloudflare asset {event} with tags {event.tags} and resolved hosts {event.resolved_hosts}")
+            host = event.resolved_hosts[0] if event.resolved_hosts else event.host
+            self.emit_open_port(host, 80, event) # emit HTTP
+            self.emit_open_port(host, 443, event) # emit HTTPS
+            return False, f"Skipping portscan due to Cloudflare asset: {event}"
+        return True
+
     async def handle_batch(self, *events):
         # ping scan
         if self.ping_scan:


### PR DESCRIPTION
Hosts proxied by cloudflare are typically websites, where ports of interest are 80 and 443. Other ports such as 8080, 8880, 2052, 2053, etc. are ports exposed by [cloudflare](https://developers.cloudflare.com/fundamentals/reference/network-ports/) which are generally uninteresting and host the same content, and thus could be considered FP.

Moreover, port scanning may alert cloudflare or defenders of attacker activity, which may reduce the effectiveness of subsequent scanning.

This PR adds a `filter_event` function to the portscan module which catches incoming hosts tagged with cloudflare and speculates port 80 and 443.