### PR TITLE
Fix version updater workflow for pydantic config format

### DIFF
--- a/.github/workflows/version_updater.yml
+++ b/.github/workflows/version_updater.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Get current version
         id: get-current-version
         run: |
-          version=$(grep -m 1 -oP '(?<=version": ")[^"]*' bbot/modules/nuclei.py)
+          version=$(grep -m 1 -oP '(?<=Field\(")[^"]*' bbot/modules/nuclei.py)
           echo "current_version=$version" >> $GITHUB_ENV
       - name: Update version
         id: update-version
         if: env.latest_version != env.current_version
-        run: "sed -i '0,/\"version\": \".*\",/ s/\"version\": \".*\",/\"version\": \"${{ env.latest_version }}\",/g' bbot/modules/nuclei.py"
+        run: "sed -i '0,/Field(\"[^\"]*\",/ s/Field(\"[^\"]*\",/Field(\"${{ env.latest_version }}\",/' bbot/modules/nuclei.py"
       - name: Create pull request to update the version
         if: steps.update-version.outcome == 'success'
         uses: peter-evans/create-pull-request@v8
@@ -88,12 +88,12 @@ jobs:
       - name: Get current version
         id: get-current-version
         run: |
-          version=$(grep -m 1 -oP '(?<=version": ")[^"]*' bbot/modules/trufflehog.py)
+          version=$(grep -m 1 -oP '(?<=Field\(")[^"]*' bbot/modules/trufflehog.py)
           echo "current_version=$version" >> $GITHUB_ENV
       - name: Update version
         id: update-version
         if: env.latest_version != env.current_version
-        run: "sed -i '0,/\"version\": \".*\",/ s/\"version\": \".*\",/\"version\": \"${{ env.latest_version }}\",/g' bbot/modules/trufflehog.py"
+        run: "sed -i '0,/Field(\"[^\"]*\",/ s/Field(\"[^\"]*\",/Field(\"${{ env.latest_version }}\",/' bbot/modules/trufflehog.py"
       - name: Create pull request to update the version
         if: steps.update-version.outcome == 'success'
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
## Summary

The daily version updater workflow (nuclei + trufflehog) broke when module configs migrated from `options` dicts to pydantic `Field(...)` syntax. The `grep` and `sed` patterns still looked for `"version": "..."` which no longer exists in the files, so version detection silently failed and PRs stopped updating. This is why PR #2739 has been stuck.

Updates both jobs to match the new `Field("version", ...)` format.