### PR TITLE
Bump trufflehog to 3.95.5, stop removing .git/index in sanitize_git_repo

### DIFF
--- a/bbot/core/helpers/git.py
+++ b/bbot/core/helpers/git.py
@@ -7,10 +7,8 @@ def sanitize_git_repo(repo_folder: Path):
     config_file = repo_folder / ".git" / "config"
     if config_file.exists():
         config_file.rename(repo_folder / "git_config_original")
-    # move the index file
-    index_file = repo_folder / ".git" / "index"
-    if index_file.exists():
-        index_file.rename(repo_folder / "git_index_original")
+    # leave .git/index in place -- it's binary metadata (filename-to-SHA mappings),
+    # not a security risk, and removing it breaks tools that need to clone the repo
     # move the hooks folder
     hooks_folder = repo_folder / ".git" / "hooks"
     if hooks_folder.exists():

--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -15,7 +15,7 @@ class trufflehog(BaseModule):
     }
 
     class Config(BaseModuleConfig):
-        version: str = Field("3.90.8", description="trufflehog version")
+        version: str = Field("3.95.5", description="trufflehog version")
         config: str = Field("", description="File path or URL to YAML trufflehog config")
         only_verified: bool = Field(True, description="Only report credentials that have been verified")
         concurrency: int = Field(8, description="Number of concurrent workers")


### PR DESCRIPTION
## Summary
- Bump trufflehog from 3.90.8 to 3.95.5
- Stop removing `.git/index` during repo sanitization

Trufflehog 3.95.5 clones local `file://` repos before scanning (their fix
for malicious git config execution, PR trufflesecurity/trufflehog#4502).
BBOT's `sanitize_git_repo()` was removing `.git/index`, which broke this
clone step. The index file is binary metadata (filename-to-SHA mappings)
with no execution path, so leaving it in place has no security impact.
The actual attack vectors (`.git/config`, `.git/hooks/`) remain sanitized.