### PR TITLE
Lightfuzz FP Tuning

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -324,6 +324,7 @@ parameter_blacklist_prefixes:
   - f5avr
   - incap_
   - visid_incap_
+  - nlbi_
   - AWSALB
   - utm_
   - ApplicationGatewayAffinity

--- a/bbot/modules/lightfuzz/submodules/crypto.py
+++ b/bbot/modules/lightfuzz/submodules/crypto.py
@@ -323,6 +323,12 @@ class crypto(BaseLightfuzz):
             # plaintext, so restricting to hex eliminates that class of FP.
             if encoding != "hex":
                 continue
+            # Digit-only strings (e.g. "7276383284") are valid hex but are almost
+            # certainly plain decimal IDs (account numbers, zip codes, etc.). Their
+            # hex-decoded bytes XOR to small values that trivially pass the ascii_score
+            # threshold, producing false keystream-reuse findings.
+            if value.isdigit():
+                continue
             if len(decoded) < 3:
                 continue
             if decoded in seen_bytes:

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -5027,6 +5027,18 @@ def test_keystream_fp_sibling_form_fields_incremental():
     assert not c.results, f"FP on sibling sequential hex form fields: {c.results}"
 
 
+def test_keystream_fp_decimal_account_numbers():
+    """Digit-only parameter values (account numbers, zip codes, etc.) are valid
+    hex but are plain decimal IDs. Their decoded bytes XOR to small values that
+    trivially pass the ascii_score threshold."""
+    c = _make_crypto_for_keystream(
+        "7276383284",
+        additional_params={"AccountName": "3767190588"},
+    )
+    c.detect_keystream_reuse("7276383284")
+    assert not c.results, f"FP on decimal account numbers: {c.results}"
+
+
 # -- True positives: MUST fire --
 
 


### PR DESCRIPTION
## Summary
- Crypto keystream-reuse: skip digit-only values that are valid hex but are plain decimal IDs (account numbers, zip codes). Their decoded bytes XOR to small values that trivially pass the ascii_score threshold.
- Add `nlbi_` (Incapsula/Imperva NGINX load balancer) to `parameter_blacklist_prefixes` alongside existing `incap_` and `visid_incap_` entries.