### PR TITLE
preset-validation: fix crashes, wire validator into YAML load, validate interactsh_server

### DIFF
--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -51,9 +51,9 @@ async def _main():
         try:
             preset.parse_args()
         except BBOTArgumentError as e:
-            log_to_stderr(str(e), level="WARNING")
+            log_to_stderr(str(e), level="ERROR")
             log.trace(traceback.format_exc())
-            return
+            return False
         # ensure arguments (-c config options etc.) are valid
         options = preset.args.parsed
         # apply CLI log level options (e.g. --debug/--verbose/--silent) to the
@@ -322,6 +322,7 @@ async def _main():
     except BBOTError as e:
         log.error(str(e))
         log.trace(traceback.format_exc())
+        return False
 
     finally:
         # save word cloud
@@ -339,7 +340,9 @@ def main():
 
     global scan_name
     try:
-        asyncio.run(_main())
+        result = asyncio.run(_main())
+        if result is False:
+            sys.exit(1)
     except asyncio.CancelledError:
         if CORE.logger.log_level <= logging.DEBUG:
             log_to_stderr(traceback.format_exc(), level="DEBUG")

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -51,9 +51,9 @@ async def _main():
         try:
             preset.parse_args()
         except BBOTArgumentError as e:
-            log_to_stderr(str(e), level="ERROR")
+            log_to_stderr(str(e), level="WARNING")
             log.trace(traceback.format_exc())
-            return False
+            return
         # ensure arguments (-c config options etc.) are valid
         options = preset.args.parsed
         # apply CLI log level options (e.g. --debug/--verbose/--silent) to the
@@ -322,7 +322,6 @@ async def _main():
     except BBOTError as e:
         log.error(str(e))
         log.trace(traceback.format_exc())
-        return False
 
     finally:
         # save word cloud
@@ -340,9 +339,7 @@ def main():
 
     global scan_name
     try:
-        result = asyncio.run(_main())
-        if result is False:
-            sys.exit(1)
+        asyncio.run(_main())
     except asyncio.CancelledError:
         if CORE.logger.log_level <= logging.DEBUG:
             log_to_stderr(traceback.format_exc(), level="DEBUG")

--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -15,13 +15,34 @@ from __future__ import annotations
 
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from pydantic import Field as _PydanticField
 from pydantic_core import PydanticUndefined
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 STRICT = ConfigDict(extra="forbid")
+
+
+def _validate_fqdn_or_ip(v: Optional[str]) -> Optional[str]:
+    """Accept None, empty, an IP address, or a hostname with at least one dot.
+
+    Single-label names like `localhost` (or a domain typed without its TLD)
+    are rejected so typos in domain-shaped config fields fail at preset-load
+    time rather than surfacing as runtime "Failed to register" errors deep
+    in a scan.
+    """
+    if v is None or v == "":
+        return v
+    # Lazy import to avoid a cycle at module load time. is_ip handles v4/v6;
+    # is_dns_name + a required dot is BBOT's everyday-FQDN check.
+    from bbot.core.helpers.misc import is_dns_name, is_ip
+
+    if is_ip(v):
+        return v
+    if "." in v and is_dns_name(v):
+        return v
+    raise ValueError(f"not a valid FQDN or IP address: {v!r}")
 
 
 def Field(default=PydanticUndefined, *, sensitive: bool = False, mandatory: bool = False, **kwargs):
@@ -315,6 +336,8 @@ class BBOTConfig(BaseSettings):
     interactsh_server: Optional[str] = None
     interactsh_token: Optional[str] = Field(default=None, sensitive=True)
     interactsh_disable: Optional[bool] = None
+
+    _validate_interactsh_server = field_validator("interactsh_server")(_validate_fqdn_or_ip)
 
     # Per-module configs — validated separately, per-module, against each
     # module's own `class Config(BaseModuleConfig)`.

--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -20,29 +20,10 @@ from pydantic import Field as _PydanticField
 from pydantic_core import PydanticUndefined
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from bbot.core.helpers.validators import validate_fqdn_or_ip
+
 
 STRICT = ConfigDict(extra="forbid")
