### PR TITLE
retirejs: stop passing CVE severity through as event severity (#3153)

### DIFF
--- a/bbot/modules/retirejs.py
+++ b/bbot/modules/retirejs.py
@@ -182,10 +182,13 @@ class retirejs(BaseModule):
                                 elif at_or_above:
                                     description_parts.append(f"Affected versions: [>= {at_or_above}]")
                                 description = " ".join(description_parts)
+                                # retire.js findings are emitted as informational
+                                # FINDINGs, not graded vulnerabilities — the related
+                                # CVE's CVSS severity stays in the description rather
+                                # than being passed through as an event severity (#3153).
                                 data = {
                                     "name": "Vulnerable JavaScript Library",
                                     "description": description,
-                                    "severity": severity,
                                     "confidence": "HIGH",
                                     "component": component,
                                     "url": event.parent.url,

--- a/bbot/test/test_step_2/module_tests/test_module_retirejs.py
+++ b/bbot/test/test_step_2/module_tests/test_module_retirejs.py
@@ -136,6 +136,10 @@ return Handlebars;
             # url field should point to the page that loaded the JS, not the JS file itself
             assert finding.data["url"] == "http://127.0.0.1:8888/", "url should be the parent page URL"
             assert finding.parent.type == "URL_UNVERIFIED", "Parent should be URL_UNVERIFIED"
+            # retire.js findings are informational; the CVE severity lives in the
+            # description and is not passed through as an event severity (#3153).
+            assert "severity" not in finding.data, "Finding should not carry a severity"
+            assert "Severity:" in finding.data["description"], "CVE severity should remain in the description"
 
 
 class TestRetireJSNoExcavate(ModuleTestBase):


### PR DESCRIPTION
Fixes #3153.

## Problem

The `retirejs` module emits its results as informational `FINDING` events, but it was also setting a `severity` field on the FINDING data dict — passing the related CVE's CVSS severity through as if it were the finding's own severity.

In bbot, `FINDING` events don't carry a severity (only `VULNERABILITY` events do — see `FINDING._data_validator` vs `VULNERABILITY._data_validator` in `bbot/core/event/base.py`). So the `severity` field on a retire.js FINDING was misleading.

## Fix

Drop the `severity` key from the FINDING data dict. The CVE's CVSS severity is **not lost** — it remains in the finding description (`Severity: HIGH`, etc.), where it belongs as context about the underlying CVE:

```
Vulnerable JavaScript library detected: handlebars v4.0.5 Severity: HIGH Summary: ... CVE(s): CVE-2019-20922 ...
```

The module's `severity` option (minimum-severity filter) is unaffected — it still controls which vulnerabilities get reported.

## Tests

Extends the existing `TestRetireJS` module test to assert:
- the emitted FINDING no longer carries a `severity` field, and
- the CVE severity still appears in the description.

The existing description assertions (which include `Severity: HIGH` / `Severity: MEDIUM`) continue to pass unchanged.

> Note: I couldn't run the retire.js integration test locally (it installs Node.js + retire.js, which the test harness fetches as Linux binaries) — CI will exercise it. The change itself is a one-line data-dict edit and `ruff check`/`ruff format` pass.
