### PR TITLE
benchmarks: use dns.minimal instead of dns.disable

### DIFF
--- a/bbot/test/benchmarks/_scan_memory_deep_chain.py
+++ b/bbot/test/benchmarks/_scan_memory_deep_chain.py
@@ -82,7 +82,7 @@ scan = Scanner(
     modules=[HTTP_MODULE],
     output_modules=["python"],
     config={
-        "dns": {"disable": True},
+        "dns": {"minimal": True},
         "scope": {"search_distance": 0},
         "web": {
             "spider_distance": CHAIN_LENGTH + 5,

--- a/bbot/test/benchmarks/_scan_memory_parallel_chains.py
+++ b/bbot/test/benchmarks/_scan_memory_parallel_chains.py
@@ -89,7 +89,7 @@ scan = Scanner(
     modules=[HTTP_MODULE],
     output_modules=["python"],
     config={
-        "dns": {"disable": True},
+        "dns": {"minimal": True},
         "scope": {"search_distance": 0},
         "web": {
             "spider_distance": CHAIN_LENGTH + 5,

--- a/bbot/test/benchmarks/_scan_memory_web_crawl.py
+++ b/bbot/test/benchmarks/_scan_memory_web_crawl.py
@@ -67,7 +67,7 @@ scan = Scanner(
     modules=[HTTP_MODULE],
     output_modules=["python"],
     config={
-        "dns": {"disable": True},
+        "dns": {"minimal": True},
         "scope": {"search_distance": 0},
         "web": {"spider_distance": 10, "spider_depth": 10, "spider_links_per_page": NUM_PAGES},
         "speculate": True,


### PR DESCRIPTION
Fixes a bug preventing the Performance Benchmarks workflow from generating reports on PRs against `dev`. Three memory-benchmark scripts crash on `Scanner` construction because `dns: {disable: true}` is no longer compatible with the default-on `speculate` module. Switching to `dns: {minimal: true}` follows the validation error's own suggestion.
