### PR TITLE
Don't echo encrypted sudo password in askpass error

### DIFF
--- a/bbot/core/helpers/depsinstaller/sudo_askpass.py
+++ b/bbot/core/helpers/depsinstaller/sudo_askpass.py
@@ -33,7 +33,7 @@ def main():
         decrypted_password = decrypt_password(encrypted_password, key)
         print(decrypted_password, end="")
     except Exception as e:
-        print(f'Error decrypting password "{encrypted_password}": {str(e)}', file=sys.stderr)
+        print(f"Error decrypting sudo password: {str(e)}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
Drops the ciphertext blob from the askpass decryption-failure message. Defense-in-depth; the encrypted blob has no diagnostic value on its own and shouldn't be in logs. Supersedes #3029 (unsigned CLA).