### PR TITLE
leakix: guard parse_results against non-list JSON

### DIFF
--- a/bbot/modules/leakix.py
+++ b/bbot/modules/leakix.py
@@ -38,7 +38,7 @@ class leakix(subdomain_enum_apikey):
     async def parse_results(self, r, query=None):
         results = set()
         json = r.json()
-        if json:
+        if isinstance(json, list):
             for entry in json:
                 subdomain = entry.get("subdomain", "")
                 if subdomain:


### PR DESCRIPTION
When `leakix.net` returns an error body that decodes to a JSON string instead of a list — e.g. `\"Incorrect API Key\"` on an unauthenticated request — `parse_results` iterates over the string character-by-character and tries `entry.get(\"subdomain\", \"\")`, raising `AttributeError: 'str' object has no attribute 'get'`. The exception is caught by the outer try/except in `subdomain_enum.query()`, so the scan continues, but it adds traceback noise.

Sample from a real scan log:

```
File "/opt/bbot_dev/bbot/modules/leakix.py", line 43, in parse_results
    subdomain = entry.get("subdomain", "")
AttributeError: 'str' object has no attribute 'get'
```

Tightens the type check from a truthy test (`if json:`) to `isinstance(json, list)` so non-list payloads are quietly ignored.

(The same scenario triggers `_api_response_is_success=False` and `api_request` retries, so the error path is well-handled at the request layer; this is just the parse layer being defensive against malformed payloads.)