### PR TITLE
Reduce memory allocation pressure in HttpCompare, wayback, and paramminer

### DIFF
--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -8,6 +8,59 @@ from bbot.errors import HttpCompareError
 log = logging.getLogger("bbot.core.helpers.diff")
 
 
+class _BaselineSnapshot:
+    """Lightweight stand-in for a blasthttp Response held by HttpCompare.
+
+    Stores only the fields external code accesses (status_code, headers,
+    text, content) and optionally spills the body to the scan's
+    BodySpillStore so the raw bytes don't pin Python heap memory for the
+    lifetime of the HttpCompare instance.
+
+    The blasthttp Headers object is kept by reference (it survives
+    Response GC independently) to preserve case-insensitive lookups and
+    duplicate-header semantics that DeepDiff relies on.
+    """
+
+    __slots__ = ("status_code", "headers", "_text", "_spill_key", "_spill_store")
+
+    def __init__(self, response, spill_store=None):
+        self.status_code = response.status_code
+        self.headers = response.headers
+        if spill_store is not None:
+            body_bytes = response.body_bytes or b""
+            self._spill_key = f"baseline-{id(self):x}"
+            spill_store.write(self._spill_key, body_bytes)
+            self._spill_store = spill_store
+            self._text = None
+        else:
+            self._text = response.text
+            self._spill_key = None
+            self._spill_store = None
+
+    @property
+    def text(self):
+        if self._text is not None:
+            return self._text
+        if self._spill_store is not None:
+            body = self._spill_store.read(self._spill_key)
+            if body is not None:
+                return body.decode("utf-8", errors="replace")
+        return ""
+
+    @property
+    def content(self):
+        if self._spill_store is not None:
+            return self._spill_store.read(self._spill_key) or b""
+        if self._text is not None:
+            return self._text.encode("utf-8", errors="replace")
+        return b""
+
+    def _cleanup(self):
+        if self._spill_store is not None and self._spill_key is not None:
+            self._spill_store.evict_and_delete(self._spill_key)
+            self._spill_key = None
+
+
 class HttpCompare:
     def __init__(
         self,
@@ -92,7 +145,6 @@ class HttpCompare:
                 timeout=self.timeout,
             )
 
-            self.baseline = baseline_1
             if baseline_1 is None or baseline_2 is None:
                 log.debug("HTTP error while establishing baseline, aborting")
                 baseline_1_repr = f"HTTP {baseline_1.status_code}" if baseline_1 is not None else "None"
@@ -144,6 +196,13 @@ class HttpCompare:
                     await self.on_baseline_ready(baseline_1)
                 except Exception as e:
                     log.debug(f"on_baseline_ready callback raised: {e}")
+
+            # Replace the heavy blasthttp Response with a lightweight
+            # snapshot. If the scan has a body_spill_store the body bytes
+            # are written to disk and served from the LRU cache on demand.
+            scan = getattr(self.parent_helper, "scan", None)
+            store = getattr(scan, "body_spill_store", None)
+            self.baseline = _BaselineSnapshot(baseline_1, spill_store=store)
 
     def gen_cache_buster(self):
         return {self.parent_helper.rand_string(6): "1"}

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -60,6 +60,14 @@ class _BaselineSnapshot:
             self._spill_store.evict_and_delete(self._spill_key)
             self._spill_key = None
 
