### PR TITLE
Remove parrot MIT-mirror override

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -23,14 +23,6 @@ jobs:
             . /etc/os-release
             if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ] || [ "$ID" = "kali" ] || [ "$ID" = "parrotsec" ]; then
               export DEBIAN_FRONTEND=noninteractive
-              # Pin Parrot to MIT mirror to avoid stale third-party mirrors (e.g. mirror.clarkson.edu)
-              # Note: parrotsec/security image reports ID=debian, so we detect via parrot.list
-              if [ -f /etc/apt/sources.list.d/parrot.list ]; then
-                rm -f /etc/apt/sources.list /etc/apt/sources.list.old /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources
-                echo "deb https://mirrors.mit.edu/parrot/ echo main contrib non-free non-free-firmware" > /etc/apt/sources.list.d/parrot.list
-                echo "deb https://mirrors.mit.edu/parrot/ echo-security main contrib non-free non-free-firmware" >> /etc/apt/sources.list.d/parrot.list
-                echo "deb https://mirrors.mit.edu/parrot/ echo-backports main contrib non-free non-free-firmware" >> /etc/apt/sources.list.d/parrot.list
-              fi
               apt-get update
               apt-get -y install curl git bash build-essential docker.io libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev
             elif [ "$ID" = "alpine" ]; then


### PR DESCRIPTION
MIT's parrot mirror now serves the apt metadata but 404s every `.deb` in the pool, breaking the parrotsec job at install time. Drop the override and let the container's own `parrot.list` handle sourcing.