### PR TITLE
Add permissions block to CLA caller workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  pull-requests: write
+  statuses: write
+
 jobs:
   cla:
     uses: blacklanternsecurity/.github/.github/workflows/cla-reusable.yml@main


### PR DESCRIPTION
## Summary

The reusable CLA workflow needs `pull-requests: write` and `statuses: write` permissions, but reusable workflows inherit permissions from the caller. Without the caller declaring them, the workflow fails with a silent "workflow file issue" error.

## Test plan

- [ ] Merge this PR
- [ ] Comment `recheck` on PR #3144
- [ ] Verify the CLA workflow actually runs (not instant 0s failure)