### PR TITLE
Fix gowitness post-scan hint to use 'report server' subcommand

### DIFF
--- a/bbot/modules/gowitness.py
+++ b/bbot/modules/gowitness.py
@@ -347,7 +347,7 @@ class gowitness(BaseModule):
         if self.screenshots_taken:
             self.success(f"{len(self.screenshots_taken):,} web screenshots captured. To view:")
             self.success("    - Start gowitness")
-            self.success(f"        - cd {self.base_path} && ./gowitness server")
+            self.success(f"        - cd {self.base_path} && ./gowitness report server")
             self.success("    - Browse to http://localhost:7171")
         else:
             self.info("No web screenshots captured")


### PR DESCRIPTION
Fixes #3092. gowitness v3.x moved `server` under `report`, so the post-scan hint should print `./gowitness report server`.