### PR TITLE
anubisdb API URL change

### DIFF
--- a/bbot/modules/anubisdb.py
+++ b/bbot/modules/anubisdb.py
@@ -6,7 +6,7 @@ class anubisdb(subdomain_enum):
     watched_events = ["DNS_NAME"]
     produced_events = ["DNS_NAME"]
     meta = {
-        "description": "Query jldc.me's database for subdomains",
+        "description": "Query anubisdb.com for subdomains",
         "created_date": "2022-10-04",
         "author": "@TheTechromancer",
     }
@@ -15,7 +15,7 @@ class anubisdb(subdomain_enum):
         "limit": "Limit the number of subdomains returned per query (increasing this may slow the scan due to garbage results from this API)"
     }
 
-    base_url = "https://jldc.me/anubis/subdomains"
+    base_url = "https://anubisdb.com/anubis/subdomains"
     dns_abort_depth = 5
 
     async def request_url(self, query):

--- a/bbot/test/test_step_2/module_tests/test_module_anubisdb.py
+++ b/bbot/test/test_step_2/module_tests/test_module_anubisdb.py
@@ -5,7 +5,7 @@ class TestAnubisdb(ModuleTestBase):
     async def setup_after_prep(self, module_test):
         module_test.module.abort_if = lambda e: False
         module_test.blasthttp_mock.add_response(
-            url="https://jldc.me/anubis/subdomains/blacklanternsecurity.com",
+            url="https://anubisdb.com/anubis/subdomains/blacklanternsecurity.com",
             json=["asdf.blacklanternsecurity.com", "zzzz.blacklanternsecurity.com"],
         )
 


### PR DESCRIPTION
## Summary
- Old endpoint \`https://jldc.me/anubis/subdomains/\` 301-redirects to \`https://jonlu.ca/anubis/subdomains/\`, which is now behind Cloudflare bot protection and returns 403 for all programmatic clients. Result: 0 subdomains from this module on every scan.
- The maintained Anubis-DB project ([jonluca/Anubis-DB](https://github.com/jonluca/Anubis-DB), last updated yesterday) documents \`https://anubisdb.com/anubis/subdomains/:domain\` as the canonical endpoint. Verified live — returns 703 subdomains for tesla.com.
- Update \`base_url\`, module description, and test mock URL.