### PR TITLE
fix(anubisdb): update base URL from jldc.me to anubisdb.com

### DIFF
--- a/bbot/modules/anubisdb.py
+++ b/bbot/modules/anubisdb.py
@@ -6,7 +6,7 @@ class anubisdb(subdomain_enum):
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
     meta = {
-        "description": "Query jldc.me's database for subdomains",
+        "description": "Query AnubisDB for subdomains",
         "created_date": "2022-10-04",
         "author": "@TheTechromancer",
     }
@@ -15,7 +15,7 @@ class anubisdb(subdomain_enum):
         "limit": "Limit the number of subdomains returned per query (increasing this may slow the scan due to garbage results from this API)"
     }
 
-    base_url = "https://jldc.me/anubis/subdomains"
+    base_url = "https://anubisdb.com/anubis/subdomains"
     dns_abort_depth = 5
 
     async def request_url(self, query):


### PR DESCRIPTION
## Summary
- Updates `base_url` from `https://jldc.me/anubis/subdomains` to `https://anubisdb.com/anubis/subdomains` — the service migrated to this domain
- Updates the module description to drop the stale `jldc.me` reference
