### PR TITLE
Security: Encrypted sudo password value is leaked in error output

### DIFF
--- a/bbot/core/helpers/depsinstaller/sudo_askpass.py
+++ b/bbot/core/helpers/depsinstaller/sudo_askpass.py
@@ -33,7 +33,7 @@ def main():
         decrypted_password = decrypt_password(encrypted_password, key)
         print(decrypted_password, end="")
     except Exception as e:
-        print(f'Error decrypting password "{encrypted_password}": {str(e)}', file=sys.stderr)
+        print(f"Error decrypting sudo password: {type(e).__name__}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

Security: Encrypted sudo password value is leaked in error output

## Problem

**Severity**: `Medium` | **File**: `bbot/core/helpers/depsinstaller/sudo_askpass.py:L33`

When sudo askpass decryption fails, the code writes the encrypted password value to stderr. Environment variables and stderr are commonly captured by logs, CI systems, terminals, crash reports, and process supervisors. Even though the value is encrypted, logging it increases the risk of offline attacks and accidental credential exposure, especially because the key path is also supplied through the environment.

## Solution

Do not include secret material, encrypted or plaintext, in error messages. Replace the message with a generic decryption failure and log only non-sensitive diagnostic metadata. Example: `print(f"Error decrypting sudo password: {type(e).__name__}", file=sys.stderr)`.

## Changes

- `bbot/core/helpers/depsinstaller/sudo_askpass.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*