### PR TITLE
Add content-based dedup for modules

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -1815,7 +1815,6 @@ class HTTP_RESPONSE(URL_UNVERIFIED):
             self._data.pop("body", None)
             self._data.pop("raw_header", None)
             self._data.pop("header", None)
-            self._data.pop("hash", None)
             self._data.pop("cert_info", None)
 
     @property

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -106,6 +106,7 @@ class BaseModule:
     target_only = False
     in_scope_only = False
     accept_url_special = False
+    _avoid_duplicate_content = False
     _module_threads = 1
     _batch_size = 1
 
@@ -144,6 +145,7 @@ class BaseModule:
         self._outgoing_event_queue = None
         # track incoming events to prevent unwanted duplicates
         self._incoming_dup_tracker = set()
+        self._content_dup_tracker = set()
         # tracks which subprocesses are running under this module
         self._proc_tracker = set()
         # seconds since we've submitted a batch
@@ -1148,6 +1150,15 @@ class BaseModule:
         is_dup = event_hash in self._incoming_dup_tracker
         if add:
             self._incoming_dup_tracker.add(event_hash)
+        if not is_dup and self._avoid_duplicate_content:
+            body_hash = event.data.get("hash", {}).get("body_mmh3", "") if isinstance(event.data, dict) else ""
+            if body_hash:
+                content_key = hash((event.host, body_hash))
+                if content_key in self._content_dup_tracker:
+                    is_dup = True
+                    reason = f"duplicate content (body_hash={body_hash})"
+                if add:
+                    self._content_dup_tracker.add(content_key)
         return is_dup, reason
 
     def _incoming_dedup_hash(self, event):
@@ -1981,6 +1992,3 @@ class BaseInterceptModule(BaseModule):
             self.incoming_event_queue.put_nowait((event, kwargs))
         except AttributeError:
             self.debug("Not in an acceptable state to queue incoming event")
-
-    async def _event_postcheck(self, event):
-        return await self._event_postcheck_inner(event)

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1151,9 +1151,10 @@ class BaseModule:
         if add:
             self._incoming_dup_tracker.add(event_hash)
         if not is_dup and self._avoid_duplicate_content:
-            body_hash = event.data.get("hash", {}).get("body_mmh3", "") if isinstance(event.data, dict) else ""
+            hash_dict = event.data.get("hash") if isinstance(event.data, dict) else None
+            body_hash = hash_dict.get("body_sha256", "") if isinstance(hash_dict, dict) else ""
             if body_hash:
-                content_key = hash((event.host, body_hash))
+                content_key = hash((event.host, event.port, body_hash))
                 if content_key in self._content_dup_tracker:
                     is_dup = True
                     reason = f"duplicate content (body_hash={body_hash})"

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1147,13 +1147,15 @@ class BaseModule:
             return True, msg
         with suppress(TypeError, ValueError):
             event_hash, reason = event_hash
-        is_dup = event_hash in self._incoming_dup_tracker
-        if add:
+        is_post = isinstance(event.data, dict) and event.data.get("method", "") == "POST"
+        is_dup = event_hash in self._incoming_dup_tracker and not is_post
+        if add and not is_post:
             self._incoming_dup_tracker.add(event_hash)
         if not is_dup and self._avoid_duplicate_content:
             hash_dict = event.data.get("hash") if isinstance(event.data, dict) else None
             body_hash = hash_dict.get("body_sha256", "") if isinstance(hash_dict, dict) else ""
-            if body_hash:
+            # skip dedup for empty bodies (e.g. 302 redirects) where the useful data is in headers
+            if body_hash and body_hash != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855":
                 content_key = hash((event.host, event.port, body_hash))
                 if content_key in self._content_dup_tracker:
                     is_dup = True

--- a/bbot/modules/http.py
+++ b/bbot/modules/http.py
@@ -153,6 +153,9 @@ class http(BaseModule):
             location = j.get("location", "")
             if location:
                 url_event.redirect_location = location
+            response_hash = j.get("hash")
+            if response_hash:
+                url_event.data["hash"] = response_hash
             if url_event != parent_event:
                 await self.emit_event(url_event)
             content_type = j.get("header", {}).get("content_type", "unspecified").split(";")[0]

