### PR TITLE
Fix _minimize() race in forward_event stripping WEB_PARAMETER fields

### DIFF
--- a/bbot/modules/lightfuzz/submodules/base.py
+++ b/bbot/modules/lightfuzz/submodules/base.py
@@ -358,10 +358,9 @@ class BaseLightfuzz:
 
     def metadata(self):
         metadata_string = f"Parameter: [{self.event.data['name']}] Parameter Type: [{self.event.data['type']}]{self.conversion_note()}"
-        if self.event.data["original_value"] != "" and self.event.data["original_value"] is not None:
-            metadata_string += (
-                f" Original Value: [{self.lightfuzz.helpers.truncate_string(self.event.data['original_value'], 200)}]"
-            )
+        original_value = self.event.data.get("original_value")
+        if original_value is not None and original_value != "":
+            metadata_string += f" Original Value: [{self.lightfuzz.helpers.truncate_string(original_value, 200)}]"
         # Surface additional_params for param types where they're needed to reproduce findings
         if self.event.data["type"] in ("POSTPARAM", "BODYJSON", "HEADER", "COOKIE"):
             additional_params = self.event.data.get("additional_params", {})

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -271,6 +271,11 @@ class ScanEgress(BaseInterceptModule):
         if -1 < event.scope_distance < 1:
             self.scan.word_cloud.absorb_event(event)
 
+        # Hold a sentinel on _module_consumers during distribution so it
+        # never transiently hits 0 between sequential queue_event() awaits
+        # (which would let a fast module's _minimize() strip fields that
+        # slower modules still need).
+        event._module_consumers += 1
         for module in self.scan.modules.values():
             # don't distribute events to intercept modules
             if module._intercept:
@@ -282,6 +287,5 @@ class ScanEgress(BaseInterceptModule):
                 continue
             await module.queue_event(event)
 
-        # if no module accepted this event, minimize it now
-        if event._module_consumers <= 0:
-            event._minimize()
+        # release the sentinel; _minimize() decrements and strips if count hits 0
+        event._minimize()

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -1325,3 +1325,61 @@ async def test_host_metadata():
     assert j4["data_json"]["status_code"] == 200
 
     await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_parameter_minimize_sentinel():
+    """Regression: forward_event distributes events via sequential awaits.
+    A fast module can finish and _minimize() (dropping _module_consumers
+    to 0, stripping original_value) before slower modules are queued.
+    The sentinel hold in forward_event prevents this.
+
+    We reproduce the race deterministically by patching queue_event to
+    call _minimize() immediately after queueing (simulating the worker
+    finishing before the next module is queued).
+    """
+    scan = Scanner("http://example.com", modules=["hunt"])
+    await scan._prep()
+
+    data = {
+        "host": "example.com",
+        "type": "COOKIE",
+        "name": "session",
+        "original_value": "abc123",
+        "url": "https://example.com/",
+        "description": "Set-Cookie Assigned Cookie [session]",
+        "additional_params": {},
+    }
+    event = scan.make_event(data, "WEB_PARAMETER", parent=scan.root_event)
+
+    # Patch every non-intercept module EXCEPT hunt: after queueing,
+    # immediately _minimize() as if the worker finished instantly.
+    # hunt is left un-patched -- it represents the slow module that
+    # still needs original_value when it eventually processes.
+    for module in scan.modules.values():
+        if module._intercept or module.name == "hunt":
+            continue
+        orig_queue = module.queue_event
+
+        async def _instant_finish(ev, _orig=orig_queue):
+            before = ev._module_consumers
+            await _orig(ev)
+            if ev._module_consumers > before:
+                ev._minimize()
+
+        module.queue_event = _instant_finish
+
+    # Reorder modules so fast (patched) output modules are iterated
+    # before hunt.  This guarantees the race: a fast module finishes
+    # and _minimize()s before hunt has been queued.
+    hunt_mod = scan.modules.pop("hunt")
+    scan.modules["hunt"] = hunt_mod
+
+    await scan.egress_module.forward_event(event, {})
+
+    # hunt must have accepted the event and still be holding it
+    assert event._module_consumers >= 1, "no module accepted the event"
+    # The sentinel must have prevented premature stripping
+    assert "original_value" in event.data, "original_value stripped during distribution -- sentinel missing"
+
+    await scan._cleanup()


### PR DESCRIPTION
## Summary

`forward_event()` distributes events to modules via sequential `await module.queue_event(event)` calls. Between iterations, the event loop can schedule a fast module's worker, which processes the event and calls `_minimize()`. If `_module_consumers` transiently hits 0 mid-loop, `_minimize()` strips fields like `original_value`, `additional_params`, and `assigned_cookies` from `WEB_PARAMETER` events before slower modules (like lightfuzz) are even queued. This caused `KeyError: 'original_value'` crashes in lightfuzz's `metadata()` for every COOKIE-type `WEB_PARAMETER`.

**Fix**: Add a sentinel hold on `_module_consumers` (+1 before the distribution loop, `_minimize()` after) so the counter never transiently reaches 0 during distribution. Also use defensive `.get()` in lightfuzz `metadata()` as a belt-and-suspenders guard.

**Regression test**: `test_web_parameter_minimize_sentinel` monkey-patches output modules to simulate instant processing, reorders modules so fast ones iterate before the slow one, then calls real `forward_event()` and asserts `original_value` survives. Confirmed: fails without fix, passes with fix. All 112 lightfuzz tests pass.