### PR TITLE
Harden pickle unpickler in webbrute_shortnames

### DIFF
--- a/bbot/modules/webbrute_shortnames.py
+++ b/bbot/modules/webbrute_shortnames.py
@@ -124,7 +124,7 @@ class webbrute_shortnames(webbrute):
             def find_class(self, module, name):
                 if name == "MinimalWordPredictor":
                     return MinimalWordPredictor
-                return super().find_class(module, name)
+                raise pickle.UnpicklingError(f"Forbidden class: {module}.{name}")
 
         self.info("Loading shortname prediction models, could take a while if not cached")
         endpoint_model = await self.helpers.wordlist(

--- a/bbot/modules/webbrute_shortnames.py
+++ b/bbot/modules/webbrute_shortnames.py
@@ -124,6 +124,8 @@ class webbrute_shortnames(webbrute):
             def find_class(self, module, name):
                 if name == "MinimalWordPredictor":
                     return MinimalWordPredictor
+                if module.startswith("numpy"):
+                    return super().find_class(module, name)
                 raise pickle.UnpicklingError(f"Forbidden class: {module}.{name}")
 
         self.info("Loading shortname prediction models, could take a while if not cached")


### PR DESCRIPTION
## Summary

- `CustomUnpickler.find_class` in `webbrute_shortnames` falls through to `super().find_class()` for any class other than `MinimalWordPredictor`, allowing arbitrary class instantiation from a malicious pickle payload (supply-chain risk if the upstream model files are compromised)
- Fix: raise `pickle.UnpicklingError` instead of falling through