### PR TITLE
Webbrute rework: HttpCompare baseline + defensive layers

### DIFF
--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -127,6 +127,7 @@ class HttpCompare:
                     "date",
                     "last-modified",
                     "content-length",
+                    "connection",
                     "ETag",
                     "X-Pad",
                     "X-Backside-Transport",

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -331,13 +331,17 @@ class paramminer_headers(BaseModule):
     def _incoming_dedup_hash(self, event):
         # dedup by endpoint structure, not full URL string -- value mutations
         # of the same parameter set (e.g. from lightfuzz probes) are one test surface
-        p = event.parsed_url
+        p = getattr(event, "parsed_url", None)
+        if p is None:
+            return hash(event), ""
         if event.type == "WEB_PARAMETER":
-            additional_params = event.data.get("additional_params", {})
-            param_keys = tuple(sorted({event.data.get("name", ""), *additional_params.keys()}))
+            name = event.data.get("name", "")
+            additional_params = event.data.get("additional_params") or {}
+            param_keys = tuple(sorted(additional_params.keys()))
         else:
+            name = ""
             param_keys = ()
-        return hash((event.type, p.scheme, p.netloc, p.path, param_keys)), "per_endpoint+keys"
+        return hash((event.type, p.scheme, p.netloc, p.path, name, param_keys)), "per_endpoint+keys"
 
     async def filter_event(self, event):
         if await self._is_http_wildcard_host(event) is True:

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -328,6 +328,17 @@ class paramminer_headers(BaseModule):
                 continue
             await self.process_results(event, results)
 
+    def _incoming_dedup_hash(self, event):
+        # dedup by endpoint structure, not full URL string -- value mutations
+        # of the same parameter set (e.g. from lightfuzz probes) are one test surface
+        p = event.parsed_url
+        if event.type == "WEB_PARAMETER":
+            additional_params = event.data.get("additional_params", {})
+            param_keys = tuple(sorted({event.data.get("name", ""), *additional_params.keys()}))
+        else:
+            param_keys = ()
+        return hash((event.type, p.scheme, p.netloc, p.path, param_keys)), "per_endpoint+keys"
+
     async def filter_event(self, event):
         if await self._is_http_wildcard_host(event) is True:
             return False, "host is an HTTP wildcard responder"

--- a/bbot/modules/webbrute.py
+++ b/bbot/modules/webbrute.py
@@ -4,7 +4,9 @@ from typing import Union
 
 import blasthttp
 
+from bbot.core.helpers.diff import HttpCompare
 from bbot.core.helpers.web.web import iter_batch_results
+from bbot.errors import HttpCompareError
 from bbot.modules.base import BaseModule
 from bbot.core.config.models import BaseModuleConfig, Field
 
@@ -112,148 +114,65 @@ class webbrute(BaseModule):
             headers.append((hk, hv))
         return headers
 
-    def _response_metrics(self, response):
-        """Extract metrics from a response for baseline comparison."""
-        text = response.text or ""
-        return {
-            "status": response.status_code,
-            "length": len(response.content),
-            "words": len(text.split()),
-            "lines": text.count("\n") + 1,
-        }
-
-    def _is_baseline_match(self, metrics, baseline_filter):
-        """Return True if the response matches the baseline (i.e. should be filtered OUT)."""
-        if baseline_filter.get("abort"):
-            return True
-        filter_type = baseline_filter.get("type", "status")
-        if filter_type == "not_status":
-            # Filter anything matching this status (e.g. 404)
-            return metrics["status"] == baseline_filter["status"]
-        elif filter_type == "status_and_size":
-            return metrics["status"] == baseline_filter["status"] and metrics["length"] == baseline_filter["size"]
-        elif filter_type == "status_and_words":
-            return metrics["status"] == baseline_filter["status"] and metrics["words"] == baseline_filter["words"]
-        elif filter_type == "status_and_lines":
-            return metrics["status"] == baseline_filter["status"] and metrics["lines"] == baseline_filter["lines"]
-        elif filter_type == "status_only":
-            return metrics["status"] == baseline_filter["status"]
-        return False
+    # Host-level abort reasons that apply to ALL extensions, not just the one that triggered them.
+    HOST_ABORT_REASONS = {"WAF_BLOCK_PAGE", "CONNECTIVITY_ISSUES", "BASELINE_CHANGED_CODES", "RECEIVED_429"}
 
     async def baseline_fuzz(self, url, exts=None, prefix="", suffix=""):
         if exts is None:
             exts = [""]
         filters = {}
-        headers = self._build_batch_headers()
-        proxy = self.scan.http_proxy or None
+        host_abort = None
 
         for ext in exts:
+            if host_abort is not None:
+                filters[ext] = host_abort
+                continue
+
             self.debug(f"running baseline for URL [{url}] with ext [{ext}]")
 
-            # Generate 4 canary strings of increasing length and batch them
-            canary_configs = []
-            canary_length = 4
-            for _ in range(4):
-                canary_word = "".join(random.choice(string.ascii_lowercase) for _ in range(canary_length))
-                canary_length += 2
-                canary_url = f"{url}{prefix}{canary_word}{suffix}{ext}"
-                canary_configs.append(
-                    blasthttp.BatchConfig(
-                        canary_url,
-                        headers=headers,
-                        timeout=self.scan.http_timeout,
-                        retries=0,
-                        verify_certs=False,
-                        follow_redirects=False,
-                        proxy=proxy,
-                    )
-                )
+            canary_url_1 = f"{url}{prefix}{self.helpers.rand_string(8, digits=False)}{suffix}{ext}"
+            canary_url_2 = f"{url}{prefix}{self.helpers.rand_string(10, digits=False)}{suffix}{ext}"
 
-            canary_results = []
-            canary_waf_count = 0
-            async for result in iter_batch_results(
-                self.blast_client.request_batch_stream(canary_configs, 4, rate_limit=self.rate)
-            ):
-                if result.success:
-                    canary_results.append(self._response_metrics(result.response))
-                    if await self.helpers.yara.match(self.waf_yara_rules, result.response.body):
-                        canary_waf_count += 1
+            compare = HttpCompare(
+                canary_url_1,
+                self.helpers,
+                allow_redirects=False,
+                timeout=self.scan.http_timeout,
+                include_cache_buster=False,
+                baseline_url_2=canary_url_2,
+            )
 
