### PR TITLE
Fix distro test failures: Fedora SSL issue, remove Parrot (rip)

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -23,8 +23,11 @@ jobs:
             . /etc/os-release
             if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ] || [ "$ID" = "kali" ] || [ "$ID" = "parrotsec" ]; then
               export DEBIAN_FRONTEND=noninteractive
-              apt-get update
-              apt-get -y install curl git bash build-essential docker.io libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev
+              for attempt in 1 2 3; do
+                apt-get update && apt-get -y install curl git bash build-essential docker.io libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev && break
+                echo "apt-get failed (attempt $attempt/3), retrying in 10s..."
+                sleep 10
+              done
             elif [ "$ID" = "alpine" ]; then
               apk add --no-cache bash gcc g++ musl-dev libffi-dev docker curl git make openssl-dev bzip2-dev zlib-dev xz-dev sqlite-dev
             elif [ "$ID" = "arch" ]; then
@@ -38,33 +41,18 @@ jobs:
             fi
           fi
 
-          # Re-run the script with bash
-          exec bash -c "
-            curl https://pyenv.run | bash
-            export PATH=\"$HOME/.pyenv/bin:\$PATH\"
-            export PATH=\"$HOME/.local/bin:\$PATH\"
-            eval \"\$(pyenv init --path)\"
-            eval \"\$(pyenv init -)\"
-            eval \"\$(pyenv virtualenv-init -)\"
-            pyenv install 3.11
-            pyenv global 3.11
-            pyenv rehash
-            python3.11 -m pip install --user pipx
-            python3.11 -m pipx ensurepath
-            pipx install uv
-          "
+          # Install uv (standalone binary, no Python prerequisite)
+          curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Set OS Environment Variable
         run: echo "OS_NAME=${{ matrix.os }}" | sed 's|[:/]|_|g' >> $GITHUB_ENV
       - name: Run tests
         run: |
-          # Preserve pyenv/pipx paths installed under the GitHub-set HOME
           export PATH="/github/home/.local/bin:$PATH"
-          export PATH="/github/home/.pyenv/bin:$PATH"
-          export PATH="/github/home/.pyenv/shims:$PATH"
           # Fix HOME to match euid (root) so rustup/cargo don't refuse to build
           export HOME="$(getent passwd $(whoami) | cut -d: -f6)"
           export BBOT_DISTRO_TESTS=true
-          uv python pin 3.11
+          uv python install 3.12
+          uv python pin 3.12
           uv sync --group dev
           uv run pytest --reruns 2 --exitfirst -o timeout_func_only=true --timeout 1200 --disable-warnings --log-cli-level=INFO .
       - name: Upload Debug Logs

--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -14,20 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu:22.04", "ubuntu:24.04", "debian", "archlinux", "fedora", "kalilinux/kali-rolling", "parrotsec/security"]
+        os: ["ubuntu:22.04", "ubuntu:24.04", "debian", "archlinux", "fedora", "kalilinux/kali-rolling"]
     steps:
       - uses: actions/checkout@v6
       - name: Install Python and uv
         run: |
           if [ -f /etc/os-release ]; then
             . /etc/os-release
-            if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ] || [ "$ID" = "kali" ] || [ "$ID" = "parrotsec" ]; then
+            if [ "$ID" = "ubuntu" ] || [ "$ID" = "debian" ] || [ "$ID" = "kali" ]; then
               export DEBIAN_FRONTEND=noninteractive
-              for attempt in 1 2 3; do
-                apt-get update && apt-get -y install curl git bash build-essential docker.io libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev && break
-                echo "apt-get failed (attempt $attempt/3), retrying in 10s..."
-                sleep 10
-              done
+              apt-get update
+              apt-get -y install curl git bash build-essential docker.io libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev
             elif [ "$ID" = "alpine" ]; then
               apk add --no-cache bash gcc g++ musl-dev libffi-dev docker curl git make openssl-dev bzip2-dev zlib-dev xz-dev sqlite-dev
             elif [ "$ID" = "arch" ]; then


### PR DESCRIPTION
## Summary

**Fedora**: Replace pyenv/pip/pipx toolchain with `uv python install 3.12`. Pyenv-compiled Python 3.11 has an SSL incompatibility with Fedora 44's OpenSSL 3.5.7, causing `[ASN1: NOT_ENOUGH_DATA]` on every TLS connection (ansible-galaxy, GitHub downloads). This has been failing 100% of runs across all recent PRs. Using uv's prebuilt Python 3.12 sidesteps the issue entirely and also eliminates the slow pyenv compile step (~90s).

**Parrot**: Removed from the distro test matrix. Parrot's package mirror (`deb.parrot.sh`) has persistent 502 outages that cause CI failures completely unrelated to BBOT. Retries don't help when the mirror is down for minutes at a time. Kali already covers the Debian-derivative niche with reliable mirrors.