### PR TITLE
Fix CLA: move reusable workflow reference to CLA repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,11 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  pull-requests: write
+  statuses: write
+
 jobs:
   cla:
-    uses: blacklanternsecurity/.github/.github/workflows/cla-reusable.yml@main
+    uses: blacklanternsecurity/CLA/.github/workflows/cla-reusable.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

The previous reference `blacklanternsecurity/.github/.github/workflows/cla-reusable.yml@main` failed silently — GitHub couldn't resolve the double `.github` in the path, causing every CLA run to fail with "workflow file issue" and zero jobs.

This points the caller at `blacklanternsecurity/CLA/.github/workflows/cla-reusable.yml@main` instead. The CLA repo is public, already stores the CLA document and signatures, and is the natural home for the reusable workflow.

## Test plan

- [ ] Merge this PR
- [ ] Comment `recheck` on PR #3144
- [ ] Verify the CLA workflow actually runs and `liquidsec` is exempt