### PR TITLE
route TRACE log entries to debug.log, not error.log

### DIFF
--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -1360,7 +1360,7 @@ class Scanner:
             error_handler = GzipRotatingFileHandler(
                 str(self.home / "error.log"), maxBytes=1024 * 1024 * 100, backupCount=100
             )
-            error_handler.addFilter(lambda x: x.levelno == logging.TRACE or x.levelno >= logging.ERROR)
+            error_handler.addFilter(lambda x: x.levelno >= logging.ERROR and x.levelno != logging.TRACE)
             self.__log_handlers = [main_handler, debug_handler, error_handler]
         return self.__log_handlers
 


### PR DESCRIPTION
## Summary

`error.log` is currently a misnomer — its filter matches `levelno == TRACE or levelno >= ERROR`, so every `self.trace()` call (which modules use for "API responded with a non-2xx, here's the body" diagnostic noise) ends up in `error.log` alongside actual errors. A sample 24-hour scan produced 145K lines of `error.log` made up almost entirely of `JSONDecodeError`s from crt/anubisdb/subdomaincenter parsing non-JSON error pages, `401 Incorrect API Key` traces from leakix, Cloudflare-challenge HTML dumps from skymem, etc. — all already gracefully handled by the modules' try/except blocks. This drowns out anything genuinely worth surfacing.

This change scopes `error.log` to ERROR + CRITICAL only. TRACE entries continue to flow into `debug.log` (whose filter is `levelno >= DEBUG`, and TRACE=49 is above DEBUG=10), so no diagnostic information is lost — it just moves to the right file.

## Note on the explicit `!= TRACE` clause

bbot defines `TRACE = 49` (just below `CRITICAL = 50`), so a plain `>= ERROR` filter would still match TRACE. The explicit `and x.levelno != logging.TRACE` excludes it. Same approach used by `main_handler` and the core logger's `debug_handler` in `bbot/core/config/logger.py`.