### PR TITLE
Fix CLA: use reusable workflow from CLA repo

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,11 @@ on:
   pull_request_target:
     types: [opened, closed, synchronize]
 
+permissions:
+  pull-requests: write
+  statuses: write
+
 jobs:
   cla:
-    uses: blacklanternsecurity/.github/.github/workflows/cla-reusable.yml@main
+    uses: blacklanternsecurity/CLA/.github/workflows/cla-reusable.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Replaces the inline CLA workflow on `dev` with a thin caller pointing at `blacklanternsecurity/CLA/.github/workflows/cla-reusable.yml@main`.

Since `pull_request_target` runs the workflow from the **base branch** of the PR, this fix must land on `dev` for dev-targeted PRs (like #3144) to pick it up. PR #3174 covers `stable`.

The reusable workflow in the CLA repo includes the org-member allowlist fix — org members who commit to external contributor PRs will no longer be falsely flagged.

## Test plan

- [ ] Merge this PR and #3174 (stable)
- [ ] Comment `recheck` on PR #3144
- [ ] Verify `liquidsec` is exempt and only `thunderstornX` is evaluated