### PR TITLE
Handle malformed YAML gracefully instead of crashing

### DIFF
--- a/bbot/core/config/files.py
+++ b/bbot/core/config/files.py
@@ -37,6 +37,10 @@ class BBOTConfigFiles:
             return conf
         except ConfigLoadError:
             raise
+        except yaml.YAMLError as e:
+            raise ConfigLoadError(
+                f"YAML syntax error in {filename}:\n\n{e}\n\nPlease check the file for indentation or formatting errors."
+            )
         except Exception as e:
             raise ConfigLoadError(f"Error parsing config at {filename}:\n\n{e}")
 

--- a/bbot/core/core.py
+++ b/bbot/core/core.py
@@ -33,7 +33,13 @@ class BBOTCore:
         self._custom_config: dict | None = None
 
         # bare minimum == logging
-        self.logger
+        try:
+            self.logger
+        except BBOTError as e:
+            import sys
+
+            print(f"\n[CRITICAL] {e}\n", file=sys.stderr)
+            sys.exit(1)
         self.log = logging.getLogger("bbot.core")
 
         self._prep_multiprocessing()

--- a/bbot/scanner/preset/preset.py
+++ b/bbot/scanner/preset/preset.py
@@ -804,8 +804,14 @@ class Preset(metaclass=BasePreset):
                 yaml_str = open(filename).read()
             except FileNotFoundError:
                 raise PresetNotFoundError(f'Could not find preset at "{filename}" - file does not exist')
+            try:
+                yaml_dict = yaml.safe_load(yaml_str) or {}
+            except yaml.YAMLError as e:
+                raise ValidationError(
+                    f"YAML syntax error in {filename}:\n\n{e}\n\nPlease check the file for indentation or formatting errors."
+                )
             preset = cls.from_dict(
-                yaml.safe_load(yaml_str) or {},
+                yaml_dict,
                 name=filename.stem,
                 _exclude=_exclude,
                 _log=_log,
@@ -830,7 +836,13 @@ class Preset(metaclass=BasePreset):
             >>> - portscan'''
             >>> preset = Preset.from_yaml_string(yaml_string)
         """
-        return cls.from_dict(yaml.safe_load(yaml_preset) or {})
+        try:
+            yaml_dict = yaml.safe_load(yaml_preset) or {}
+        except yaml.YAMLError as e:
+            raise ValidationError(
+                f"YAML syntax error in preset:\n\n{e}\n\nPlease check the YAML for indentation or formatting errors."
+            )
+        return cls.from_dict(yaml_dict)
 
     def to_dict(self, include_target=False, full_config=False, redact_secrets=False):
         """

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1299,3 +1299,42 @@ def test_preset_dnsresolve_required_by_dns_name_consumers():
 
     # disabling dnsresolve with no DNS_NAME consumers enabled is allowed
     Preset(exclude_modules=["dnsresolve"]).validate().bake()
+
+
+def test_malformed_yaml_preset_file(tmp_path):
+    """Regression test for https://github.com/blacklanternsecurity/bbot/issues/3158
+
+    Malformed YAML (e.g. bad indentation) must raise a clear ValidationError,
+    not an unhandled exception with a raw traceback.
+    """
+    malformed = tmp_path / "bad_preset.yml"
+    malformed.write_text(
+        "target:\n  - evilcorp.com\nmodules:\n  sslcert:\n    option: value\n   robots:\n    option: value\n"
+    )
+    with pytest.raises(ValidationError, match="YAML syntax error"):
+        Preset.from_yaml_file(str(malformed))
+
+
+def test_malformed_yaml_preset_string():
+    """Regression test for https://github.com/blacklanternsecurity/bbot/issues/3158
+
+    Malformed YAML string must raise ValidationError, not an unhandled yaml.YAMLError.
+    """
+    malformed_yaml = "target:\n  - evilcorp.com\nconfig:\n  key: value\n   bad_indent: oops\n"
+    with pytest.raises(ValidationError, match="YAML syntax error"):
+        Preset.from_yaml_string(malformed_yaml)
+
+
+def test_malformed_yaml_config_file(tmp_path):
+    """Regression test for https://github.com/blacklanternsecurity/bbot/issues/3158
+
+    Malformed YAML in a config file (bbot.yml / secrets.yml) must raise
+    ConfigLoadError with a helpful message, not crash with a raw traceback.
+    """
+    from bbot.core.config.files import BBOTConfigFiles
+    from bbot.errors import ConfigLoadError
+
+    malformed = tmp_path / "bad_config.yml"
+    malformed.write_text("web:\n  http_rate_limit: 100\n   bad_key: value\n")
+    with pytest.raises(ConfigLoadError, match="YAML syntax error"):
+        BBOTConfigFiles._get_config(None, str(malformed))


### PR DESCRIPTION
## Summary
- Catch `yaml.YAMLError` in config file loading, preset file loading, and preset string parsing so users get a clear error message instead of a raw traceback
- Catch `BBOTError` in `BBOTCore.__init__` so a malformed `bbot.yml` or `secrets.yml` exits cleanly instead of crashing at import time
- Add three regression tests for malformed YAML in each path

Closes #3158