### PR TITLE
Fix brittle retirejs test

### DIFF
--- a/bbot/test/test_step_2/module_tests/test_module_retirejs.py
+++ b/bbot/test/test_step_2/module_tests/test_module_retirejs.py
@@ -116,13 +116,14 @@ return Handlebars;
         descriptions = [finding.data.get("description", "") for finding in retirejs_findings]
         all_descriptions = "\n".join(descriptions)
 
-        # Look for specific vulnerabilities we expect to find
-        expected_handlebars_vuln = "Vulnerable JavaScript library detected: handlebars v4.0.5 Severity: HIGH Summary: Regular Expression Denial of Service in Handlebars JavaScript URL: http://127.0.0.1:8888/handlebars.min.js CVE(s): CVE-2019-20922 Affected versions: [4.0.0 to 4.4.5)"
-        expected_jquery_vuln = "Vulnerable JavaScript library detected: jquery v3.4.1 Severity: MEDIUM Summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS JavaScript URL: http://127.0.0.1:8888/jquery-3.4.1.min.js CVE(s): CVE-2020-11022 Affected versions: [1.2.0 to 3.5.0)"
+        # Match on stable identifiers — upstream RetireJS revises summary and
+        # affected-version strings over time.
+        def has_vuln(library, version, cve, js_url):
+            needle = f"library detected: {library} v{version}"
+            return any(needle in d and cve in d and js_url in d for d in descriptions)
 
-        # Verify at least one of the expected vulnerabilities is found
-        handlebars_found = expected_handlebars_vuln in all_descriptions
-        jquery_found = expected_jquery_vuln in all_descriptions
+        handlebars_found = has_vuln("handlebars", "4.0.5", "CVE-2019-20922", "http://127.0.0.1:8888/handlebars.min.js")
+        jquery_found = has_vuln("jquery", "3.4.1", "CVE-2020-11022", "http://127.0.0.1:8888/jquery-3.4.1.min.js")
 
         assert handlebars_found and jquery_found, (
             f"Expected to find specific vulnerabilities but didn't find them. Found descriptions:\n{all_descriptions}"


### PR DESCRIPTION
## Summary

`test_module_retirejs::TestRetireJS::test_module_run` matched the full vulnerability description string verbatim, including upstream-volatile fields like `Severity:`, `Summary:`, and `Affected versions:`. Recently, the [RetireJS advisory database](https://github.com/RetireJS/retire.js/blob/master/repository/jsrepository-v4.json) tightened CVE-2020-11022's affected jQuery range from `[1.2.0 to 3.5.0)` to `[1.12.0 to 3.5.0)`, breaking the test on every CI run across all distros and Python versions ([example failure](https://github.com/blacklanternsecurity/bbot/actions/runs/26039796397/job/76548055059)).

Match on stable identifiers instead — library name, version, CVE id, and JS URL — so future upstream wording/severity/range changes don't break us.

Verified locally: both retirejs tests pass.