### PR TITLE
retirejs: emit findings as INFO severity instead of passing through CVE severity

### DIFF
--- a/bbot/modules/retirejs.py
+++ b/bbot/modules/retirejs.py
@@ -185,7 +185,7 @@ class retirejs(BaseModule):
                                 data = {
                                     "name": "Vulnerable JavaScript Library",
                                     "description": description,
-                                    "severity": severity,
+                                    "severity": "INFO",
                                     "confidence": "HIGH",
                                     "component": component,
                                     "url": event.parent.url,

--- a/bbot/test/test_step_2/module_tests/test_module_retirejs.py
+++ b/bbot/test/test_step_2/module_tests/test_module_retirejs.py
@@ -136,6 +136,10 @@ return Handlebars;
             # url field should point to the page that loaded the JS, not the JS file itself
             assert finding.data["url"] == "http://127.0.0.1:8888/", "url should be the parent page URL"
             assert finding.parent.type == "URL_UNVERIFIED", "Parent should be URL_UNVERIFIED"
+            # severity should always be INFO; the CVE severity belongs in the description only
+            assert finding.data["severity"] == "INFO", (
+                f"Finding severity should be INFO, got {finding.data['severity']}"
+            )
 
 
 class TestRetireJSNoExcavate(ModuleTestBase):


### PR DESCRIPTION
## Summary
- retirejs was passing upstream CVE severity (e.g. HIGH, CRITICAL) as the FINDING event's own severity
- Changed to always emit `INFO` severity; CVE severity remains in the description text
- Added test assertion to verify findings always have INFO severity

Fixes #3153