### PR TITLE
Fix dnscaa crash on unrecognized CAA properties

### DIFF
--- a/bbot/modules/dnscaa.py
+++ b/bbot/modules/dnscaa.py
@@ -67,8 +67,21 @@ class dnscaa(BaseModule):
             if not isinstance(caa, dict):
                 continue
 
-            tag = (caa.get("tag") or "").lower()
+            raw_tag = caa.get("tag")
+            # hickory wraps unrecognized CAA properties as {"Unknown": "name"}
+            if isinstance(raw_tag, dict):
+                raw_tag = raw_tag.get("Unknown", "")
+            if not isinstance(raw_tag, str):
+                continue
+            tag = raw_tag.lower()
+
             value = caa.get("value") or {}
+            # hickory wraps unrecognized values as {"Unknown": [byte_array]}
+            if isinstance(value, dict) and isinstance(value.get("Unknown"), list):
+                try:
+                    value = {"raw_text": bytes(value["Unknown"]).decode()}
+                except (ValueError, UnicodeDecodeError):
+                    continue
 
             # iodef -> "Url" containing mailto: or https:// for incident reporting
             if tag == "iodef":
@@ -89,6 +102,15 @@ class dnscaa(BaseModule):
                                 tags=tags,
                                 parent=event,
                             )
+
+            # contactemail (RFC 8657) -> email for CA to contact domain owner
+            elif tag == "contactemail":
+                raw_text = value.get("raw_text") if isinstance(value, dict) else None
+                if raw_text and self._emails:
+                    for match in email_regex.finditer(raw_text):
+                        await self.emit_event(
+                            raw_text[match.start() : match.end()], "EMAIL_ADDRESS", tags=tags, parent=event
+                        )
 
             # issue / issuewild -> "Issuer" containing the CA's domain
             elif tag.startswith("issue"):

--- a/bbot/test/test_step_2/module_tests/test_module_dnscaa.py
+++ b/bbot/test/test_step_2/module_tests/test_module_dnscaa.py
@@ -22,6 +22,9 @@ class TestDNSCAA(ModuleTestBase):
                         '1 issue "digicert.com; cansignhttpexchanges=yes"',
                         '0 issuewild "letsencrypt.org"',
                         '128 issuewild "pki.goog; cansignhttpexchanges=yes"',
+                        '0 contactemail "contact@blacklanternsecurity.notreal"',
+                        '0 contactphone "+1-555-123-4567"',
+                        '0 somefuturetag "whatever"',
                     ],
                 },
                 "caa.blacklanternsecurity.notreal": {"A": ["127.0.0.22"]},
@@ -50,6 +53,9 @@ class TestDNSCAA(ModuleTestBase):
         ), "Failed to detect URL"
         assert any(e.type == "EMAIL_ADDRESS" and e.data == "caa@blacklanternsecurity.notreal" for e in events), (
             "Failed to detect email address"
+        )
+        assert any(e.type == "EMAIL_ADDRESS" and e.data == "contact@blacklanternsecurity.notreal" for e in events), (
+            "Failed to detect contactemail address"
         )
         # make sure we're not checking CAA records for out-of-scope hosts
         assert not any(str(e.host) == "caa.comodoca.com" for e in events)


### PR DESCRIPTION
## Summary

- Hickory-dns wraps unrecognized CAA property tags (e.g. `contactemail`, `contactphone`) as `{"Unknown": "name"}` instead of a plain string, causing `'dict' object has no attribute 'lower'` in `handle_event`
- Unwrap the `Unknown` dict for both tag and value fields
- Extract emails from `contactemail` records (RFC 8657)
- Unknown properties with no handler are silently skipped

Closes #3191