--- a/bbot/modules/internal/excavate.py
+++ b/bbot/modules/internal/excavate.py
@@ -365,6 +365,7 @@ class excavate(BaseInternalModule, BaseInterceptModule):
 
     watched_events = ["HTTP_RESPONSE", "RAW_TEXT"]
     produced_events = ["URL_UNVERIFIED", "WEB_PARAMETER"]
+    _avoid_duplicate_content = True
     flags = ["safe", "passive"]
     meta = {
         "description": "Passively extract juicy tidbits from scan data",

--- a/bbot/scanner/manager.py
+++ b/bbot/scanner/manager.py
@@ -156,6 +156,9 @@ class ScanIngress(BaseInterceptModule):
                 continue
         raise asyncio.queues.QueueEmpty()
 
+    async def _event_postcheck(self, event):
+        return await self._event_postcheck_inner(event)
+
     def is_incoming_duplicate(self, event, add=False):
         """
         Calculate whether an event is a duplicate in the context of the module that emitted it

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -1924,3 +1924,144 @@ class TestExcavateHttpWildcardSkipsUrls(ModuleTestBase):
         assert any(e.type == "DNS_NAME" and e.data == "extracted.test.notreal" for e in events), (
             "Excavate should still extract DNS_NAMEs from HTTP wildcard host responses"
         )
+
+
+
+class TestExcavateContentDedup(ModuleTestBase):
+    """Verify _avoid_duplicate_content=True on excavate skips HTTP_RESPONSE events with duplicate body hashes."""
+
+    targets = [
+        "http://127.0.0.1:8888/dir1/page.html",
+        "http://127.0.0.1:8888/dir2/page.html",
+        "http://127.0.0.1:8888/other/page.html",
+    ]
+    modules_overrides = ["excavate", "http"]
+    config_overrides = {"web": {"spider_distance": 0, "spider_depth": 0}, "omit_event_types": []}
+
+    duplicate_body = "<html><body><a href='./found.html'>click</a></body></html>"
+    unique_body = "<html><body><a href='./unique.html'>click</a></body></html>"
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/dir1/page.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/dir2/page.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/other/page.html"},
+            respond_args={"response_data": self.unique_body},
+        )
+        module_test.httpserver.no_handler_status_code = 404
+
+    def check(self, module_test, events):
+        excavate = module_test.scan.modules["excavate"]
+        assert len(excavate._content_dup_tracker) > 0, "Content dedup tracker was empty"
+
+        url_events = [e for e in events if e.type == "URL_UNVERIFIED"]
+        urls = {e.url for e in url_events}
+
+        assert "http://127.0.0.1:8888/other/unique.html" in urls, "Unique page link not extracted"
+
+        dir1_found = "http://127.0.0.1:8888/dir1/found.html" in urls
+        dir2_found = "http://127.0.0.1:8888/dir2/found.html" in urls
+        assert dir1_found or dir2_found, "Neither duplicate page was processed"
+        assert not (dir1_found and dir2_found), (
+            "Both duplicate pages were processed — content dedup failed to skip the second one"
+        )
+
+
+class TestExcavateContentDedupDisabled(ModuleTestBase):
+    """Verify that with _avoid_duplicate_content=False, duplicate content on different URLs is NOT deduped."""
+
+    targets = [
+        "http://127.0.0.1:8888/dir1/page.html",
+        "http://127.0.0.1:8888/dir2/page.html",
+    ]
+    modules_overrides = ["excavate", "http"]
+    config_overrides = {"web": {"spider_distance": 0, "spider_depth": 0}, "omit_event_types": []}
+
+    duplicate_body = "<html><body><a href='./found.html'>click</a></body></html>"
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/dir1/page.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/dir2/page.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.httpserver.no_handler_status_code = 404
+
+    async def setup_after_prep(self, module_test):
+        module_test.scan.modules["excavate"]._avoid_duplicate_content = False
+
+    def check(self, module_test, events):
+        url_events = [e for e in events if e.type == "URL_UNVERIFIED"]
+        urls = {e.url for e in url_events}
+
+        dir1_found = "http://127.0.0.1:8888/dir1/found.html" in urls
+        dir2_found = "http://127.0.0.1:8888/dir2/found.html" in urls
+        assert dir1_found and dir2_found, (
+            f"Both duplicate pages should be processed when _avoid_duplicate_content=False, "
+            f"got dir1={dir1_found}, dir2={dir2_found}"
+        )
+
+
+class TestContentDedupWithURLEvents(ModuleTestBase):
+    """Verify _avoid_duplicate_content works for modules watching URL events (via body_mmh3 hash)."""
+
+    targets = [
+        "http://127.0.0.1:8888/page1.html",
+        "http://127.0.0.1:8888/page2.html",
+        "http://127.0.0.1:8888/different.html",
+    ]
+    modules_overrides = ["excavate", "http"]
+    config_overrides = {"web": {"spider_distance": 0, "spider_depth": 0}, "omit_event_types": []}
+
+    duplicate_body = "<html><body>identical content</body></html>"
+    unique_body = "<html><body>different content</body></html>"
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/page1.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/page2.html"},
+            respond_args={"response_data": self.duplicate_body},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/different.html"},
+            respond_args={"response_data": self.unique_body},
+        )
+        module_test.httpserver.no_handler_status_code = 404
+
+    async def setup_after_prep(self, module_test):
+        class URLConsumer(BaseModule):
+            watched_events = ["URL"]
+            _name = "url_consumer"
+            _avoid_duplicate_content = True
+            events_seen = []
+
+            async def handle_event(self, event):
+                self.events_seen.append(event)
+
+        module_test.scan.modules["url_consumer"] = URLConsumer(module_test.scan)
+
+    def check(self, module_test, events):
+        consumer = module_test.scan.modules["url_consumer"]
+        seen_urls = {e.url for e in consumer.events_seen if e.type == "URL"}
+
+        assert "http://127.0.0.1:8888/different.html" in seen_urls, "Unique URL should be processed"
+
+        page1_seen = "http://127.0.0.1:8888/page1.html" in seen_urls
+        page2_seen = "http://127.0.0.1:8888/page2.html" in seen_urls
+        assert page1_seen or page2_seen, "At least one duplicate-content URL should be processed"
+        assert not (page1_seen and page2_seen), (
+            "Both duplicate-content URLs were processed — content dedup failed for URL events"
+        )
+        assert len(consumer._content_dup_tracker) > 0, "Content dedup tracker should have entries"

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -1926,7 +1926,6 @@ class TestExcavateHttpWildcardSkipsUrls(ModuleTestBase):
         )
 
 
-
 class TestExcavateContentDedup(ModuleTestBase):
     """Verify _avoid_duplicate_content=True on excavate skips HTTP_RESPONSE events with duplicate body hashes."""
 

--- a/bbot/test/test_step_2/module_tests/test_module_excavate.py
+++ b/bbot/test/test_step_2/module_tests/test_module_excavate.py
@@ -2012,7 +2012,7 @@ class TestExcavateContentDedupDisabled(ModuleTestBase):
 
 
 class TestContentDedupWithURLEvents(ModuleTestBase):
-    """Verify _avoid_duplicate_content works for modules watching URL events (via body_mmh3 hash)."""
+    """Verify _avoid_duplicate_content works for modules watching URL events (via body_sha256 hash)."""
 
     targets = [
         "http://127.0.0.1:8888/page1.html",


### PR DESCRIPTION
## Summary

- Adds a reusable `_avoid_duplicate_content = True` class-level toggle on `BaseModule` that skips processing events with identical response bodies (by `body_mmh3` hash) on the same host. Enabled on `excavate` to avoid redundant extraction on duplicate pages (e.g. SPA product pages with identical templates).
- Copies the response hash dict onto URL events in the http module, so both URL and HTTP_RESPONSE events carry hashes in the same `data["hash"]` structure.
- **Bug fix:** `BaseInterceptModule._event_postcheck` was skipping `is_incoming_duplicate()` entirely, making excavate's `accept_dupes = False` dead code since it was converted to an intercept module. Removed the override so intercept modules now run the standard dedup path. `ScanIngress` retains its own override since it handles dedup separately in `handle_event`.