### PR TITLE
Fix preset path resolution clobbering default search paths

### DIFF
--- a/bbot/scanner/preset/path.py
+++ b/bbot/scanner/preset/path.py
@@ -19,19 +19,21 @@ class PresetPath:
 
     def find(self, filename):
         filename_path = Path(filename).expanduser()
+        if "/" in str(filename):
+            resolved = filename_path.resolve()
+            if resolved.is_file():
+                self.add_path(resolved.parent)
+                return resolved
+            self.add_path(filename_path.parent)
         extension = filename_path.suffix.lower()
         file_candidates = set()
         extension_candidates = {".yaml", ".yml"}
         if extension:
             extension_candidates.add(extension.lower())
-        else:
-            file_candidates.add(filename_path.stem)
         for ext in extension_candidates:
             file_candidates.add(f"{filename_path.stem}{ext}")
         file_candidates = sorted(file_candidates)
         file_candidates_str = ",".join([str(s) for s in file_candidates])
-        if "/" in str(filename):
-            self.add_path(filename_path.parent)
         log.debug(f"Searching for {file_candidates_str} in {[str(p) for p in self.paths]}")
         for path in self.paths:
             for candidate in file_candidates:
@@ -59,8 +61,9 @@ class PresetPath:
         if not path.is_dir():
             log.debug(f'Path "{path.resolve()}" is not a directory')
             return
-        # preemptively remove any paths that are subdirectories of the new path
-        self.paths = [p for p in self.paths if not p.is_relative_to(path)]
+        # preemptively remove any paths that are subdirectories of the new path,
+        # but never remove the default preset path
+        self.paths = [p for p in self.paths if p == DEFAULT_PRESET_PATH or not p.is_relative_to(path)]
         self.paths.insert(0, path)
 
     def find_file(self, filename):

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1301,6 +1301,42 @@ def test_preset_dnsresolve_required_by_dns_name_consumers():
     Preset(exclude_modules=["dnsresolve"]).validate().bake()
 
 
+def test_preset_path_no_clobber_default(tmp_path):
+    """Regression: loading a preset via path (e.g. ./scan.yml) must not clobber
+    the default preset search path, even when the preset lives in a parent
+    directory of bbot/presets/. Previously, add_path() would remove
+    DEFAULT_PRESET_PATH from the search list, causing rglob to search the
+    entire tree and match non-YAML files (like .venv/bin/baddns).
+    """
+    from bbot.scanner.preset.path import PresetPath, DEFAULT_PRESET_PATH
+
+    # preset that includes a built-in preset by name (no extension, no path)
+    preset_file = tmp_path / "scan.yml"
+    preset_file.write_text("description: regression test\ninclude:\n  - baddns\n")
+
+    # non-YAML decoy that would match an extensionless rglob for "baddns"
+    decoy_dir = tmp_path / "fake_venv" / "bin"
+    decoy_dir.mkdir(parents=True)
+    decoy = decoy_dir / "baddns"
+    decoy.write_text("#!/usr/bin/env python\nif __name__ == '__main__':\n    pass\n")
+
+    pp = PresetPath()
+    # resolve the top-level file
+    found = pp.find(str(preset_file))
+    assert found == preset_file.resolve()
+    # DEFAULT_PRESET_PATH must survive
+    assert DEFAULT_PRESET_PATH in pp.paths
+
+    # the built-in include must resolve to the real preset, not the decoy
+    found_include = pp.find("baddns")
+    assert found_include.suffix in (".yml", ".yaml")
+    assert "fake_venv" not in str(found_include)
+
+    # full round-trip through Preset
+    preset = Preset.from_yaml_file(str(preset_file))
+    assert "baddns" in preset.explicit_scan_modules
+
+
 def test_malformed_yaml_preset_file(tmp_path):
     """Regression test for https://github.com/blacklanternsecurity/bbot/issues/3158
 


### PR DESCRIPTION
## Summary

When a preset was passed with a directory component (e.g. `bbot -p ./my_preset.yml`), `PresetPath.add_path()` would add the parent directory to the search paths and remove any existing paths that were subdirectories of it -- including the default `bbot/presets/` path. This caused subsequent include resolution (e.g. `baddns-heavy` -> `baddns`) to `rglob` the entire repo tree, matching non-YAML files like `.venv/bin/baddns` and failing with a YAML parse error.

Fix: resolve direct file paths immediately and return without modifying search paths. Include names (like `baddns-heavy`) continue to resolve via the default `bbot/presets/` path as before.