### PR TITLE
Test Stability

### DIFF
--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -402,9 +402,9 @@ async def test_cli_args(monkeypatch, caplog, capsys, clean_default_config):
     assert result is True
 
     # invasive modules should run without a gate (just warnings)
-    monkeypatch.setattr("sys.argv", ["bbot", "-m", "nuclei"])
+    monkeypatch.setattr("sys.argv", ["bbot", "-m", "dotnetnuke"])
     result = await cli._main()
-    assert result is True, "-m nuclei should run without any special flags"
+    assert result is True, "-m dotnetnuke should run without any special flags"
 
     # install all deps
     monkeypatch.setattr("sys.argv", ["bbot", "--install-all-deps"])


### PR DESCRIPTION
## Summary
- The `test_cli_args` invasive-module gate test used `nuclei`, which hard-fails setup in CI when the binary isn't installed. This makes the test unstable, since nuclei installation can sometimes be problematic - this test isn't trying to test nuclei.
- Switched to `dotnetnuke` which also has the `invasive` flag but doesn't depend on external binary installation (tested separately via `--install-all-deps`)