-            # If all canary responses are WAF block pages, the WAF is blocking everything
-            if canary_waf_count == len(canary_results) and canary_waf_count > 0:
-                self.warning(f"All baseline requests for URL [{url}] ext [{ext}] returned WAF block pages, aborting.")
-                filters[ext] = {"abort": True, "reason": "WAF_BLOCK_PAGE"}
+            try:
+                await compare._baseline()
+            except HttpCompareError as e:
+                self.warning(f"Could not establish baseline for URL [{url}] ext [{ext}]: {e}")
+                abort = {"abort": True, "reason": "CONNECTIVITY_ISSUES"}
+                filters[ext] = abort
+                host_abort = abort
                 continue
 
-            # Check we got all 4 responses
-            if len(canary_results) != 4:
-                self.warning(
-                    f"Could not attain baseline for URL [{url}] ext [{ext}] — only got {len(canary_results)}/4 responses. Possible connectivity issues."
-                )
-                filters[ext] = {"abort": True, "reason": "CONNECTIVITY_ISSUES"}
+            baseline_status = compare.baseline.status_code
+
+            if await self.helpers.yara.match(self.waf_yara_rules, compare.baseline.content):
+                self.warning(f"Baseline for URL [{url}] ext [{ext}] returned WAF block page, aborting.")
+                abort = {"abort": True, "reason": "WAF_BLOCK_PAGE"}
+                filters[ext] = abort
+                host_abort = abort
                 continue
 
-            # If status codes differ across canaries, likely load balancing
-            statuses = {r["status"] for r in canary_results}
-            if len(statuses) != 1:
-                self.warning("Got different status codes for each baseline. This could indicate load balancing")
-                filters[ext] = {"abort": True, "reason": "BASELINE_CHANGED_CODES"}
-                continue
-
-            baseline_status = canary_results[0]["status"]
-
-            # All 404s — just look for anything not 404
-            if baseline_status == 404:
-                self.debug("All baseline results were 404, filtering on status != 404")
-                filters[ext] = {"type": "not_status", "status": 404}
-                continue
-
-            # All 403s — possible WAF
-            if baseline_status == 403:
-                self.warning("All baseline requests received 403. A WAF may be actively blocking traffic.")
-
-            # All 429s — rate limiting, abort
             if baseline_status == 429:
                 self.warning(
                     f"Received 429 (Too Many Requests) for URL [{url}]. A WAF or rate limiter is blocking requests, aborting."
                 )
-                filters[ext] = {"abort": True, "reason": "RECEIVED_429"}
+                abort = {"abort": True, "reason": "RECEIVED_429"}
+                filters[ext] = abort
+                host_abort = abort
                 continue
 
-            # Try to find a stable metric for AND filtering
-            # 1. Same body size across all canaries
-            if len({r["length"] for r in canary_results}) == 1:
-                self.debug("All baseline results had the same body size, filtering on status + size")
-                filters[ext] = {
-                    "type": "status_and_size",
-                    "status": baseline_status,
-                    "size": canary_results[0]["length"],
-                }
-                continue
+            if baseline_status == 403:
+                self.warning("All baseline requests received 403. A WAF may be actively blocking traffic.")
 
-            # 2. Same word count
-            if len({r["words"] for r in canary_results}) == 1:
-                self.debug("All baseline results had the same word count, filtering on status + words")
-                filters[ext] = {
-                    "type": "status_and_words",
-                    "status": baseline_status,
-                    "words": canary_results[0]["words"],
-                }
-                continue
-
-            # 3. Same line count
-            if len({r["lines"] for r in canary_results}) == 1:
-                self.debug("All baseline results had the same line count, filtering on status + lines")
-                filters[ext] = {
-                    "type": "status_and_lines",
-                    "status": baseline_status,
-                    "lines": canary_results[0]["lines"],
-                }
-                continue
-
-            # Nothing stable — fall back to status-only
-            self.debug("No stable baseline metric found, filtering on status only")
-            filters[ext] = {"type": "status_only", "status": baseline_status}
+            filters[ext] = {"compare": compare}
 
         return filters
 
@@ -265,7 +184,6 @@ class webbrute(BaseModule):
         suffix="",
         exts=None,
         filters=None,
-        baseline=False,
     ):
         if exts is None:
             exts = [""]
@@ -276,10 +194,14 @@ class webbrute(BaseModule):
         proxy = self.scan.http_proxy or None
 
         for ext in exts:
-            # Check for abort filter; default to filtering 404s if no filter provided
-            ext_filter = filters.get(ext, {"type": "not_status", "status": 404})
+            ext_filter = filters.get(ext, {})
             if ext_filter.get("abort"):
                 self.warning(f"Skipping fuzz for ext [{ext}]: {ext_filter.get('reason', 'ABORT')}")
+                continue
+
+            compare = ext_filter.get("compare")
+            if compare is None:
+                self.debug(f"No baseline for ext [{ext}], skipping")
                 continue
 
             # Build batch configs for this extension
@@ -303,11 +225,6 @@ class webbrute(BaseModule):
 
             self.debug(f"Fuzzing {len(configs)} URLs for ext [{ext}]")
 
