### PR TITLE
Fix benchmark CI: tolerate test failures, remove invalid config keys

### DIFF
--- a/bbot/scripts/benchmark_report.py
+++ b/bbot/scripts/benchmark_report.py
@@ -47,7 +47,11 @@ def checkout_branch(branch: str, repo_path: Path = None):
 
 
 def run_benchmarks(output_file: Path, repo_path: Path = None) -> bool:
-    """Run benchmarks and save results to JSON file."""
+    """Run benchmarks and save results to JSON file.
+
+    Returns True if benchmark JSON was written (even if some tests failed),
+    False only if benchmarks truly didn't produce any data.
+    """
     print(f"Running benchmarks, saving to {output_file}")
 
     # Check if benchmarks directory exists
@@ -57,23 +61,35 @@ def run_benchmarks(output_file: Path, repo_path: Path = None) -> bool:
         print("This branch likely doesn't have benchmark tests yet.")
         return False
 
-    try:
-        cmd = [
-            "uv",
-            "run",
-            "python",
-            "-m",
-            "pytest",
-            "bbot/test/benchmarks/",
-            "--benchmark-only",
-            f"--benchmark-json={output_file}",
-            "-q",
-        ]
-        run_command(cmd, cwd=repo_path, capture_output=False)
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "pytest",
+        "bbot/test/benchmarks/",
+        "--benchmark-only",
+        f"--benchmark-json={output_file}",
+        "-q",
+    ]
+    result = subprocess.run(cmd, cwd=repo_path, capture_output=True, text=True)
+
+    # Print pytest output so failures are visible in CI logs
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr)
+
+    if result.returncode != 0:
+        print(f"Pytest exited with code {result.returncode}")
+
+    # pytest-benchmark writes JSON regardless of test failures;
+    # treat the run as successful if the output file has data
+    if output_file.exists() and output_file.stat().st_size > 0:
         return True
-    except subprocess.CalledProcessError:
-        print("Benchmarks failed for current state")
-        return False
+
+    print("Benchmark output file was not written")
+    return False
 
 
 def load_benchmark_data(filepath: Path) -> Dict[str, Any]:

--- a/bbot/test/benchmarks/test_event_validation_benchmarks.py
+++ b/bbot/test/benchmarks/test_event_validation_benchmarks.py
@@ -11,12 +11,10 @@ class TestEventValidationBenchmarks:
         # Set deterministic random seed for reproducible benchmarks
         random.seed(42)
 
-        # Create a minimal scanner with no modules to isolate event validation performance
+        # Create a minimal scanner config to isolate event validation performance
         self.scanner_config = {
-            "modules": None,  # No modules to avoid overhead
-            "output_modules": None,  # No output modules
-            "dns": {"disable": True},  # Disable DNS to avoid network calls
-            "web": {"http_timeout": 1},  # Minimal timeouts
+            "dns": {"disable": True},
+            "web": {"http_timeout": 1},
         }
 
     def _generate_diverse_targets(self, count=1000):


### PR DESCRIPTION
## Summary

- **benchmark_report.py**: `run_benchmarks()` no longer discards results when some tests fail. It now prints actual pytest output in CI logs and returns success as long as the benchmark JSON was written.
- **test_event_validation_benchmarks.py**: Removed `modules` and `output_modules` from `scanner_config` -- these are Preset constructor kwargs, not valid config keys. The pydantic preset validation rejects them, causing 2/31 benchmark tests to fail with `ValidationError`, which cascaded into the script returning no data at all.