-
-
-def _validate_fqdn_or_ip(v: Optional[str]) -> Optional[str]:
-    """Accept None, empty, an IP address, or a hostname with at least one dot.
-
-    Single-label names like `localhost` (or a domain typed without its TLD)
-    are rejected so typos in domain-shaped config fields fail at preset-load
-    time rather than surfacing as runtime "Failed to register" errors deep
-    in a scan.
-    """
-    if v is None or v == "":
-        return v
-    # Lazy import to avoid a cycle at module load time. is_ip handles v4/v6;
-    # is_dns_name + a required dot is BBOT's everyday-FQDN check.
-    from bbot.core.helpers.misc import is_dns_name, is_ip
-
-    if is_ip(v):
-        return v
-    if "." in v and is_dns_name(v):
-        return v
-    raise ValueError(f"not a valid FQDN or IP address: {v!r}")
 
 
 def Field(default=PydanticUndefined, *, sensitive: bool = False, mandatory: bool = False, **kwargs):
@@ -337,7 +318,7 @@ class BBOTConfig(BaseSettings):
     interactsh_token: Optional[str] = Field(default=None, sensitive=True)
     interactsh_disable: Optional[bool] = None
 
-    _validate_interactsh_server = field_validator("interactsh_server")(_validate_fqdn_or_ip)
+    _validate_interactsh_server = field_validator("interactsh_server")(validate_fqdn_or_ip)
 
     # Per-module configs — validated separately, per-module, against each
     # module's own `class Config(BaseModuleConfig)`.

--- a/bbot/core/helpers/validators.py
+++ b/bbot/core/helpers/validators.py
@@ -7,7 +7,7 @@ from contextlib import suppress
 from bbot.core.helpers import regexes
 from bbot.errors import ValidationError
 from bbot.core.helpers.url import parse_url, hash_url
-from bbot.core.helpers.misc import smart_encode_punycode, split_host_port, make_netloc, is_ip
+from bbot.core.helpers.misc import smart_encode_punycode, split_host_port, make_netloc, is_dns_name, is_ip
 
 log = logging.getLogger("bbot.core.helpers.validators")
 
@@ -127,6 +127,38 @@ def validate_host(host: Union[str, ipaddress.IPv4Address, ipaddress.IPv6Address]
                 if r.match(host):
                     return host
     raise ValidationError(f'Invalid hostname: "{host}"')
+
+
+def validate_fqdn_or_ip(host):
+    """Strict FQDN-or-IP check. Accepts an IPv4/IPv6 address or a hostname
+    containing at least one dot. Rejects single-label values (e.g.
+    `localhost`, or a domain typed without its TLD), so domain-shaped
+    config fields fail at preset-load time instead of surfacing as runtime
+    errors deep in a scan.
+
+    `None` and the empty string pass through to support optional config
+    fields with `null` defaults.
+
+    Unlike `validate_host`, this function does not normalize the input
+    (no port-stripping, lowercasing, or punycode conversion); it returns
+    the value as supplied. Use it as a pydantic `field_validator` on
+    schema fields that must be an FQDN or IP and nothing else.
+
+    Examples:
+        >>> validate_fqdn_or_ip("example.com")
+        'example.com'
+        >>> validate_fqdn_or_ip("192.168.1.1")
+        '192.168.1.1'
+        >>> validate_fqdn_or_ip("localhost")
+        ValueError: not a valid FQDN or IP address: 'localhost'
+    """
+    if host is None or host == "":
+        return host
+    if is_ip(host):
+        return host
+    if isinstance(host, str) and "." in host and is_dns_name(host):
+        return host
+    raise ValueError(f"not a valid FQDN or IP address: {host!r}")
 
 
 FINDING_SEVERITY_LEVELS = ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL")

--- a/bbot/modules/webbrute.py
+++ b/bbot/modules/webbrute.py
@@ -1,5 +1,6 @@
 import random
 import string
+from typing import Union
 
 import blasthttp
 
@@ -25,8 +26,9 @@ class webbrute(BaseModule):
         )
         lines: int = Field(5000, description="take only the first N lines from the wordlist when finding directories")
         max_depth: int = Field(0, description="the maximum directory depth to attempt to solve")
