### PR TITLE
Pin wpscan to 3.8.28 for Ruby 3.2 compat

### DIFF
--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -58,7 +58,10 @@ class wpscan(BaseModule):
         },
         {
             "name": "Install wpscan gem",
-            "gem": {"name": "wpscan", "state": "latest", "user_install": False},
+            # Pin to 3.8.28 (requires Ruby >= 3.0). wpscan 4.0.0 requires Ruby >= 3.3,
+            # which is newer than the Ruby shipped by Ubuntu 24.04 (3.2.3) and the bbot
+            # CI runners. Bump this when the runners ship Ruby 3.3+.
+            "gem": {"name": "wpscan", "version": "3.8.28", "user_install": False},
             "become": True,
         },
     ]


### PR DESCRIPTION
## Summary
- `wpscan 4.0.0` (released 2026-05-19) bumped its minimum Ruby requirement to `>= 3.3`.
- Ubuntu 24.04 (the GitHub Actions runner image) ships Ruby `3.2.3`, so every CI run since the release fails on `--install-all-deps` → `test_cli_args`.
- Pins to `3.8.28` (the last release that supports Ruby `>= 3.0`) to unblock CI. Bump the pin when the runners ship Ruby 3.3+.