### PR TITLE
Wire bbot_io_api_key config through to asndb

### DIFF
--- a/bbot/core/helpers/asn.py
+++ b/bbot/core/helpers/asn.py
@@ -29,7 +29,8 @@ class ASNHelper:
             from asndb import ASNDB
 
             ssl_verify = self.parent_helper.web_config.get("ssl_verify", False)
-            self._client = ASNDB(verify=ssl_verify)
+            api_key = self.parent_helper.config.get("bbot_io_api_key", None)
+            self._client = ASNDB(bbot_io_api_key=api_key, verify=ssl_verify)
         return self._client
 
     def _normalize(self, response):

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -314,3 +314,7 @@ omit_event_types:
 interactsh_server: null
 interactsh_token: null
 interactsh_disable: false
+
+# API key for bbot.io services (currently used by ASN lookups via the asndb library)
+# Can also be set via the BBOT_IO_API_KEY environment variable, which takes precedence.
+bbot_io_api_key: null

--- a/bbot/test/test_step_1/test_helpers.py
+++ b/bbot/test/test_step_1/test_helpers.py
@@ -1146,3 +1146,27 @@ def test_clean_dns_record():
     assert clean_dns_record("'d1jwhzvlef5tfb.example.com'") == "d1jwhzvlef5tfb.example.com"
     # quotes + trailing dot
     assert clean_dns_record('"d1jwhzvlef5tfb.example.com."') == "d1jwhzvlef5tfb.example.com"
+
+
+@pytest.mark.asyncio
+async def test_asn_helper_passes_api_key(bbot_scanner, monkeypatch):
+    """ASNHelper should forward the configured bbot_io_api_key to ASNDB."""
+    captured = {}
+
+    class FakeASNDB:
+        def __init__(self, bbot_io_api_key=None, verify=True):
+            captured["bbot_io_api_key"] = bbot_io_api_key
+            captured["verify"] = verify
+
+    import asndb
+
+    monkeypatch.setattr(asndb, "ASNDB", FakeASNDB)
+
+    scan = bbot_scanner("8.8.8.8", config={"bbot_io_api_key": "test-key-xyz"})
+    _ = scan.helpers.asn.client
+    assert captured["bbot_io_api_key"] == "test-key-xyz"
+
+    captured.clear()
+    scan2 = bbot_scanner("8.8.8.8")
+    _ = scan2.helpers.asn.client
+    assert captured["bbot_io_api_key"] is None


### PR DESCRIPTION
Fixes https://github.com/blacklanternsecurity/bbot/issues/3108

## Summary
- Adds a top-level `bbot_io_api_key` config field (mirrors `interactsh_token`) that flows through `ASNHelper` to the `asndb` library.
- Previously the only way to set this credential was the `BBOT_IO_API_KEY` env var (read by the asndb library directly), with no BBOT-side config slot, no preset visibility, and no way to put it in `secrets.yml`.
- Env var still takes precedence (asndb's own `os.getenv(...) or kwarg` behavior).