-        extensions: str = Field(
-            "", description="Optionally include a list of extensions to extend the keyword with (comma separated)"
+        extensions: Union[str, list[str]] = Field(
+            "",
+            description="Optionally include a list of extensions to extend the keyword with (comma separated or YAML list)",
         )
         ignore_case: bool = Field(False, description="Only put lowercase words into the wordlist")
         rate: int = Field(0, description="Maximum requests per second (0 = unlimited)")

--- a/bbot/scanner/preset/environ.py
+++ b/bbot/scanner/preset/environ.py
@@ -69,13 +69,16 @@ class BBOTEnviron:
             {"modules": {"http": {"threads": 10}}} --> ("BBOT_MODULES_HTTP_THREADS", "10")
 
         Lists are skipped (they don't translate cleanly to env var values).
+        None values are skipped too, since `str(None)` would write the literal
+        string "None" into the env and round-trip back through pydantic-settings
+        as a string, defeating any field validator that expects a real value.
         """
         if isinstance(config, dict):
             for k, v in config.items():
                 new_base = f"{base}_{k}"
                 if isinstance(v, dict):
                     yield from self.flatten_config(v, base=new_base)
-                elif not isinstance(v, list):
+                elif v is not None and not isinstance(v, list):
                     yield (new_base.upper(), str(v))
 
     def prepare(self):

--- a/bbot/scanner/preset/preset.py
+++ b/bbot/scanner/preset/preset.py
@@ -660,6 +660,14 @@ class Preset(metaclass=BasePreset):
             >>> preset = Preset.from_dict({"target": ["evilcorp.com"], "modules": ["portscan"]})
         """
         from bbot.core.helpers.misc import chain_lists
+        from .validate import validate_preset
+
+        # Surface preset typos / shape errors up front rather than letting
+        # them propagate to bake() as raw TypeErrors / AttributeErrors. This
+        # covers presets loaded from YAML files, YAML strings, and dicts.
+        errs = validate_preset(preset_dict)
+        if errs:
+            raise ValidationError("\n".join(str(e) for e in errs))
 
         # Handle seeds and targets from dict
         # for user-friendliness, we allow both "target" and "targets" to be used. we merge them into a single list.

--- a/bbot/scanner/preset/validate.py
+++ b/bbot/scanner/preset/validate.py
@@ -141,6 +141,17 @@ def _format_msg(err: dict, known_modules: set | None = None, known_paths: set | 
         return f"Expected one of {expected}, got {input_value!r}" if expected else err.get("msg", "")
     if kind == "missing":
         return f"Required option {field!r} is missing"
+    if kind == "value_error":
+        # Pydantic wraps ValueError raised inside a field_validator and prefixes
+        # the message with "Value error, ". Surface the original ValueError text
+        # so the error reads naturally.
+        ctx = err.get("ctx") or {}
+        inner = ctx.get("error")
+        if inner is not None:
+            return str(inner)
+        msg = err.get("msg", "")
+        prefix = "Value error, "
+        return msg[len(prefix) :] if msg.startswith(prefix) else msg
 
     # Fallback to pydantic's own message
     return err["msg"] if err.get("msg") else f"validation error at {path}"

--- a/bbot/scanner/preset/validate.py
+++ b/bbot/scanner/preset/validate.py
@@ -26,7 +26,23 @@ from typing import Any
 
 from pydantic import ValidationError
 
+from bbot.core.config.models import PresetSchema
 from bbot.core.helpers.misc import get_closest_match, get_keys_in_dot_syntax
+
+
+def _preset_top_level_keys() -> set[str]:
+    """Field names and aliases declared on PresetSchema, used for closest-match
+    suggestions on unknown top-level preset keys (e.g. `modlues` -> `modules`)."""
+    keys: set[str] = set()
+    for name, field in PresetSchema.model_fields.items():
+        keys.add(name)
+        alias = getattr(field, "alias", None)
+        if alias:
+            keys.add(alias)
+    return keys
+
+
+_PRESET_KEYS = _preset_top_level_keys()
 
 
 log = logging.getLogger("bbot.presets.validate")
@@ -59,6 +75,10 @@ def _classify_loc(loc: tuple) -> tuple[str, str]:
 
     if len(parts) >= 2 and parts[0] == "config" and parts[1] == "modules":
         # Error is somewhere under config.modules.*
+        if len(parts) == 2:
+            # The `modules` mapping itself has the wrong shape (e.g. a list).
+            # Classify as a config-level error rather than walking deeper.
+            return ("config", "modules")
         if len(parts) == 3:
             # The module name itself is unknown (extra_forbidden on ModulesSchema)
             return ("preset", ".".join(parts))
@@ -84,6 +104,11 @@ def _format_msg(err: dict, known_modules: set | None = None, known_paths: set | 
         # a suggestion drawn from the set of known module names.
         if len(loc) == 3 and loc[0] == "config" and loc[1] == "modules":
             return get_closest_match(field, known_modules or set(), msg="module")
+        # Top-level preset key (e.g. `modlues:`) — suggest from PresetSchema
+        # field names rather than the dotted config-path universe, so users
+        # get useful hints like "Did you mean 'modules'?".
+        if len(loc) == 1:
+            return get_closest_match(field, _PRESET_KEYS, msg="preset option")
         # For everything else, suggest from the known dotted-path universe
         # (`web.spier_distance` → `web.spider_distance`).
         if known_paths:
@@ -173,7 +198,12 @@ def validate_preset(preset_dict: Any, module_loader=None) -> list[PresetValidati
         preset_dict.get("module_dirs"),
         config_dict.get("module_dirs") if isinstance(config_dict, dict) else None,
     ):
-        for d in source or []:
+        # Skip non-list shapes (e.g. a string) so we don't iterate characters
+        # and trigger filesystem calls. The schema pass below reports the
+        # actual type error.
+        if not isinstance(source, list):
+            continue
+        for d in source:
             if isinstance(d, str):
                 module_loader.add_module_dir(d)
 
@@ -194,8 +224,13 @@ def validate_preset(preset_dict: Any, module_loader=None) -> list[PresetValidati
     # Module names listed in top-level `modules`/`output_modules`/`exclude_modules`
     # aren't covered by the composite schema (they're a list of strings, not a
     # nested mapping). Check them explicitly, with the same closest-match hint.
+    # Skip non-list values; the schema pass above already flagged the type error,
+    # and iterating a string here would yield bogus per-character lookups.
     for key in ("modules", "output_modules", "exclude_modules"):
-        for name in preset_dict.get(key) or []:
+        value = preset_dict.get(key)
+        if not isinstance(value, list):
+            continue
+        for name in value:
             if name not in known_modules:
                 hint = get_closest_match(name, known_modules, msg="module")
                 errors.append(PresetValidationError(where="preset", path=key, message=hint))
@@ -204,11 +239,23 @@ def validate_preset(preset_dict: Any, module_loader=None) -> list[PresetValidati
 
 
 def validate_preset_file(path: str | Path, **kwargs) -> list[PresetValidationError]:
-    """Convenience wrapper for validating a YAML preset file on disk."""
+    """Convenience wrapper for validating a YAML preset file on disk.
+
+    Returns a list of errors. A missing file or unreadable YAML is reported
+    as a single error rather than raised, so callers can treat all failure
+    modes uniformly.
+    """
     import yaml
 
-    with open(path) as f:
-        data = yaml.safe_load(f) or {}
+    try:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return [PresetValidationError("preset", "", f"Preset file not found: {path}")]
+    except OSError as e:
+        return [PresetValidationError("preset", "", f"Could not read preset file {path}: {e}")]
+    except yaml.YAMLError as e:
+        return [PresetValidationError("preset", "", f"Invalid YAML in {path}: {e}")]
     if not isinstance(data, dict):
         return [PresetValidationError("preset", "", f"Expected a YAML mapping, got {type(data).__name__}")]
     return validate_preset(data, **kwargs)

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -75,7 +75,7 @@ async def test_preset_yaml(clean_default_config):
         verbose=False,
         debug=False,
         silent=True,
-        config={"preset_test_asdf": 1},
+        config={"keep_scans": 42},
     )
     preset1 = preset1.bake()
     assert "evilcorp.com" in preset1.target.seeds
@@ -785,16 +785,14 @@ class TestModule5(BaseModule):
 """
         )
 
-    preset = Preset.from_yaml_string(
-        """
+    # should fail at preset-load time now that validation runs in from_dict
+    with pytest.raises(ValidationError):
+        Preset.from_yaml_string(
+            """
 modules:
   - testmodule5
 """
-    )
-    # should fail
-    with pytest.raises(ValidationError):
-        scan = Scanner(preset=preset)
-        await scan._prep()
+        )
 
     preset = Preset.from_yaml_string(
         f"""
@@ -823,6 +821,8 @@ def test_preset_include():
     mkdir(custom_preset_dir_4)
     mkdir(custom_preset_dir_5)
 
+    # Real modules so the (now-strict) validator accepts them. We use the
+    # universal `module_timeout` field as an opaque marker per preset.
     preset_file = custom_preset_dir_1 / "preset1.yml"
     with open(preset_file, "w") as f:
         f.write(
@@ -832,8 +832,8 @@ include:
 
 config:
   modules:
-    testpreset1:
-      test: asdf
+    nuclei:
+      module_timeout: 1
 """
         )
 
@@ -846,8 +846,8 @@ include:
 
 config:
   modules:
-    testpreset2:
-      test: fdsa
+    sslcert:
+      module_timeout: 2
 """
         )
 
@@ -862,8 +862,8 @@ include:
 
 config:
   modules:
-    testpreset3:
-      test: qwerty
+    gowitness:
+      module_timeout: 3
 """
         )
 
@@ -876,8 +876,8 @@ include:
 
 config:
   modules:
-    testpreset4:
-      test: zxcv
+    robots:
+      module_timeout: 4
 """
         )
 
@@ -887,26 +887,26 @@ config:
             """
 config:
   modules:
-    testpreset5:
-      test: hjkl
+    wayback:
+      module_timeout: 5
 """
         )
 
     # with include=
     preset = Preset(include=[str(custom_preset_dir_1 / "preset1")])
-    assert preset.config["modules"]["testpreset1"]["test"] == "asdf"
-    assert preset.config["modules"]["testpreset2"]["test"] == "fdsa"
-    assert preset.config["modules"]["testpreset3"]["test"] == "qwerty"
-    assert preset.config["modules"]["testpreset4"]["test"] == "zxcv"
-    assert preset.config["modules"]["testpreset5"]["test"] == "hjkl"
+    assert preset.config["modules"]["nuclei"]["module_timeout"] == 1
+    assert preset.config["modules"]["sslcert"]["module_timeout"] == 2
+    assert preset.config["modules"]["gowitness"]["module_timeout"] == 3
+    assert preset.config["modules"]["robots"]["module_timeout"] == 4
+    assert preset.config["modules"]["wayback"]["module_timeout"] == 5
 
     # same thing but with presets= (an alias to include)
     preset = Preset(presets=[str(custom_preset_dir_1 / "preset1")])
-    assert preset.config["modules"]["testpreset1"]["test"] == "asdf"
-    assert preset.config["modules"]["testpreset2"]["test"] == "fdsa"
-    assert preset.config["modules"]["testpreset3"]["test"] == "qwerty"
-    assert preset.config["modules"]["testpreset4"]["test"] == "zxcv"
-    assert preset.config["modules"]["testpreset5"]["test"] == "hjkl"
+    assert preset.config["modules"]["nuclei"]["module_timeout"] == 1
+    assert preset.config["modules"]["sslcert"]["module_timeout"] == 2
+    assert preset.config["modules"]["gowitness"]["module_timeout"] == 3
+    assert preset.config["modules"]["robots"]["module_timeout"] == 4
+    assert preset.config["modules"]["wayback"]["module_timeout"] == 5
 
     # can't use both include= and presets= at the same time
     with pytest.raises(ValueError):
@@ -993,8 +993,8 @@ modules:
   - robots
 config:
   modules:
-    asdf:
-      option1: asdf
+    robots:
+      module_timeout: 10
 """
     preset_2_yaml = """
 name: override2
@@ -1005,8 +1005,8 @@ modules:
   - c99
 config:
   modules:
-    asdf:
-      option1: fdsa
+    robots:
+      module_timeout: 20
 """
     preset_3_yaml = """
 name: override3
@@ -1060,7 +1060,7 @@ config:
     assert targets == {"evilcorp1.com", "evilcorp2.com", "evilcorp3.com", "evilcorp4.com"}
     assert preset.config["web"]["spider_distance"] == 1
     assert preset.config["web"]["spider_depth"] == 2
-    assert preset.config["modules"]["asdf"]["option1"] == "fdsa"
+    assert preset.config["modules"]["robots"]["module_timeout"] == 20
     assert set(preset.scan_modules) == {"http", "c99", "robots", "virustotal", "securitytrails"}
 
 

--- a/bbot/test/test_step_1/test_validate_preset.py
+++ b/bbot/test/test_step_1/test_validate_preset.py
@@ -156,3 +156,23 @@ def test_from_yaml_string_raises_on_typos():
     with pytest.raises(BBOTValidationError) as excinfo:
         Preset.from_yaml_string("config:\n  scope:\n    strct: true\n")
     assert "strct" in str(excinfo.value)
+
+
+def test_validate_preset_interactsh_server_accepts_valid():
+    """interactsh_server accepts FQDNs, IPv4, IPv6, None, and empty string."""
+    for v in ["example.com", "sub.example.com", "192.168.1.1", "::1", "", None]:
+        errs = validate_preset({"config": {"interactsh_server": v}})
+        assert errs == [], f"expected {v!r} to validate, got: {[str(e) for e in errs]}"
+
+
+def test_validate_preset_interactsh_server_rejects_invalid():
+    """A single-label hostname (a value without any dots, e.g. a typo'd
+    domain where the user forgot the TLD) or a value with whitespace must
+    be rejected at preset-load time, before any module tries to register
+    with the interactsh server."""
+    for v in ["badhost", "localhost", "with spaces.com"]:
+        errs = validate_preset({"config": {"interactsh_server": v}})
+        assert len(errs) == 1, f"expected {v!r} to fail validation"
+        assert errs[0].path == "interactsh_server"
+        assert "FQDN or IP" in errs[0].message
+        assert repr(v) in errs[0].message

--- a/bbot/test/test_step_1/test_validate_preset.py
+++ b/bbot/test/test_step_1/test_validate_preset.py
@@ -84,3 +84,75 @@ def test_validate_preset_non_dict():
     errs = validate_preset(["not a dict"])
     assert len(errs) == 1
     assert "dict" in errs[0].message
+
+
+def test_validate_preset_config_modules_as_list():
+    """`config.modules` given as a list (wrong shape) used to crash with IndexError."""
+    errs = validate_preset({"config": {"modules": ["nuclei"]}})
+    assert len(errs) == 1
+    assert errs[0].where == "config"
+    assert errs[0].path == "modules"
+
+
+def test_validate_preset_module_dirs_as_string():
+    """`module_dirs` as a string used to iterate characters and raise PermissionError."""
+    errs = validate_preset({"module_dirs": "/tmp/foo"})
+    assert any(e.path == "module_dirs" and "list" in e.message for e in errs)
+
+
+def test_validate_preset_modules_as_string_no_cascade():
+    """`modules: "nuclei"` (string instead of list) should NOT produce per-character lookups."""
+    errs = validate_preset({"modules": "nuclei"})
+    # exactly one type error, no per-character bogus suggestions
+    assert len(errs) == 1
+    assert errs[0].path == "modules"
+    assert "list" in errs[0].message
+
+
+def test_validate_preset_top_level_typo_suggests_preset_field():
+    """Typos at the preset root should suggest preset field names, not config paths."""
+    cases = [
+        ("modlues", "modules"),
+        ("flgas", "flags"),
+        ("targest", "target"),
+        ("output_moduels", "output_modules"),
+    ]
+    for typo, expected in cases:
+        errs = validate_preset({typo: ["x"]})
+        assert any(f'"{typo}"' in str(e) and f'"{expected}"' in str(e) for e in errs), (
+            f"expected suggestion {expected!r} for typo {typo!r}, got: {[str(e) for e in errs]}"
+        )
+
+
+def test_validate_preset_file_missing_returns_error():
+    """A missing preset path should be reported as a single error, not raised."""
+    from bbot.scanner import validate_preset_file
+
+    errs = validate_preset_file("/tmp/does-not-exist-bbot-fuzz.yml")
+    assert len(errs) == 1
+    assert "not found" in errs[0].message.lower()
+
+
+def test_from_dict_raises_on_typos():
+    """from_dict() should reject typo'd preset dicts up front instead of letting
+    them flow through to bake()."""
+    from bbot.errors import ValidationError as BBOTValidationError
+    from bbot.scanner.preset import Preset
+
+    import pytest
+
+    with pytest.raises(BBOTValidationError) as excinfo:
+        Preset.from_dict({"modlues": ["nuclei"]})
+    assert "modlues" in str(excinfo.value)
+
+
+def test_from_yaml_string_raises_on_typos():
+    """YAML strings carrying typos should also be rejected up front."""
+    from bbot.errors import ValidationError as BBOTValidationError
+    from bbot.scanner.preset import Preset
+
+    import pytest
+
+    with pytest.raises(BBOTValidationError) as excinfo:
+        Preset.from_yaml_string("config:\n  scope:\n    strct: true\n")
+    assert "strct" in str(excinfo.value)

--- a/bbot/test/test_step_2/module_tests/test_module_retirejs.py
+++ b/bbot/test/test_step_2/module_tests/test_module_retirejs.py
@@ -116,13 +116,14 @@ return Handlebars;
         descriptions = [finding.data.get("description", "") for finding in retirejs_findings]
         all_descriptions = "\n".join(descriptions)
 
-        # Look for specific vulnerabilities we expect to find
-        expected_handlebars_vuln = "Vulnerable JavaScript library detected: handlebars v4.0.5 Severity: HIGH Summary: Regular Expression Denial of Service in Handlebars JavaScript URL: http://127.0.0.1:8888/handlebars.min.js CVE(s): CVE-2019-20922 Affected versions: [4.0.0 to 4.4.5)"
-        expected_jquery_vuln = "Vulnerable JavaScript library detected: jquery v3.4.1 Severity: MEDIUM Summary: Regex in its jQuery.htmlPrefilter sometimes may introduce XSS JavaScript URL: http://127.0.0.1:8888/jquery-3.4.1.min.js CVE(s): CVE-2020-11022 Affected versions: [1.2.0 to 3.5.0)"
+        # Match on stable identifiers — upstream RetireJS revises summary and
+        # affected-version strings over time.
+        def has_vuln(library, version, cve, js_url):
+            needle = f"library detected: {library} v{version}"
+            return any(needle in d and cve in d and js_url in d for d in descriptions)
 
-        # Verify at least one of the expected vulnerabilities is found
-        handlebars_found = expected_handlebars_vuln in all_descriptions
-        jquery_found = expected_jquery_vuln in all_descriptions
+        handlebars_found = has_vuln("handlebars", "4.0.5", "CVE-2019-20922", "http://127.0.0.1:8888/handlebars.min.js")
+        jquery_found = has_vuln("jquery", "3.4.1", "CVE-2020-11022", "http://127.0.0.1:8888/jquery-3.4.1.min.js")
 
         assert handlebars_found and jquery_found, (
             f"Expected to find specific vulnerabilities but didn't find them. Found descriptions:\n{all_descriptions}"


### PR DESCRIPTION
Follow-up to #3058 addressing the issues found in [this fuzz comment](https://github.com/blacklanternsecurity/bbot/pull/3058#issuecomment-4481902520), plus an additional FQDN check uncovered while testing.

## What this PR does

### Crash fixes in `validate_preset()`
- `_classify_loc` now guards against short `loc` tuples. `validate_preset({"config": {"modules": ["nuclei"]}})` used to raise `IndexError`; it now returns a clean error.
- The `module_dirs` pre-pass now skips non-list shapes. `validate_preset({"module_dirs": "/tmp/foo"})` used to iterate characters and surface as `PermissionError`; it now returns a clean type error.
- The modules-list post-pass now skips non-list shapes. `validate_preset({"modules": "nuclei"})` used to emit one correct type error plus six bogus per-character lookups; it now emits just the one type error.

### Better suggestions for top-level typos
`_format_msg` now draws `extra_forbidden` suggestions from `PresetSchema` field names when `len(loc) == 1`. Before, top-level typos consulted the dotted config-path universe and produced things like:
- `modlues:` → "Did you mean **'module_dirs'**?"
- `flgas:` → "Did you mean 'file_blobs'?"
- `targest:` → "Did you mean 'aggregate'?"

After:
- `modlues:` → "Did you mean 'modules'?"
- `flgas:` → "Did you mean 'flags'?"
- `targest:` → "Did you mean 'target'?"

### YAML preset files now run through the validator
`validate_preset()` is now called from `Preset.from_dict()`, which covers `from_yaml_file`, `from_yaml_string`, and `include:` directives. Previously the validator only ran for `-c` CLI args, so typos in `-p preset.yml` were silently accepted and bad values crashed later inside `bake()` (e.g., `scope.strict: "yesplease"` → `TypeError` from radixtarget; `scope:` as a list → `AttributeError`).

### `interactsh_server` is validated as an FQDN or IP
Found while fuzzing: a domain typed without its TLD (a single-label value with no dot) used to pass preset-load validation and then surface as "Failed to register with an interactsh server" warnings from every interactsh-using module mid-scan. A new `validate_fqdn_or_ip` helper attached as a `field_validator` to `BBOTConfig.interactsh_server` rejects this up front. Accepts `None`, empty string, any IPv4/IPv6, or a hostname containing at least one dot. Rejects single-label values like `localhost`.

The helper lives in `bbot/core/helpers/validators.py` alongside `validate_host`, `validate_port`, `validate_url`, and friends. Module authors who want the same check on their own `class Config` fields can opt in with one line:

```python
from bbot.core.helpers.validators import validate_fqdn_or_ip
from pydantic import field_validator

class Config(BaseModuleConfig):
    host: str = Field("127.0.0.1", description="...")
    _validate_host = field_validator("host")(validate_fqdn_or_ip)
```

Other fields surveyed but **left alone** (each carries some compatibility risk for users with internal endpoints, worth its own discussion): `web.http_proxy`, output module URLs (splunk, elastic, slack, discord, webhook, rabbitmq), database hosts (postgres, mysql, mongo, neo4j), and the `baddns` `custom_nameservers` list typing. Each can opt in to `validate_fqdn_or_ip` (or a future URL validator) in its own module.

### `flatten_config` skips `None` (latent bug)
While wiring the FQDN validator, surfaced a separate bug in `bbot/scanner/preset/environ.py`: `flatten_config` was doing `str(v)` on every value, which wrote the literal string `"None"` into `BBOT_*` env vars for any null field. Pydantic-settings then merged that back into the config dict during validation, defeating any field validator that expects a real value. Now skipped.

### `validate_preset_file()` no longer leaks `FileNotFoundError`
Catches `FileNotFoundError`, `OSError`, and `yaml.YAMLError` and returns a single `PresetValidationError` instead.

### `webbrute` schema bumped to accept lists
`extensions` was declared `str` but the bundled `web/dirbust-heavy.yml` preset passes a YAML list, and the runtime feeds it through `chain_lists` which handles both. The strict YAML validation surfaced this. Schema is now `Union[str, list[str]]`.

### CLI exit code: unchanged from baseline
An earlier version of this PR tried to make bbot exit 1 on validation failure. That broke `test_cli_customheaders`, which asserts `_main()` returns `None` on invalid `--custom-headers` input, and the failure cascaded across the test-distros matrix and Python 3.14. Reverted in commit `02cdec64e`. The CLI keeps the existing convention: validation errors are logged (`[ERRR]` or `[WARN]`) and `_main` returns `None`. Users still see the error; the exit code stays 0 like every other arg-failure path in BBOT.

## Tests

- Ten new cases in `test_validate_preset.py` covering each fix, including the single-label-hostname FQDN repro.
- Four existing tests in `test_presets.py` updated. They used fake module names (`testpreset1`...`testpreset5`, `asdf`) as opaque config markers; the stricter validator now rejects those, so the tests use real module names with the universal `module_timeout` field.
- All 40 tests in `test_validate_preset.py` + `test_presets.py` + `test_config.py` + `test_cli.py::test_cli_customheaders` pass locally.
- Lint and format clean.

## Fuzz battery before/after

| Surface | Before | After |
|---|---|---|
| YAML preset typos | silently accepted | clean error, useful suggestions |
| `config.modules` as list | `IndexError` | clean error |
| `module_dirs` as string | `PermissionError` on `/run/docker` | clean type error |
| `modules: "nuclei"` | type error + 6 bogus cascade | single type error |
| Top-level typos | bad suggestions from wrong pool | suggestions from `PresetSchema` |
| `validate_preset_file("/missing")` | `FileNotFoundError` raised | clean error returned |
| `interactsh_server` as a single-label hostname (missing TLD) | runtime "Failed to register" cascade from every module | rejected at preset-load with a clean error |

## Commits

- `b10514e17` — Original crash, typo-suggestion, YAML-load wiring, and webbrute-schema fixes.
- `02cdec64e` — Revert the cli.py exit-code change to match the existing test framework convention.
- `c77dc5588` — `interactsh_server` FQDN validation + `flatten_config` `None` skip + `value_error` formatter polish + tests.
- `a74e065a9` — Cherry-pick of @liquidsec's `d423533f4` from `retirejs-test-version-range-brittleness`. Unrelated to this PR — retire.js's vulnerability DB drifted upstream (CVE-2020-11022 affected-versions range moved from `[1.2.0 ...` to `[1.12.0 ...`), breaking the brittle full-string assertion in `test_module_retirejs`. Picked the existing fix in to get CI green. If that branch lands on `preset-validation` first, this commit becomes a no-op merge.
- `2d15ac687` — Mechanical move of `validate_fqdn_or_ip` from `bbot/core/config/models.py` to `bbot/core/helpers/validators.py` so it lives next to BBOT's other public validators. No behavior change.

## Known item left alone

Pydantic v2 lax bool coercion still accepts `"yes" / "true" / "1" / "on"` etc. for `scope.strict`. Flagged in the original review as P1. Not addressed here because adding `strict=True` to every bool field is a broader change worth its own discussion.
