### PR TITLE
Fix CLA check failing for org member commits on external PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -34,13 +34,14 @@ jobs:
 
           COMMITTERS=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUM/commits" --paginate --jq '.[].author.login' | sort -u)
           ALL_EXEMPT=true
+          EXEMPT_LOGINS=""
 
           for LOGIN in $COMMITTERS; do
             # treat commits with no associated GitHub login as non-exempt
             if [ -z "$LOGIN" ] || [ "$LOGIN" = "null" ]; then
               echo "Unknown committer (no GitHub login) — not exempt"
               ALL_EXEMPT=false
-              break
+              continue
             fi
 
             EXEMPT=false
@@ -60,14 +61,16 @@ jobs:
               fi
             fi
 
-            if [ "$EXEMPT" = "false" ]; then
+            if [ "$EXEMPT" = "true" ]; then
+              EXEMPT_LOGINS="${EXEMPT_LOGINS:+$EXEMPT_LOGINS,}$LOGIN"
+            else
               echo "$LOGIN is not exempt — CLA required"
               ALL_EXEMPT=false
-              break
             fi
           done
 
           echo "all_exempt=$ALL_EXEMPT" >> "$GITHUB_OUTPUT"
+          echo "exempt_logins=$EXEMPT_LOGINS" >> "$GITHUB_OUTPUT"
 
       - name: Skip CLA when all committers are exempt
         if: steps.cla-check.outputs.all_exempt == 'true' && github.event_name == 'pull_request_target'
@@ -91,7 +94,7 @@ jobs:
           path-to-signatures: "signatures/version1/cla.json"
           path-to-document: "https://github.com/blacklanternsecurity/CLA/blob/main/ICLA.md"
           branch: "main"
-          allowlist: "dependabot[bot],github-actions[bot],renovate[bot]"
+          allowlist: "dependabot[bot],github-actions[bot],renovate[bot],${{ steps.cla-check.outputs.exempt_logins }}"
           remote-organization-name: "blacklanternsecurity"
           remote-repository-name: "CLA"
           lock-pullrequest-aftermerge: "false"


### PR DESCRIPTION
## Summary

- Fixes the CLA workflow falsely flagging org members (e.g. `liquidsec`) as unsigned when they commit to a PR opened by an external contributor
- The pre-check step already identifies org members as exempt, but previously didn't pass that information to the CLA Assistant action — which re-evaluated all committers against a hardcoded bot-only allowlist
- Collects exempt logins (org members + bots) during the pre-check loop and appends them to the CLA Assistant's `allowlist` parameter
- Changes `break` to `continue` so all committers are checked instead of stopping at the first non-exempt one

## Context

Observed on PR #3144 — `liquidsec` merged `dev` into the branch, adding his commits. The CLA bot then flagged him as unsigned despite being a BLS org member, because the CLA Assistant step's allowlist only contained `dependabot[bot],github-actions[bot],renovate[bot]`.

**Note:** The same bug exists in other BLS repos that copied this workflow (e.g. `baddns`, `blockbuster`). The master template in `blacklanternsecurity/.github` uses a simpler author-only check that avoids this, but doesn't cover all committers. Those repos may want the same fix.

## Test plan

- [ ] Retrigger CLA check on PR #3144 — `liquidsec` should now be allowlisted and only `thunderstornX` should be evaluated for CLA signature
- [ ] Verify a PR with only org-member commits still skips CLA entirely (existing behavior, unchanged)
- [ ] Verify a PR from a new external contributor still requires CLA signature