### PR TITLE
make leakix api key mandatory

### DIFF
--- a/bbot/modules/leakix.py
+++ b/bbot/modules/leakix.py
@@ -8,9 +8,8 @@ class leakix(subdomain_enum_apikey):
     flags = ["safe", "subdomain-enum", "passive"]
 
     class Config(BaseModuleConfig):
-        api_key: str = Field("", description="LeakIX API Key", sensitive=True)
+        api_key: str = Field("", description="LeakIX API Key", sensitive=True, mandatory=True)
 
-    # NOTE: API key is not required (but having one will get you more results)
     meta = {
         "description": "Query leakix.net for subdomains",
         "created_date": "2022-07-11",
@@ -20,17 +19,9 @@ class leakix(subdomain_enum_apikey):
     base_url = "https://leakix.net"
     ping_url = f"{base_url}/host/1.1.1.1"
 
-    async def setup(self):
-        ret = await super(subdomain_enum_apikey, self).setup()
-        self.api_key = self.config.get("api_key", "")
-        if self.api_key:
-            return await self.require_api_key()
-        return ret
-
     def prepare_api_request(self, url, kwargs):
-        if self.api_key:
-            kwargs["headers"]["api-key"] = self.api_key
-            kwargs["headers"]["Accept"] = "application/json"
+        kwargs["headers"]["api-key"] = self.api_key
+        kwargs["headers"]["Accept"] = "application/json"
         return url, kwargs
 
     async def request_url(self, query):

--- a/bbot/modules/subdomainradar.py
+++ b/bbot/modules/subdomainradar.py
@@ -75,8 +75,7 @@ class SubdomainRadar(subdomain_enum_apikey):
         return True
 
     def prepare_api_request(self, url, kwargs):
-        if self.api_key:
-            kwargs["headers"] = {"Authorization": f"Bearer {self.api_key}"}
+        kwargs["headers"] = {"Authorization": f"Bearer {self.api_key}"}
         return url, kwargs
 
     async def handle_event(self, event):

--- a/bbot/test/test_step_2/module_tests/test_module_leakix.py
+++ b/bbot/test/test_step_2/module_tests/test_module_leakix.py
@@ -24,26 +24,3 @@ class TestLeakIX(ModuleTestBase):
 
     def check(self, module_test, events):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
-
-
-class TestLeakIX_NoAPIKey(ModuleTestBase):
-    modules_overrides = ["leakix"]
-
-    async def setup_before_prep(self, module_test):
-        module_test.blasthttp_mock.add_response(
-            url="https://leakix.net/host/1.1.1.1",
-            json={"title": "Not Found", "description": "Host not found"},
-        )
-        module_test.blasthttp_mock.add_response(
-            url="https://leakix.net/api/subdomains/blacklanternsecurity.com",
-            json=[
-                {
-                    "subdomain": "asdf.blacklanternsecurity.com",
-                    "distinct_ips": 3,
-                    "last_seen": "2023-04-02T09:38:30.02Z",
-                },
-            ],
-        )
-
-    def check(self, module_test, events):
-        assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"


### PR DESCRIPTION
## Summary
- leakix.net now returns HTTP 401 \"Incorrect API Key\" for all endpoints (including \`/api/subdomains/...\` and the \`/host/1.1.1.1\` ping URL) when no key is provided. Verified manually against the live service.
- Remove the keyless setup override and conditional header logic. The module now uses the standard \`subdomain_enum_apikey.setup()\` flow, which soft-fails with \"No API key set\" if no key is configured.
- Add \`auth_required: True\` to meta so the module listing correctly shows \`Yes\` in the API Key Required column.
- Drop the \`TestLeakIX_NoAPIKey\` test, since keyless mode is no longer supported by the upstream API.