### PR TITLE
fix: guard against chaotic chaos responses

### DIFF
--- a/bbot/modules/chaos.py
+++ b/bbot/modules/chaos.py
@@ -34,6 +34,10 @@ class chaos(subdomain_enum_apikey):
             domain = j.get("domain", "")
             if domain:
                 subdomains = j.get("subdomains", [])
+                if len(subdomains) > 10000:
+                    # In extremely rare cases, Chaos API returns a gigaton of subdomains.
+                    # If that happens, we simply treat the domain as a wildcard.
+                    subdomains = ["*"]
                 for s in subdomains:
                     s = s.lower().strip(".*")
                     subdomains_set.add(s)


### PR DESCRIPTION
In extremely rare cases, Chaos API returns a gigaton of subdomains. If that happens, we simply treat the domain as a wildcard. I've hardcoded the limit to 10,000 subdomains, which I think is a bit generous, but oh well.

resolves #2879