-            # Fire all requests via native blasthttp batch (Rust concurrency).
-            # Stream results in completion order — canary detection and hit
-            # collection are order-independent (we only check `canary_found and
-            # hits` after the stream completes), so per-result work overlaps with
-            # in-flight HTTP I/O.
             canary_found = False
             hits = []
             async for result in iter_batch_results(
@@ -319,10 +236,10 @@ class webbrute(BaseModule):
                     continue
 
                 response = result.response
-                metrics = self._response_metrics(response)
 
-                # Check if this matches the baseline (should be filtered out)
-                if ext_filter and self._is_baseline_match(metrics, ext_filter):
+                # HttpCompare: empty diff_reasons = matches baseline = filter out
+                diff_reasons = compare._compare_sync(response, response.url)
+                if not diff_reasons:
                     continue
 
                 # Extract the word from the URL to check for canary
@@ -337,8 +254,7 @@ class webbrute(BaseModule):
                     canary_found = True
                     continue
 
-                # Filter 3xx redirects to site root — these are soft 404s,
-                # not real findings (e.g. mod_userdir sending ~user to /)
+                # Filter 3xx redirects to site root
                 if 300 <= response.status < 400:
                     location = ""
                     for hdr_name, hdr_val in response.headers.items():
@@ -349,47 +265,31 @@ class webbrute(BaseModule):
                         self.debug(f"Filtering redirect-to-root hit: {response.url} -> {location}")
                         continue
 
-                # Filter WAF block pages (can return any status code, including 200)
+                # Filter WAF block pages
                 if await self.helpers.yara.match(self.waf_yara_rules, response.body):
                     self.debug(f"Filtering WAF block page: {response.url}")
                     continue
 
                 hits.append({"url": response.url, "status": response.status})
 
-            # If canary was found in results, the server is returning everything — abort
             if canary_found and hits:
-                self.debug("Found canary in results, all hits are likely false positives — aborting")
+                self.debug("Found canary in results, all hits are likely false positives -- aborting")
                 return
 
-            # Mid-scan validation: one canary check per extension.
-            # Single request — use client.request() directly instead of a
-            # 1-config request_batch_stream loop (the streaming API only
-            # earns its keep with multiple in-flight requests).
-            if hits and not baseline and ext_filter:
-                canary_word = "".join(random.choice(string.ascii_lowercase) for _ in range(4))
-                canary_url = f"{url}{prefix}{canary_word}{suffix}{ext}"
+            # Mid-scan validation: does a fresh canary still match baseline?
+            if hits:
+                canary_url = f"{url}{prefix}{self.helpers.rand_string(8, digits=False)}{suffix}{ext}"
                 try:
-                    canary_response = await self.blast_client.request(
-                        canary_url,
-                        headers=headers,
-                        timeout=self.scan.http_timeout,
-                        retries=0,
-                        verify_certs=False,
-                        follow_redirects=False,
-                        proxy=proxy,
+                    match, reasons, _, _ = await compare.compare(canary_url)
+                except HttpCompareError:
+                    match = False
+                    reasons = ["error"]
+                if not match:
+                    self.verbose(
+                        f"Would have reported {len(hits)} hit(s), but mid-scan baseline check "
+                        f"failed ({reasons}). Aborting the current run against [{url}]"
                     )
-                except Exception as e:
-                    self.debug(f"Mid-scan canary request failed: {e}")
-                    canary_response = None
-                if canary_response is not None:
-                    canary_metrics = self._response_metrics(canary_response)
-                    if not self._is_baseline_match(canary_metrics, ext_filter):
-                        self.verbose(
-                            f"Would have reported {len(hits)} hit(s), but mid-scan baseline check failed. "
-                            "This could be due to a WAF turning on mid-scan."
-                        )
-                        self.verbose(f"Aborting the current run against [{url}]")
-                        return
+                    return
 
             for hit in hits:
                 yield hit

--- a/bbot/modules/webbrute.py
+++ b/bbot/modules/webbrute.py
@@ -200,7 +200,7 @@ class webbrute(BaseModule):
         if exts is None:
             exts = [""]
         if filters is None:
-            filters = {}
+            filters = await self.baseline_fuzz(url, exts=exts, prefix=prefix, suffix=suffix)
 
         headers = self._build_batch_headers()
         proxy = self.scan.http_proxy or None

--- a/bbot/modules/webbrute.py
+++ b/bbot/modules/webbrute.py
@@ -35,6 +35,9 @@ class webbrute(BaseModule):
         ignore_case: bool = Field(False, description="Only put lowercase words into the wordlist")
         rate: int = Field(0, description="Maximum requests per second (0 = unlimited)")
         concurrency: int = Field(50, description="Number of concurrent requests per URL being fuzzed")
+        avoid_wafs: bool = Field(
+            True, description="Avoid running against confirmed WAFs, which are likely to block brute-force requests"
+        )
 
     banned_characters = {" "}
     blacklist = ["images", "css", "image"]
@@ -63,6 +66,8 @@ class webbrute(BaseModule):
                 f"Module rate limit ({self.rate} rps) is higher than global http_rate_limit ({global_rate} rps). "
                 f"The more restrictive global setting will be used."
             )
+        self._host_timeouts = {}
+        self._blocked_hosts = set()
         self.verbose(f"Generated dynamic wordlist with length [{str(words_len)}]")
         try:
             self.extensions = self.helpers.chain_lists(self.config.get("extensions", ""), validate=True)
@@ -90,8 +95,9 @@ class webbrute(BaseModule):
             for ext in self.extensions:
                 exts.append(f".{ext}")
 
+        netloc = event.parsed_url.netloc
         filters = await self.baseline_fuzz(fixed_url, exts=exts)
-        async for r in self.execute_fuzz(self.words, fixed_url, exts=exts, filters=filters):
+        async for r in self.execute_fuzz(self.words, fixed_url, netloc, exts=exts, filters=filters):
             await self.emit_event(
                 r["url"],
                 "URL_UNVERIFIED",
@@ -103,6 +109,11 @@ class webbrute(BaseModule):
     async def filter_event(self, event):
         if "endpoint" in event.tags:
             return False, "webbrute doesn't fuzz endpoints"
+        if self.config.get("avoid_wafs", True) and "waf" in event.tags:
+            return False, "host is behind a WAF"
+        netloc = event.parsed_url.netloc
+        if netloc in self._blocked_hosts:
+            return False, f"host [{netloc}] is blocked"
         if await self._is_http_wildcard_host(event) is True:
             return False, "host is an HTTP wildcard responder"
         return True
@@ -180,6 +191,7 @@ class webbrute(BaseModule):
         self,
         words,
         url,
+        netloc,
         prefix="",
         suffix="",
         exts=None,
@@ -194,6 +206,10 @@ class webbrute(BaseModule):
         proxy = self.scan.http_proxy or None
 
         for ext in exts:
+            if netloc in self._blocked_hosts:
+                self.debug(f"Host [{netloc}] is blocked, skipping remaining extensions")
+                return
+
             ext_filter = filters.get(ext, {})
             if ext_filter.get("abort"):
                 self.warning(f"Skipping fuzz for ext [{ext}]: {ext_filter.get('reason', 'ABORT')}")
@@ -225,6 +241,16 @@ class webbrute(BaseModule):
 
             self.debug(f"Fuzzing {len(configs)} URLs for ext [{ext}]")
 
+            # Hits are collected before emission, gated by three false-positive defenses:
+            #   1. Canary: a random word is injected into the wordlist. If it "hits",
+            #      the server is responding uniquely to everything, so all hits are junk.
+            #   2. Mid-scan baseline: after streaming, a fresh random URL is checked
+            #      against the baseline. If it no longer matches, the server's behavior
+            #      drifted during the scan (e.g. WAF kicked in), so hits are unreliable.
+            #   3. Hit cap: if the number of hits exceeds a sqrt-scaled threshold,
+            #      something slipped past the baseline (e.g. the server returns subtly
+            #      unique content per real word but not per random string). The host is
+            #      blocked and all hits are discarded before emission.
             canary_found = False
             hits = []
             async for result in iter_batch_results(
@@ -233,6 +259,11 @@ class webbrute(BaseModule):
                 if self.scan.stopping:
                     return
                 if not result.success:
+                    self._host_timeouts[netloc] = self._host_timeouts.get(netloc, 0) + 1
+                    if self._host_timeouts[netloc] >= 50:
+                        self.verbose(f"Host [{netloc}] has {self._host_timeouts[netloc]} timeouts, blocking host")
+                        self._blocked_hosts.add(netloc)
+                        return
                     continue
 
                 response = result.response
@@ -289,6 +320,17 @@ class webbrute(BaseModule):
                         f"Would have reported {len(hits)} hit(s), but mid-scan baseline check "
                         f"failed ({reasons}). Aborting the current run against [{url}]"
                     )
+                    return
+
+            # sqrt-scaled hit cap: ~28 at 50 words, ~40 at 100, ~126 at 1000, ~283 at 5000
+            if len(words) >= 50:
+                hit_cap = int(4 * (len(words) ** 0.5))
+                if len(hits) > hit_cap:
+                    self.warning(
+                        f"Discarding {len(hits)} hits for [{url}] ext [{ext}] "
+                        f"(exceeds cap of {hit_cap}), likely a filtering failure. Blocking host."
+                    )
+                    self._blocked_hosts.add(netloc)
                     return
 
             for hit in hits:

--- a/bbot/modules/webbrute_shortnames.py
+++ b/bbot/modules/webbrute_shortnames.py
@@ -161,6 +161,8 @@ class webbrute_shortnames(webbrute):
 
         self.per_host_collection = {}
         self.shortname_to_event = {}
+        self._host_timeouts = {}
+        self._blocked_hosts = set()
 
         return True
 
@@ -221,6 +223,7 @@ class webbrute_shortnames(webbrute):
 
         root_stub = "/".join(event.parsed_url.path.split("/")[:-1])
         root_url = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}{root_stub}/"
+        netloc = event.parsed_url.netloc
 
         if shortname_type == "endpoint":
             used_extensions = self.build_extension_list(event)
@@ -235,7 +238,7 @@ class webbrute_shortnames(webbrute):
         if words_len > 0:
             if shortname_type == "endpoint":
                 for ext in used_extensions:
-                    async for r in self.execute_fuzz(words, root_url, suffix=f".{ext}"):
+                    async for r in self.execute_fuzz(words, root_url, netloc, suffix=f".{ext}"):
                         await self.emit_event(
                             r["url"],
                             "URL_UNVERIFIED",
@@ -245,7 +248,7 @@ class webbrute_shortnames(webbrute):
                         )
 
             elif shortname_type == "directory":
-                async for r in self.execute_fuzz(words, root_url, exts=["/"]):
+                async for r in self.execute_fuzz(words, root_url, netloc, exts=["/"]):
                     r_url = f"{r['url'].rstrip('/')}/"
                     await self.emit_event(
                         r_url,
@@ -263,7 +266,7 @@ class webbrute_shortnames(webbrute):
                     self.verbose(f"Detected delimiter [{delimiter}] in hint [{filename_hint}]")
                     words, words_len = await self.generate_templist(partial_hint, "directory")
                     fuzz_prefix = f"{prefix}{delimiter}"
-                    async for r in self.execute_fuzz(words, root_url, prefix=fuzz_prefix, exts=["/"]):
+                    async for r in self.execute_fuzz(words, root_url, netloc, prefix=fuzz_prefix, exts=["/"]):
                         await self.emit_event(
                             r["url"],
                             "URL_UNVERIFIED",
@@ -280,7 +283,9 @@ class webbrute_shortnames(webbrute):
                         self.verbose(f"Detected delimiter [{delimiter}] in hint [{filename_hint}]")
                         words, words_len = await self.generate_templist(partial_hint, "endpoint")
                         fuzz_prefix = f"{prefix}{delimiter}"
-                        async for r in self.execute_fuzz(words, root_url, prefix=fuzz_prefix, suffix=f".{ext}"):
+                        async for r in self.execute_fuzz(
+                            words, root_url, netloc, prefix=fuzz_prefix, suffix=f".{ext}"
+                        ):
                             await self.emit_event(
                                 r["url"],
                                 "URL_UNVERIFIED",
@@ -294,7 +299,7 @@ class webbrute_shortnames(webbrute):
             if subword:
                 if "shortname-directory" in event.tags:
                     words, words_len = await self.generate_templist(suffix, "directory")
-                    async for r in self.execute_fuzz(words, root_url, prefix=subword, exts=["/"]):
+                    async for r in self.execute_fuzz(words, root_url, netloc, prefix=subword, exts=["/"]):
                         await self.emit_event(
                             r["url"],
                             "URL_UNVERIFIED",
@@ -305,7 +310,7 @@ class webbrute_shortnames(webbrute):
                 elif "shortname-endpoint" in event.tags:
                     for ext in used_extensions:
                         words, words_len = await self.generate_templist(suffix, "endpoint")
-                        async for r in self.execute_fuzz(words, root_url, prefix=subword, suffix=f".{ext}"):
+                        async for r in self.execute_fuzz(words, root_url, netloc, prefix=subword, suffix=f".{ext}"):
                             await self.emit_event(
                                 r["url"],
                                 "URL_UNVERIFIED",
@@ -327,6 +332,7 @@ class webbrute_shortnames(webbrute):
                     self.verbose(f"Found common prefix: [{prefix}] for host [{host}]")
                     for hint_tuple in hint_tuple_list:
                         hint, url = hint_tuple
+                        netloc = self.shortname_to_event[hint].parsed_url.netloc
                         if hint.startswith(prefix):
                             if "shortname-endpoint" in self.shortname_to_event[hint].tags:
                                 shortname_type = "endpoint"
@@ -347,7 +353,7 @@ class webbrute_shortnames(webbrute):
                                         f"Running common prefix check for URL_HINT: {hint} with prefix: {prefix} and partial_hint: {partial_hint}"
                                     )
 
-                                    async for r in self.execute_fuzz(words, url, prefix=prefix, exts=["/"]):
+                                    async for r in self.execute_fuzz(words, url, netloc, prefix=prefix, exts=["/"]):
                                         await self.emit_event(
                                             r["url"],
                                             "URL_UNVERIFIED",
@@ -362,7 +368,9 @@ class webbrute_shortnames(webbrute):
                                         self.verbose(
                                             f"Running common prefix check for URL_HINT: {hint} with prefix: {prefix}, extension: .{ext}, and partial_hint: {partial_hint}"
                                         )
-                                        async for r in self.execute_fuzz(words, url, prefix=prefix, suffix=f".{ext}"):
+                                        async for r in self.execute_fuzz(
+                                            words, url, netloc, prefix=prefix, suffix=f".{ext}"
+                                        ):
                                             await self.emit_event(
                                                 r["url"],
                                                 "URL_UNVERIFIED",

--- a/bbot/presets/kitchen-sink.yml
+++ b/bbot/presets/kitchen-sink.yml
@@ -20,6 +20,8 @@ config:
       recursive_mutations: true
     dnscommonsrv:
       recursive_mutations: true
+    webbrute:
+      avoid_wafs: False
     wayback:
       urls: True
       parameters: True

--- a/bbot/presets/web/dirbust-heavy.yml
+++ b/bbot/presets/web/dirbust-heavy.yml
@@ -16,6 +16,7 @@ config:
       # we exploit the shortnames vulnerability to produce URL_HINTs which are consumed by webbrute_shortnames
       detect_only: False
     webbrute:
+      avoid_wafs: False
       max_depth: 3
       lines: 5000
       extensions:

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_headers.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_headers.py
@@ -286,6 +286,16 @@ class TestParamminerHeadersDedupValueMutations(Paramminer_Headers):
         )
         assert hash_a != hash_d, "Same param keys on different paths should produce different dedup hashes"
 
+        # different focus name, same sibling keys (excavate emits one WP per param) -> distinct
+        hash_e, _ = pm._incoming_dedup_hash(
+            make_wp(
+                url="http://127.0.0.1:8888/page?culture=x&page=1",
+                name="page",
+                additional_params={"culture": "x"},
+            )
+        )
+        assert hash_a != hash_e, "Different focus name with same siblings should produce different dedup hashes"
+
         # HTTP_RESPONSE events: same endpoint collapses regardless
         hash_hr_a, _ = pm._incoming_dedup_hash(make_hr("http://127.0.0.1:8888/page"))
         hash_hr_b, _ = pm._incoming_dedup_hash(make_hr("http://127.0.0.1:8888/page"))

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_headers.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_headers.py
@@ -221,3 +221,78 @@ class TestParamminerHeadersWildcardSkip(ModuleTestBase):
     def check(self, module_test, events):
         web_params = [e for e in events if e.type == "WEB_PARAMETER" and str(e.module) == "paramminer_headers"]
         assert len(web_params) == 0, f"paramminer_headers should not fuzz wildcard hosts, but emitted: {web_params}"
+
+
+class TestParamminerHeadersDedupValueMutations(Paramminer_Headers):
+    """Value mutations of the same parameter set on the same endpoint should collapse to one test surface."""
+
+    async def setup_after_prep(self, module_test):
+        await super().setup_after_prep(module_test)
+        pm = module_test.scan.modules["paramminer_headers"]
+
+        def make_wp(**kwargs):
+            defaults = {"host": "127.0.0.1:8888", "type": "GETPARAM", "original_value": "x"}
+            defaults.update(kwargs)
+            return module_test.scan.make_event(defaults, "WEB_PARAMETER", dummy=True)
+
+        def make_hr(url):
+            return module_test.scan.make_event(
+                {
+                    "url": url,
+                    "status_code": 200,
+                    "header-dict": {},
+                    "body": "",
+                    "raw_header": "HTTP/1.1 200 OK\r\n\r\n",
+                    "method": "GET",
+                },
+                "HTTP_RESPONSE",
+                dummy=True,
+            )
+
+        # same endpoint, same param keys, different values (simulates lightfuzz probe cycling)
+        hash_a, _ = pm._incoming_dedup_hash(
+            make_wp(
+                url="http://127.0.0.1:8888/page?culture=probe_a&page=1",
+                name="culture",
+                additional_params={"page": "1"},
+            )
+        )
+        hash_b, _ = pm._incoming_dedup_hash(
+            make_wp(
+                url="http://127.0.0.1:8888/page?culture=probe_b&page=2",
+                name="culture",
+                additional_params={"page": "2"},
+            )
+        )
+        assert hash_a == hash_b, "Value mutations of same param keys should produce same dedup hash"
+
+        # different param keys on same path -> distinct
+        hash_c, _ = pm._incoming_dedup_hash(
+            make_wp(
+                url="http://127.0.0.1:8888/page?culture=x&page=1&csrf=tok",
+                name="culture",
+                additional_params={"page": "1", "csrf": "tok"},
+            )
+        )
+        assert hash_a != hash_c, "Different param key sets should produce different dedup hashes"
+
+        # different path, same keys -> distinct
+        hash_d, _ = pm._incoming_dedup_hash(
+            make_wp(
+                url="http://127.0.0.1:8888/other?culture=x&page=1",
+                name="culture",
+                additional_params={"page": "1"},
+            )
+        )
+        assert hash_a != hash_d, "Same param keys on different paths should produce different dedup hashes"
+
+        # HTTP_RESPONSE events: same endpoint collapses regardless
+        hash_hr_a, _ = pm._incoming_dedup_hash(make_hr("http://127.0.0.1:8888/page"))
+        hash_hr_b, _ = pm._incoming_dedup_hash(make_hr("http://127.0.0.1:8888/page"))
+        assert hash_hr_a == hash_hr_b, "HTTP_RESPONSE events for same endpoint should produce same dedup hash"
+
+        # WEB_PARAMETER and HTTP_RESPONSE for same URL should NOT collide
+        assert hash_a != hash_hr_a, "WEB_PARAMETER and HTTP_RESPONSE should not share dedup hashes"
+
+    def check(self, module_test, events):
+        super().check(module_test, events)

--- a/bbot/test/test_step_2/module_tests/test_module_webbrute.py
+++ b/bbot/test/test_step_2/module_tests/test_module_webbrute.py
@@ -252,6 +252,73 @@ class TestWebBruteHitCap(ModuleTestBase):
         )
 
 
+class TestWebBruteCanaryDefense(ModuleTestBase):
+    """Server returns unique content for EVERY path including random strings.
+    The canary fires and aborts, discarding all hits."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "webbrute"
+    test_wordlist = ["admin", "secret", "login"]
+    config_overrides = {"modules": {"webbrute": {"wordlist": tempwordlist(test_wordlist)}}}
+    modules_overrides = ["webbrute", "http"]
+
+    _counter = 0
+
+    def request_handler(self, request):
+        uri = request.path
+        if uri == "/":
+            return Response("<html>Home</html>", status=200)
+        # Every path (including random canary strings) gets unique content
+        # that differs structurally from the baseline, not just in a filterable position.
+        TestWebBruteCanaryDefense._counter += 1
+        n = TestWebBruteCanaryDefense._counter
+        extra = "".join(f"<p>Section {i}</p>\n" for i in range(n % 5 + 1))
+        body = f"<html><body><h1>Custom page #{n} for {uri}</h1>\n{extra}</body></html>"
+        return Response(body, status=200)
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests_handler(expect_args=re.compile("/.*"), request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        webbrute_urls = [e for e in events if e.type == "URL_UNVERIFIED" and str(e.module) == "webbrute"]
+        assert len(webbrute_urls) == 0, (
+            f"Canary defense should have aborted, but webbrute emitted: {[e.url for e in webbrute_urls]}"
+        )
+
+
+class TestWebBruteMidScanBaselineDrift(ModuleTestBase):
+    """Server matches baseline initially, then drifts (WAF kicks in after N requests).
+    Mid-scan baseline check should detect the drift and abort."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "webbrute"
+    test_wordlist = ["admin", "secret", "login"]
+    config_overrides = {"modules": {"webbrute": {"wordlist": tempwordlist(test_wordlist)}}}
+    modules_overrides = ["webbrute", "http"]
+
+    _request_count = 0
+
+    def request_handler(self, request):
+        uri = request.path
+        if uri == "/":
+            return Response("<html>Home</html>", status=200)
+        TestWebBruteMidScanBaselineDrift._request_count += 1
+        # First 4 requests: normal 404 (baseline probes + early fuzz).
+        # After that: WAF kicks in, returns block page for everything.
+        if TestWebBruteMidScanBaselineDrift._request_count <= 4:
+            return Response("Not Found", status=404)
+        return Response("<html>Access Denied by WAF</html>", status=200)
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests_handler(expect_args=re.compile("/.*"), request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        webbrute_urls = [e for e in events if e.type == "URL_UNVERIFIED" and str(e.module) == "webbrute"]
+        assert len(webbrute_urls) == 0, (
+            f"Mid-scan baseline drift should have aborted, but webbrute emitted: {[e.url for e in webbrute_urls]}"
+        )
+
+
 class TestWebBruteWildcardSkip(ModuleTestBase):
     """When the host is an HTTP wildcard, webbrute should skip fuzzing entirely."""
 

--- a/bbot/test/test_step_2/module_tests/test_module_webbrute.py
+++ b/bbot/test/test_step_2/module_tests/test_module_webbrute.py
@@ -214,6 +214,44 @@ class TestWebBruteDynamicContentFilter(ModuleTestBase):
         )
 
 
+class TestWebBruteHitCap(ModuleTestBase):
+    """Server returns unique content for every path, causing all words to pass
+    HttpCompare. The sqrt-scaled hit cap should detect this as a filtering
+    failure and discard everything before emission."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "webbrute"
+    # 50 words → cap of int(4 * sqrt(50)) = 28. All 50 will "hit", exceeding the cap.
+    test_wordlist = [f"word{i:03d}" for i in range(50)]
+    config_overrides = {"modules": {"webbrute": {"wordlist": tempwordlist(test_wordlist)}}}
+    modules_overrides = ["webbrute", "http"]
+
+    _counter = 0
+
+    def request_handler(self, request):
+        uri = request.path
+        if uri == "/":
+            return Response("<html>Home</html>", status=200)
+        # Return unique content only for wordlist words (word000-word049).
+        # Random strings (like the canary) get a normal 404 so the canary
+        # doesn't mask the hit cap.
+        segment = uri.strip("/")
+        if segment.startswith("word"):
+            TestWebBruteHitCap._counter += 1
+            body = f"<html><body>Unique page {TestWebBruteHitCap._counter} for {uri}</body></html>"
+            return Response(body, status=200)
+        return Response("Not Found", status=404)
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests_handler(expect_args=re.compile("/.*"), request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        webbrute_urls = [e for e in events if e.type == "URL_UNVERIFIED" and str(e.module) == "webbrute"]
+        assert len(webbrute_urls) == 0, (
+            f"Hit cap should have discarded all hits, but got: {[e.url for e in webbrute_urls]}"
+        )
+
+
 class TestWebBruteWildcardSkip(ModuleTestBase):
     """When the host is an HTTP wildcard, webbrute should skip fuzzing entirely."""
 

--- a/bbot/test/test_step_2/module_tests/test_module_webbrute.py
+++ b/bbot/test/test_step_2/module_tests/test_module_webbrute.py
@@ -168,6 +168,52 @@ class TestWebBruteWAFFalsePositive(ModuleTestBase):
         assert len(waf_hits) == 0, f"webbrute should filter WAF block pages, but got: {[e.url for e in waf_hits]}"
 
 
+class TestWebBruteDynamicContentFilter(ModuleTestBase):
+    """Server returns 200 with a per-request CSRF token for unknown paths.
+    Without HttpCompare, the baseline would fall through to status-only filtering
+    and report every 200 as a hit. HttpCompare should detect the token as a dynamic
+    position and filter it out, only reporting /admin (genuinely different content)."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "webbrute"
+    test_wordlist = ["admin", "junkword1", "zzzjunkword2"]
+    config_overrides = {"modules": {"webbrute": {"wordlist": tempwordlist(test_wordlist)}}}
+    modules_overrides = ["webbrute", "http"]
+
+    _counter = 0
+
+    def request_handler(self, request):
+        uri = request.path
+        if uri == "/":
+            return Response("<html>Home</html>", status=200)
+        if uri.lstrip("/").startswith("admin"):
+            return Response("<html><body>Admin Panel - Secret Content</body></html>", status=200)
+        TestWebBruteDynamicContentFilter._counter += 1
+        body = (
+            "<html>\n"
+            "<head><title>Page Not Found</title></head>\n"
+            "<body>\n"
+            "<p>The page you requested could not be found.</p>\n"
+            f'<input type="hidden" name="csrf" value="tok{TestWebBruteDynamicContentFilter._counter:06d}"/>\n'
+            "</body>\n"
+            "</html>"
+        )
+        return Response(body, status=200)
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests_handler(expect_args=re.compile("/.*"), request_handler=self.request_handler)
+
+    def check(self, module_test, events):
+        webbrute_urls = [e for e in events if e.type == "URL_UNVERIFIED" and str(e.module) == "webbrute"]
+        assert any("admin" in e.url for e in webbrute_urls), (
+            f"webbrute should find /admin (genuinely different), but got: {[e.url for e in webbrute_urls]}"
+        )
+        junk_hits = [e for e in webbrute_urls if "junkword" in e.url]
+        assert len(junk_hits) == 0, (
+            f"webbrute should filter dynamic-content false positives, but got: {[e.url for e in junk_hits]}"
+        )
+
+
 class TestWebBruteWildcardSkip(ModuleTestBase):
     """When the host is an HTTP wildcard, webbrute should skip fuzzing entirely."""
 

--- a/docs/modules/webbrute.md
+++ b/docs/modules/webbrute.md
@@ -1,0 +1,169 @@
+# Web Brute-Force (webbrute)
+
+## Overview
+
+`webbrute` is BBOT's built-in web directory and file brute-forcer, similar to tools like [ffuf](https://github.com/ffuf/ffuf) or [DirBuster](https://owasp.org/www-project-dirbuster/). It discovers hidden directories and files by sending a wordlist of common path names to a target and identifying responses that differ from the baseline (i.e., the server's default response to a nonexistent path).
+
+Unlike standalone tools, webbrute runs as part of BBOT's recursive pipeline. URLs discovered by other modules (spidering, wayback, etc.) are automatically fuzzed, and webbrute's discoveries feed back into the pipeline for further processing.
+
+Webbrute is powered by [blasthttp](https://github.com/blacklanternsecurity/blasthttp), our custom-built native Rust HTTP engine, giving it performance comparable to ffuf.
+
+## Quick Start
+
+```bash
+# Basic directory brute-force
+bbot -t example.com -m webbrute
+
+# With file extensions
+bbot -t example.com -m webbrute -c modules.webbrute.extensions=php,asp,jsp
+
+# Aggressive mode with larger wordlist and recursion
+bbot -t example.com -p dirbust-heavy
+```
+
+## Features
+
+### Extensions
+
+By default, webbrute tests each word as both a bare path (`/admin`) and as a directory (`/admin/`). You can add file extensions to also test paths like `/admin.php`, `/admin.asp`, etc.
+
+```yaml
+modules:
+  webbrute:
+    extensions:
+      - php
+      - asp
+      - aspx
+      - jsp
+```
+
+Each extension gets its own independent baseline, so a server that behaves differently for `.php` vs `.jsp` requests is handled correctly.
+
+### Recursive Fuzzing
+
+With `max_depth` set above 0, webbrute will recursively fuzz directories it discovers. For example, if it finds `/admin/`, it will fuzz `/admin/` with the same wordlist to discover `/admin/config/`, and so on up to the configured depth.
+
+```yaml
+modules:
+  webbrute:
+    max_depth: 3
+```
+
+### Wordlists
+
+The default wordlist is [raft-small-directories](https://github.com/danielmiessler/SecLists/tree/master/Discovery/Web-Content) from SecLists, limited to the first 5000 lines. You can specify a custom wordlist or merge multiple wordlists (duplicates are automatically removed):
+
+```yaml
+modules:
+  webbrute:
+    wordlist:
+      - https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/raft-small-directories.txt
+      - /path/to/custom-words.txt
+    lines: 10000
+```
+
+### Rate Limiting
+
+Webbrute respects BBOT's global `http_rate_limit` setting and also has its own per-module rate limit:
+
+```yaml
+modules:
+  webbrute:
+    rate: 100        # max requests per second (0 = unlimited)
+    concurrency: 50  # concurrent requests per URL
+```
+
+If both a module rate and a global rate are set, the more restrictive one wins.
+
+## WAF Detection and Avoidance
+
+Brute-forcing through a WAF wastes time and can get your IP blocked. Webbrute handles WAFs at multiple levels:
+
+### Pre-Scan: `avoid_wafs`
+
+When `avoid_wafs` is enabled (the default), webbrute skips any URL whose host has been tagged as being behind a WAF by BBOT's `cloudcheck` module. This prevents wasting thousands of requests against a host that will block them.
+
+```yaml
+modules:
+  webbrute:
+    avoid_wafs: true  # default
+```
+
+### Baseline: WAF Block Page and 429 Detection
+
+During baseline setup, webbrute checks whether the server's response to random paths contains known WAF block page signatures (detected via YARA rules). If the baseline itself is a WAF block page, the host is skipped immediately. The same check catches 429 (Too Many Requests) responses.
+
+### In-Stream: WAF Page Filtering
+
+During fuzzing, every response is checked against the same WAF YARA rules. Individual responses that match WAF signatures are silently filtered, even if they have a 200 status code. This catches WAFs that start blocking mid-scan after a burst of requests.
+
+### Timeout Tracking
+
+Some WAFs silently drop packets rather than returning error pages. Webbrute tracks connection failures per host across the entire scan. If a host accumulates 50 timeouts, it is blocked for the remainder of the scan, preventing the module from draining its entire wordlist against a dead connection.
+
+## False Positive Prevention
+
+Web brute-forcing is inherently noisy. Servers return custom error pages, dynamic content, and catch-all redirects that make it difficult to distinguish real hits from junk. Webbrute uses several layers of defense to prevent false positives.
+
+### Baseline Filtering (HttpCompare)
+
+Before fuzzing begins, webbrute sends two requests with random paths and uses HttpCompare (a DeepDiff-based response comparison engine) to diff them. Any positions that vary between the two (timestamps, CSRF tokens, request IDs) are marked as dynamic and excluded from future comparisons. During fuzzing, each response is compared against this baseline. Only responses that differ in non-dynamic ways (status code, headers, or body content) are considered potential hits.
+
+This catches a common class of false positives that simpler tools miss: servers that return 200 for all paths with subtly different content (e.g., a per-request CSRF token embedded in a custom 404 page).
+
+### Redirect-to-Root Filtering
+
+3xx responses that redirect to `/` or the base URL are filtered. This is a common catch-all pattern where servers redirect all unknown paths to the homepage.
+
+### Three-Layer Post-Stream Validation
+
+Hits are collected during the response stream but are not emitted immediately. Before anything reaches the rest of the pipeline, three checks run in sequence:
+
+1. **Canary check**: A random word is injected into the wordlist alongside the real words. If the canary word appears in the hits, it means the server is returning unique content for random paths too, and all hits are likely false positives. Everything is discarded.
+
+2. **Mid-scan baseline validation**: After streaming completes, a fresh random URL is sent and compared against the original baseline. If it no longer matches (e.g., a WAF started blocking mid-scan, or the server's behavior changed), the baseline has drifted and the hits are unreliable. Everything is discarded.
+
+3. **Hit cap**: If the number of hits exceeds a threshold scaled to the wordlist size (`4 * sqrt(wordlist_length)`), something has slipped past the other defenses. This catches edge cases where the server returns subtly unique content for real dictionary words but not for random strings. The host is blocked and all hits are discarded before emission.
+
+## Configuration Reference
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `wordlist` | string or list | raft-small-directories | Wordlist URL(s) or path(s). Multiple wordlists are merged with deduplication. |
+| `lines` | int | 5000 | Use only the first N lines from the wordlist. |
+| `max_depth` | int | 0 | Maximum directory depth for recursive fuzzing. 0 = root only. |
+| `extensions` | string or list | (none) | File extensions to append (e.g., `php,asp,jsp`). |
+| `ignore_case` | bool | false | Lowercase all wordlist entries (deduplicates case variants). |
+| `rate` | int | 0 | Max requests per second. 0 = unlimited (subject to global `http_rate_limit`). |
+| `concurrency` | int | 50 | Number of concurrent requests per URL being fuzzed. |
+| `avoid_wafs` | bool | true | Skip URLs behind confirmed WAFs. |
+
+## Presets
+
+BBOT includes two presets for directory brute-forcing:
+
+### `dirbust-light`
+
+Surface-level directory discovery with a smaller wordlist. Good for quick scans.
+
+- Wordlist: raft-small-directories (first 1000 lines)
+- No extensions, no recursion
+- WAF avoidance enabled
+
+```bash
+bbot -t example.com -p dirbust-light
+```
+
+### `dirbust-heavy`
+
+Aggressive recursive brute-forcing with a large extension list. Includes spidering and wayback URL extraction to discover additional directories to fuzz. WAF avoidance is disabled so brute-forcing proceeds even against WAF-protected hosts.
+
+- Wordlist: raft-small-directories (first 5000 lines)
+- Extensions: php, asp, aspx, ashx, asmx, jsp, jspx, cfm, zip, conf, config, xml, json, yml, yaml
+- Recursive to depth 3
+- Includes spider and wayback modules
+- `avoid_wafs` disabled
+
+```bash
+bbot -t example.com -p dirbust-heavy
+```


### PR DESCRIPTION
## Summary

Overhauls webbrute's false-positive prevention based on field testing against real scan data.

- **HttpCompare baseline**: Replaces the old strict size/words/lines equality cascade with HttpCompare (DeepDiff-based). Two baseline requests are diffed to detect dynamic positions (CSRF tokens, timestamps, etc.), which are excluded from future comparisons. This eliminates false-positive floods from servers with per-request dynamic content.

- **Three-layer post-stream validation**: Hits are collected before emission and gated by three checks:
  1. **Canary** -- a random word injected into the wordlist; if it "hits", all results are junk
  2. **Mid-scan baseline** -- a fresh random URL is re-checked after streaming; if it no longer matches baseline, the server's behavior drifted
  3. **Hit cap** -- sqrt-scaled threshold (`4 * sqrt(wordlist_length)`); catches edge cases where the server returns unique content for real words but not random strings

- **WAF avoidance** (`avoid_wafs`, default true): Skips hosts tagged as WAF by cloudcheck. Disabled in `dirbust-heavy` and `kitchen-sink` presets.

- **Host-level timeout tracking**: Blocks hosts after 50 connection failures (catches packet-dropping WAFs).

- **HttpCompare fix**: Added `Connection` header to the ignore list -- Apache sends `Connection: close` under load, causing spurious header diffs.

- **Docs**: Added `docs/modules/webbrute.md` covering features, configuration, WAF handling, and false-positive prevention.

- **Tests**: 9 tests total (4 pre-existing + 5 new), covering dynamic content filtering, WAF pages, redirect-to-root, wildcard skip, and hit cap validation.