### PR TITLE
Add optional API key + cursor pagination to certspotter

### DIFF
--- a/bbot/modules/certspotter.py
+++ b/bbot/modules/certspotter.py
@@ -1,4 +1,5 @@
 from bbot.modules.templates.subdomain_enum import subdomain_enum
+from bbot.core.config.models import BaseModuleConfig, Field
 
 
 class certspotter(subdomain_enum):
@@ -11,11 +12,56 @@ class certspotter(subdomain_enum):
         "author": "@TheTechromancer",
     }
 
+    class Config(BaseModuleConfig):
+        api_key: str = Field(
+            "", description="SSLMate API key (enables pagination and higher rate limits)", sensitive=True
+        )
+
     base_url = "https://api.certspotter.com/v1"
+
+    async def setup(self):
+        self.api_key = self.config.get("api_key", "")
+        return await super().setup()
 
     def request_url(self, query):
         url = f"{self.base_url}/issuances?domain={self.helpers.quote(query)}&include_subdomains=true&expand=dns_names"
         return self.api_request(url)
+
+    async def handle_event(self, event):
+        if not self.api_key:
+            return await super().handle_event(event)
+        query = self.make_query(event)
+        after = None
+        while True:
+            url = f"{self.base_url}/issuances?domain={self.helpers.quote(query)}&include_subdomains=true&expand=dns_names"
+            if after is not None:
+                url += f"&after={after}"
+            response = await self.api_request(url)
+            if response is None:
+                break
+            try:
+                json_data = response.json()
+            except Exception:
+                break
+            if not json_data or not isinstance(json_data, list):
+                break
+            for hostname in await self.parse_results(response, query):
+                if hostname:
+                    try:
+                        hostname = self.helpers.validators.validate_host(hostname)
+                    except ValueError:
+                        continue
+                    if hostname and hostname.endswith(f".{query}") and hostname != event.data:
+                        await self.emit_event(
+                            hostname,
+                            "DNS_NAME",
+                            event,
+                            abort_if=self.abort_if,
+                            context=f'{{module}} searched {self.source_pretty_name} for "{query}" and found {{event.type}}: {{event.pretty_string}}',
+                        )
+            after = json_data[-1].get("id")
+            if after is None:
+                break
 
     async def parse_results(self, r, query):
         results = set()

--- a/bbot/test/test_step_2/module_tests/test_module_certspotter.py
+++ b/bbot/test/test_step_2/module_tests/test_module_certspotter.py
@@ -14,6 +14,46 @@ class TestCertspotter(ModuleTestBase):
         assert any(e.data == "asdf.blacklanternsecurity.com" for e in events), "Failed to detect subdomain"
 
 
+class TestCertspotterPaginated(ModuleTestBase):
+    module_name = "certspotter"
+    config_overrides = {"modules": {"certspotter": {"api_key": "test_key"}}}
+
+    base_url = "https://api.certspotter.com/v1/issuances"
+
+    async def setup_after_prep(self, module_test):
+        module_test.module.abort_if = lambda e: False
+        await module_test.mock_dns(
+            {
+                "page1.blacklanternsecurity.com": {"A": ["127.0.0.1"]},
+                "also-page1.blacklanternsecurity.com": {"A": ["127.0.0.2"]},
+                "page2.blacklanternsecurity.com": {"A": ["127.0.0.3"]},
+            }
+        )
+        module_test.blasthttp_mock.add_response(
+            url=f"{self.base_url}?domain=blacklanternsecurity.com&include_subdomains=true&expand=dns_names",
+            json=[
+                {"id": 100, "dns_names": ["page1.blacklanternsecurity.com"]},
+                {"id": 200, "dns_names": ["also-page1.blacklanternsecurity.com"]},
+            ],
+        )
+        module_test.blasthttp_mock.add_response(
+            url=f"{self.base_url}?domain=blacklanternsecurity.com&include_subdomains=true&expand=dns_names&after=200",
+            json=[
+                {"id": 300, "dns_names": ["page2.blacklanternsecurity.com"]},
+            ],
+        )
+        module_test.blasthttp_mock.add_response(
+            url=f"{self.base_url}?domain=blacklanternsecurity.com&include_subdomains=true&expand=dns_names&after=300",
+            json=[],
+        )
+
+    def check(self, module_test, events):
+        dns_names = {e.data for e in events if e.type == "DNS_NAME"}
+        assert "page1.blacklanternsecurity.com" in dns_names, "Missing page 1 result"
+        assert "also-page1.blacklanternsecurity.com" in dns_names, "Missing page 1 second result"
+        assert "page2.blacklanternsecurity.com" in dns_names, "Missing page 2 result"
+
+
 class TestCertspotterRateLimited(ModuleTestBase):
     module_name = "certspotter"
     modules_overrides = ["certspotter"]


### PR DESCRIPTION
## Summary
- Adds optional SSLMate API key support to the certspotter module (closes #1578)
- When an API key is configured, enables cursor-based pagination via `after=ID` parameter, retrieving all certificate issuances instead of just the first page
- Without an API key, behavior is unchanged (single-page query via the subdomain_enum template)
- Auth header is automatically added by `prepare_api_request` when `self.api_key` is set
- New `TestCertspotterPaginated` test verifies multi-page retrieval with mock DNS