+    def __del__(self):
+        # Reclaim the spilled body when the snapshot is GC'd (HttpCompare
+        # instances are mostly short-lived locals, so this fires promptly).
+        try:
+            self._cleanup()
+        except Exception:
+            pass
+
 
 class HttpCompare:
     def __init__(

--- a/bbot/modules/paramminer_headers.py
+++ b/bbot/modules/paramminer_headers.py
@@ -133,7 +133,7 @@ class paramminer_headers(BaseModule):
     async def setup(self):
         self.recycle_words = self.config.get("recycle_words", True)
         self.event_dict = {}
-        self.already_checked = set()
+        self.already_checked = {}
 
         # global parameter blacklist (shared with excavate) — known framework/CDN/tracker names
         self.global_blacklist = {p.lower() for p in self.scan.config.get("parameter_blacklist", [])}
@@ -165,10 +165,10 @@ class paramminer_headers(BaseModule):
         return self.helpers.rand_string(*args, **kwargs)
 
     async def do_mining(self, wl, url, batch_size, compare_helper):
+        url_checked = self.already_checked.setdefault(url, set())
         for i in wl:
             if i not in self.wl:
-                h = hash(i + url)
-                self.already_checked.add(h)
+                url_checked.add(hash(i))
 
         results = set()
         abort_threshold = 15
@@ -316,10 +316,9 @@ class paramminer_headers(BaseModule):
             except HttpCompareError as e:
                 self.debug(f"Error initializing compare helper: {e}")
                 continue
+            url_checked = self.already_checked.get(url, set())
             words_to_process = {
-                i
-                for i in self._mutate_for_url(url, self.extracted_words_master)
-                if hash(i + url) not in self.already_checked
+                i for i in self._mutate_for_url(url, self.extracted_words_master) if hash(i) not in url_checked
             }
             try:
                 results = await self.do_mining(words_to_process, url, batch_size, compare_helper)
@@ -327,6 +326,7 @@ class paramminer_headers(BaseModule):
                 self.debug(f"Encountered HttpCompareError: [{e}] for URL [{url}]")
                 continue
             await self.process_results(event, results)
+            self.already_checked.pop(url, None)
 
     def _incoming_dedup_hash(self, event):
         # dedup by endpoint structure, not full URL string -- value mutations

--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -109,11 +109,11 @@ rule akamai_bot_manager_url
         """Drop blacklisted, garbage, and YARA-junk URLs in one pass. Returns (kept, junk_dropped).
 
         YARA matching is batched: all candidate URLs are concatenated into
-        a single blob (newline-delimited) and matched once, then string
-        instance offsets are mapped back to individual URLs and counted
-        per-URL against ``_junk_url_match_threshold``. This replaces the
-        previous per-URL ``rules.match()`` call and cuts allocation
-        pressure from ~22 GB cumulative to a single match invocation.
+        a single UTF-8 blob (newline-delimited) and matched once, then
+        string instance offsets are mapped back to individual URLs and
+        counted per-URL against ``_junk_url_match_threshold``. Batching
+        replaces a per-URL ``rules.match()`` call and cuts allocation
+        pressure to a single match invocation.
         """
         # Phase 1: cheap filters (blacklist + garbage)
         candidates = []
@@ -127,16 +127,20 @@ rule akamai_bot_manager_url
         if not candidates:
             return [], 0
 
-        # Phase 2: batch YARA match on concatenated blob
+        # Phase 2: batch YARA match on concatenated blob.
+        # YARA reports match offsets in bytes, so the blob and the offset
+        # table must both be built from the UTF-8 encodings. A char-count
+        # offset table is misaligned for any URL containing multibyte chars.
         junk_set = set()
-        blob = "\n".join(candidates)
+        encoded = [url.encode("utf-8") for url in candidates]
+        blob = b"\n".join(encoded)
         matches = self._junk_url_rules.match(data=blob)
         if matches:
             offsets = []
             pos = 0
-            for url in candidates:
+            for enc in encoded:
                 offsets.append(pos)
-                pos += len(url) + 1
+                pos += len(enc) + 1
 
             match_counts = [0] * len(candidates)
             for m in matches:

--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -1,4 +1,5 @@
 import re
+import bisect
 from collections import Counter
 from datetime import datetime
 from urllib.parse import parse_qs, urlparse, urlunparse
@@ -100,20 +101,58 @@ rule akamai_bot_manager_url
         counts = Counter(segments)
         return counts.most_common(1)[0][1] > self._max_path_segment_repeats
 
+    # Per-URL match threshold for the YARA junk-URL rules.
+    # The akamai_bot_manager_url rule requires #strict_seg >= 2.
+    _junk_url_match_threshold = 2
+
     def _filter_urls_sync(self, urls):
-        """Drop blacklisted, garbage, and YARA-junk URLs in one pass. Returns (kept, junk_dropped)."""
-        kept = []
-        junk_dropped = 0
+        """Drop blacklisted, garbage, and YARA-junk URLs in one pass. Returns (kept, junk_dropped).
+
+        YARA matching is batched: all candidate URLs are concatenated into
+        a single blob (newline-delimited) and matched once, then string
+        instance offsets are mapped back to individual URLs and counted
+        per-URL against ``_junk_url_match_threshold``. This replaces the
+        previous per-URL ``rules.match()`` call and cuts allocation
+        pressure from ~22 GB cumulative to a single match invocation.
+        """
+        # Phase 1: cheap filters (blacklist + garbage)
+        candidates = []
         for url in urls:
             if any(bl in url for bl in self.url_blacklist):
                 continue
             if self._is_garbage_url(url):
                 continue
-            if self._junk_url_rules.match(data=url):
-                junk_dropped += 1
-                continue
-            kept.append(url)
-        return kept, junk_dropped
+            candidates.append(url)
+
+        if not candidates:
+            return [], 0
+
+        # Phase 2: batch YARA match on concatenated blob
+        junk_set = set()
+        blob = "\n".join(candidates)
+        matches = self._junk_url_rules.match(data=blob)
+        if matches:
+            offsets = []
+            pos = 0
+            for url in candidates:
+                offsets.append(pos)
+                pos += len(url) + 1
+
+            match_counts = [0] * len(candidates)
+            for m in matches:
+                for s in m.strings:
+                    for instance in s.instances:
+                        idx = bisect.bisect_right(offsets, instance.offset) - 1
+                        if 0 <= idx < len(candidates):
+                            match_counts[idx] += 1
+
+            threshold = self._junk_url_match_threshold
+            for idx, count in enumerate(match_counts):
+                if count >= threshold:
+                    junk_set.add(idx)
+
+        kept = [url for idx, url in enumerate(candidates) if idx not in junk_set]
+        return kept, len(junk_set)
 
     def _is_interesting_file(self, url):
         ext = get_file_extension(url)

--- a/bbot/test/test_step_1/test_body_spill.py
+++ b/bbot/test/test_step_1/test_body_spill.py
@@ -6,13 +6,28 @@ Two layers:
   - ``TestHTTPResponseSpill``: integration tests asserting that
     HTTP_RESPONSE events route bodies through the spill store when one
     is attached to the scan, and fall back to in-memory data when not.
+  - ``TestBaselineSnapshot``: unit tests of the HttpCompare baseline
+    snapshot that also spills its body through the store.
 """
+
+import gc
 
 import pytest
 
 from bbot.core.event.spill import BodySpillStore
+from bbot.core.helpers.diff import _BaselineSnapshot
 
 from ..bbot_fixtures import *  # noqa: F401, F403
+
+
+class _FakeResponse:
+    """Minimal stand-in for a blasthttp Response for snapshot tests."""
+
+    def __init__(self, body_bytes=b"", text="", status_code=200, headers=None):
+        self.body_bytes = body_bytes
+        self.text = text
+        self.status_code = status_code
+        self.headers = {} if headers is None else headers
 
 
 # ── BodySpillStore unit tests ─────────────────────────────────────────
@@ -220,3 +235,44 @@ class TestHTTPResponseSpill:
         raw = event.raw_response
         assert "<html><body>hi</body></html>" in raw
         assert "HTTP/1.1 200 OK" in raw
+
+
+# ── _BaselineSnapshot unit tests ──────────────────────────────────────
+
+
+class TestBaselineSnapshot:
+    def test_roundtrip_via_spill_store(self, tmp_path):
+        """text/content are served from the spill store, not pinned on the snapshot."""
+        store = BodySpillStore(tmp_path, cache_bytes=4096)
+        body = "<html>ünïcödé body</html>".encode("utf-8")
+        snap = _BaselineSnapshot(_FakeResponse(body_bytes=body), spill_store=store)
+        assert snap.content == body
+        assert snap.text == body.decode("utf-8")
+        assert snap._text is None  # body is not held on the Python object
+
+    def test_no_spill_store_falls_back_to_memory(self, tmp_path):
+        """Without a store, text/content come from the in-memory text."""
+        snap = _BaselineSnapshot(_FakeResponse(text="hello"), spill_store=None)
+        assert snap.text == "hello"
+        assert snap.content == b"hello"
+        assert not any(tmp_path.iterdir())
+
+    def test_del_reclaims_spilled_body(self, tmp_path):
+        """Garbage-collecting the snapshot deletes its spill file and cache entry."""
+        store = BodySpillStore(tmp_path, cache_bytes=4096)
+        snap = _BaselineSnapshot(_FakeResponse(body_bytes=b"X" * 256), spill_store=store)
+        assert any(tmp_path.iterdir())
+        assert store.stats()["cache_entries"] == 1
+
+        del snap
+        gc.collect()
+        assert not list(tmp_path.iterdir())
+        assert store.stats()["cache_entries"] == 0
+
+    def test_cleanup_is_idempotent(self, tmp_path):
+        """Calling _cleanup twice (e.g. explicit + __del__) is safe."""
+        store = BodySpillStore(tmp_path, cache_bytes=4096)
+        snap = _BaselineSnapshot(_FakeResponse(body_bytes=b"data"), spill_store=store)
+        snap._cleanup()
+        snap._cleanup()
+        assert not list(tmp_path.iterdir())

--- a/bbot/test/test_step_2/module_tests/test_module_wayback.py
+++ b/bbot/test/test_step_2/module_tests/test_module_wayback.py
@@ -631,6 +631,43 @@ class TestWaybackJunkUrlFilter(ModuleTestBase):
             assert any(path in u for u in emitted), f"Legit URL was filtered: {legit}"
 
 
+class TestWaybackJunkUrlFilterUnicode(ModuleTestBase):
+    """A multibyte URL preceding junk URLs must not desync the byte-offset
+    mapping used to attribute YARA matches back to individual URLs."""
+
+    module_name = "wayback"
+    modules_overrides = ["wayback"]
+    targets = ["blacklanternsecurity.com"]
+    config_overrides = {"modules": {"wayback": {"urls": True}}}
+
+    # leading URL with multibyte characters: each 'ü' is 2 UTF-8 bytes, so a
+    # char-count offset table would be misaligned for every URL after it,
+    # causing junk matches to be attributed to the wrong URL.
+    unicode_url = "https://blacklanternsecurity.com/" + ("ü" * 50)
+    junk_urls = [
+        "https://blacklanternsecurity.com/Aa1/Bb2/Cc3",
+        "https://blacklanternsecurity.com/Dd4/Ee5/Ff6",
+        "https://blacklanternsecurity.com/Gg7/Hh8/Ii9",
+    ]
+    # plain ASCII URL after the junk; must survive (proves good URLs aren't
+    # dropped by a misattributed match, and that the pipeline emitted at all)
+    legit_url = "https://blacklanternsecurity.com/about/contact"
+
+    async def setup_after_prep(self, module_test):
+        all_urls = [self.unicode_url, *self.junk_urls, self.legit_url]
+        module_test.blasthttp_mock.add_response(
+            url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
+            json=[["original"], *([u] for u in all_urls)],
+        )
+
+    def check(self, module_test, events):
+        emitted = [e.url for e in events if e.type == "URL_UNVERIFIED"]
+        assert any("/about/contact" in u for u in emitted), "Legit URL was filtered or pipeline emitted nothing"
+        for junk in self.junk_urls:
+            path = junk.split("blacklanternsecurity.com", 1)[1]
+            assert not any(path in u for u in emitted), f"Junk URL leaked past filter: {junk}"
+
+
 class TestWaybackArchive429Retry(ModuleTestBase):
     """Archive fetches that get 429 rate-limited should back off and retry successfully."""
 


### PR DESCRIPTION
## Summary

Addresses three of the measured memory hotspots from the memray profiling report (excluding baddns, which is being handled separately):

- **HttpCompare baseline spill**: After establishing the baseline, the heavy blasthttp `Response` is replaced with a lightweight `_BaselineSnapshot` that spills body bytes to the scan's `BodySpillStore` (disk-backed LRU cache). External code (`lightfuzz`, `webbrute`, `sqli`) sees the same `.text`, `.content`, `.status_code`, `.headers` API. Frees the Rust-side body allocation for the lifetime of each `HttpCompare` instance.

- **Batch wayback YARA matching**: Instead of calling `rules.match(data=url)` per-URL (100K+ CFFI boundary crossings on large CDX responses), all candidate URLs are concatenated into a newline-delimited blob and matched once. String instance offsets are mapped back to individual URLs via `bisect` and counted per-URL against the threshold. Measured: ~22 GB cumulative allocation pressure reduced to a single match invocation.

- **Paramminer per-URL scoping**: `already_checked` changes from a flat `set(hash(word+url))` to `dict[url, set(hash(word))]`. After `finish()` processes each URL, its word set is evicted. Frees ~30-100 MB on heavy paramminer scans instead of retaining all word hashes until scan end.

Also audited `_module_consumers` accounting -- all increment/decrement paths are correctly paired, no actionable leak found.