### PR TITLE
Make output_modules additive, add exclude_output_modules

### DIFF
--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -391,6 +391,7 @@ class BBOTConfig(BaseModel):
     dnsresolve: Optional[bool] = None
     cloudcheck: Optional[bool] = None
     unarchive: Optional[bool] = None
+    python: Optional[bool] = None
 
     # URL handling
     url_querystring_remove: Optional[bool] = None
@@ -443,6 +444,7 @@ class PresetSchema(BaseModel):
     modules: Optional[list[str]] = None
     output_modules: Optional[list[str]] = None
     exclude_modules: Optional[list[str]] = None
+    exclude_output_modules: Optional[list[str]] = None
     flags: Optional[list[str]] = None
     require_flags: Optional[list[str]] = None
     exclude_flags: Optional[list[str]] = None

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -186,6 +186,8 @@ aggregate: True
 dnsresolve: True
 # Cloud provider tagging
 cloudcheck: True
+# Python API event bridge
+python: True
 
 # Strip querystring from URLs by default
 url_querystring_remove: True

--- a/bbot/modules/internal/python.py
+++ b/bbot/modules/internal/python.py
@@ -3,19 +3,20 @@ from bbot.modules.output.base import BaseOutputModule
 
 class python(BaseOutputModule):
     """
-    Pseudo-output module backing ``Scanner.async_start()``. The scan loop
+    Internal module backing ``Scanner.async_start()``. The scan loop
     drains its incoming queue directly via ``_events_waiting`` and yields
-    events to the API caller — there is no real worker.
+    events to the API caller -- there is no real worker.
 
-    Because the worker is a no-op, we override ``queue_event`` so the
-    standard ``_module_consumers`` increment is skipped. Without this,
+    Because the worker is a no-op, we override ``_increment_consumer_count``
+    so the standard ``_module_consumers`` increment is skipped. Without this,
     every event leaks +1 on its consumer count (worker would normally
     pair the increment with a ``_minimize()`` call in its ``finally``
     block, but there is no worker here). The leak prevents
-    ``_minimize()``'s ``<= 0`` block from ever firing — bodies stay in
+    ``_minimize()``'s ``<= 0`` block from ever firing -- bodies stay in
     memory / spill files stay on disk for the entire scan.
     """
 
+    _type = "internal"
     watched_events = ["*"]
     meta = {"description": "Output via Python API", "created_date": "2022-09-13", "author": "@TheTechromancer"}
 
@@ -23,6 +24,4 @@ class python(BaseOutputModule):
         pass
 
     def _increment_consumer_count(self, event):
-        # No-op: see class docstring. The standard increment would leak
-        # because there's no worker to pair it with a `_minimize()` call.
         pass

--- a/bbot/scanner/preset/args.py
+++ b/bbot/scanner/preset/args.py
@@ -159,6 +159,7 @@ class BBOTArgs:
 
         # modules + flags
         args_preset.exclude_modules.update(set(self.parsed.exclude_modules))
+        args_preset.exclude_output_modules.update(set(self.parsed.exclude_output_modules))
         args_preset.exclude_flags.update(set(self.parsed.exclude_flags))
         args_preset.require_flags.update(set(self.parsed.require_flags))
         args_preset.explicit_scan_modules.update(set(self.parsed.modules))
@@ -372,7 +373,15 @@ class BBOTArgs:
             "--output-modules",
             nargs="+",
             default=[],
-            help=f"Output module(s). Choices: {','.join(sorted(self.preset.module_loader.output_module_choices))}",
+            help=f"Add output module(s). Choices: {','.join(sorted(self.preset.module_loader.output_module_choices))}",
+            metavar="MODULE",
+        )
+        output.add_argument(
+            "-eom",
+            "--exclude-output-modules",
+            nargs="+",
+            default=[],
+            help="Exclude output module(s)",
             metavar="MODULE",
         )
         output.add_argument("-lo", "--list-output-modules", action="store_true", help="List available output modules")
@@ -440,6 +449,7 @@ class BBOTArgs:
         self.parsed.modules = chain_lists(self.parsed.modules)
         self.parsed.exclude_modules = chain_lists(self.parsed.exclude_modules)
         self.parsed.output_modules = chain_lists(self.parsed.output_modules)
+        self.parsed.exclude_output_modules = chain_lists(self.parsed.exclude_output_modules)
         self.parsed.targets = chain_lists(
             self.parsed.targets, try_files=True, msg="Reading targets from file: {filename}", _strip_comments=True
         )

--- a/bbot/scanner/preset/preset.py
+++ b/bbot/scanner/preset/preset.py
@@ -119,6 +119,7 @@ class Preset(metaclass=BasePreset):
         modules=None,
         output_modules=None,
         exclude_modules=None,
+        exclude_output_modules=None,
         flags=None,
         require_flags=None,
         exclude_flags=None,
@@ -147,8 +148,9 @@ class Preset(metaclass=BasePreset):
                 If not specified, seeds will be backfilled from target when target is defined.
             blacklist (list, optional): Blacklisted target(s). Takes ultimate precedence. Defaults to empty.
             modules (list[str], optional): List of scan modules to enable for the scan. Defaults to empty list.
-            output_modules (list[str], optional): List of output modules to use. Defaults to csv, human, and json.
+            output_modules (list[str], optional): Additional output modules to enable (additive on top of defaults).
             exclude_modules (list[str], optional): List of modules to exclude from the scan.
+            exclude_output_modules (list[str], optional): Output modules to exclude (e.g. to remove defaults).
             require_flags (list[str], optional): Only enable modules if they have these flags.
             exclude_flags (list[str], optional): Don't enable modules if they have any of these flags.
             module_dirs (list[str], optional): additional directories to load modules from.
@@ -186,6 +188,7 @@ class Preset(metaclass=BasePreset):
         # modules / flags
         self.modules = set()
         self.exclude_modules = set()
+        self.exclude_output_modules = set()
         self.flags = set()
         self.exclude_flags = set()
         self.require_flags = set()
@@ -203,6 +206,10 @@ class Preset(metaclass=BasePreset):
             exclude_modules = []
         if isinstance(exclude_modules, str):
             exclude_modules = [exclude_modules]
+        if exclude_output_modules is None:
+            exclude_output_modules = []
+        if isinstance(exclude_output_modules, str):
+            exclude_output_modules = [exclude_output_modules]
         if flags is None:
             flags = []
         if isinstance(flags, str):
@@ -280,6 +287,7 @@ class Preset(metaclass=BasePreset):
         self.explicit_scan_modules.update(set(modules))
         self.explicit_output_modules.update(set(output_modules))
         self.exclude_modules.update(set(exclude_modules))
+        self.exclude_output_modules.update(set(exclude_output_modules))
         self.flags.update(set(flags))
         self.exclude_flags.update(set(exclude_flags))
         self.require_flags.update(set(require_flags))
@@ -315,7 +323,7 @@ class Preset(metaclass=BasePreset):
         if self._default_output_modules is not None:
             output_modules = self._default_output_modules
         else:
-            output_modules = ["python", "csv", "txt", "json"]
+            output_modules = ["csv", "txt", "json"]
             if self._cli:
                 output_modules.append("stdout")
         return output_modules
@@ -358,6 +366,7 @@ class Preset(metaclass=BasePreset):
         # modules + flags
         # establish requirements / exclusions first
         self.exclude_modules.update(other.exclude_modules)
+        self.exclude_output_modules.update(other.exclude_output_modules)
         self.require_flags.update(other.require_flags)
         self.exclude_flags.update(other.exclude_flags)
         # then it's okay to start enabling modules
@@ -450,13 +459,10 @@ class Preset(metaclass=BasePreset):
         for module in baked_preset.explicit_scan_modules:
             baked_preset.add_module(module, module_type="scan")
 
-        # enable output modules
-        output_modules_to_enable = set(baked_preset.explicit_output_modules)
-        default_output_modules = self.default_output_modules
-        output_module_override = any(m in default_output_modules for m in output_modules_to_enable)
-        # if none of the default output modules have been explicitly specified, enable them all
-        if not output_module_override:
-            output_modules_to_enable.update(self.default_output_modules)
+        # enable output modules (always additive: defaults + explicit, minus excluded)
+        output_modules_to_enable = set(self.default_output_modules)
+        output_modules_to_enable.update(baked_preset.explicit_output_modules)
+        output_modules_to_enable -= baked_preset.exclude_output_modules
         for module in output_modules_to_enable:
             baked_preset.add_module(module, module_type="output", raise_error=False)
 
@@ -481,8 +487,8 @@ class Preset(metaclass=BasePreset):
                     self.log_debug(f'Enabling module "{module}" because it has flag "{flag}"')
                     baked_preset.add_module(module, module_type, raise_error=False)
 
-        # ensure we have output modules
-        if not baked_preset.output_modules:
+        # ensure we have output modules (unless the user explicitly excluded them)
+        if not baked_preset.output_modules and not baked_preset.exclude_output_modules:
             for output_module in self.default_output_modules:
                 baked_preset.add_module(output_module, module_type="output", raise_error=False)
 
@@ -739,6 +745,7 @@ class Preset(metaclass=BasePreset):
             modules=preset_dict.get("modules"),
             output_modules=preset_dict.get("output_modules"),
             exclude_modules=preset_dict.get("exclude_modules"),
+            exclude_output_modules=preset_dict.get("exclude_output_modules"),
             flags=preset_dict.get("flags"),
             require_flags=preset_dict.get("require_flags"),
             exclude_flags=preset_dict.get("exclude_flags"),
@@ -896,6 +903,8 @@ class Preset(metaclass=BasePreset):
             preset_dict["exclude_flags"] = sorted(self.exclude_flags)
         if self.exclude_modules:
             preset_dict["exclude_modules"] = sorted(self.exclude_modules)
+        if self.exclude_output_modules:
+            preset_dict["exclude_output_modules"] = sorted(self.exclude_output_modules)
         if self.flags:
             preset_dict["flags"] = sorted(self.flags)
         if self.explicit_scan_modules:
@@ -1026,6 +1035,11 @@ class Preset(metaclass=BasePreset):
             if excluded_module not in self.module_loader.all_module_choices:
                 raise ValidationError(
                     get_closest_match(excluded_module, self.module_loader.all_module_choices, msg="module")
+                )
+        for excluded_module in self.exclude_output_modules:
+            if excluded_module not in self.module_loader.output_module_choices:
+                raise ValidationError(
+                    get_closest_match(excluded_module, self.module_loader.output_module_choices, msg="output module")
                 )
         # validate declared module names so typos fail early
         for scan_module in self.explicit_scan_modules:

--- a/bbot/scanner/preset/validate.py
+++ b/bbot/scanner/preset/validate.py
@@ -275,7 +275,7 @@ def validate_preset(preset_dict: Any, module_loader=None) -> list[PresetValidati
     # nested mapping). Check them explicitly, with the same closest-match hint.
     # Skip non-list values; the schema pass above already flagged the type error,
     # and iterating a string here would yield bogus per-character lookups.
-    for key in ("modules", "output_modules", "exclude_modules"):
+    for key in ("modules", "output_modules", "exclude_modules", "exclude_output_modules"):
         value = preset_dict.get(key)
         if not isinstance(value, list):
             continue

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -397,9 +397,9 @@ class Scanner:
                 intercept_module._incoming_event_queue = interqueue
                 prev_intercept_module._outgoing_event_queue = interqueue
 
-            # abort if there are no output modules
+            # abort if there are no output modules (unless the user explicitly excluded them)
             num_output_modules = len([m for m in self.modules.values() if m._type == "output"])
-            if num_output_modules < 1:
+            if num_output_modules < 1 and not self.preset.exclude_output_modules:
                 raise ScanError("Failed to load output modules. Aborting.")
             # abort if any of the module .setup()s hard-failed (i.e. they errored or returned False)
             total_failed = len(hard_failed + soft_failed)
@@ -563,7 +563,7 @@ class Scanner:
 
         if not self._stopping:
             # queue final scan event with output modules
-            output_modules = [m for m in self.modules.values() if m._type == "output" and m.name != "python"]
+            output_modules = [m for m in self.modules.values() if m._type == "output"]
             for m in output_modules:
                 await m.queue_event(scan_finish_event)
             # wait until output modules are flushed

--- a/bbot/test/benchmarks/_scan_memory_deep_chain.py
+++ b/bbot/test/benchmarks/_scan_memory_deep_chain.py
@@ -80,7 +80,7 @@ threading.Thread(target=server.serve_forever, daemon=True).start()
 scan = Scanner(
     f"http://127.0.0.1:{port}/",
     modules=[HTTP_MODULE],
-    output_modules=["python"],
+    exclude_output_modules=["csv", "json", "txt"],
     config={
         "dns": {"minimal": True},
         "scope": {"search_distance": 0},

--- a/bbot/test/benchmarks/_scan_memory_parallel_chains.py
+++ b/bbot/test/benchmarks/_scan_memory_parallel_chains.py
@@ -87,7 +87,7 @@ targets = [f"http://127.0.0.1:{port}/seed{i}/page0" for i in range(NUM_SEEDS)]
 scan = Scanner(
     *targets,
     modules=[HTTP_MODULE],
-    output_modules=["python"],
+    exclude_output_modules=["csv", "json", "txt"],
     config={
         "dns": {"minimal": True},
         "scope": {"search_distance": 0},

--- a/bbot/test/benchmarks/_scan_memory_subdomain_enum.py
+++ b/bbot/test/benchmarks/_scan_memory_subdomain_enum.py
@@ -30,7 +30,7 @@ CHECKPOINT_EVERY = 1000  # mid-scan census cadence (events seen)
 scan = Scanner(
     "example.com",
     modules=[],
-    output_modules=["python"],
+    exclude_output_modules=["csv", "json", "txt"],
     config={
         "dns": {"disable": True},
         "scope": {"search_distance": 0},

--- a/bbot/test/benchmarks/_scan_memory_web_crawl.py
+++ b/bbot/test/benchmarks/_scan_memory_web_crawl.py
@@ -65,7 +65,7 @@ threading.Thread(target=server.serve_forever, daemon=True).start()
 scan = Scanner(
     f"http://127.0.0.1:{port}/",
     modules=[HTTP_MODULE],
-    output_modules=["python"],
+    exclude_output_modules=["csv", "json", "txt"],
     config={
         "dns": {"minimal": True},
         "scope": {"search_distance": 0},

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -322,44 +322,55 @@ async def test_cli_args(monkeypatch, caplog, capsys, clean_default_config):
     assert "| dnsbrute " not in out
     assert "| http " in out
 
-    # output modules override
+    # -om is additive (defaults stay)
     caplog.clear()
     assert not caplog.text
     monkeypatch.setattr("sys.argv", ["bbot", "-om", "csv,json", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 2/2 output modules, (csv,json)" in caplog.text
+    assert "Loaded 4/4 output modules, (csv,json,stdout,txt)" in caplog.text
     caplog.clear()
     monkeypatch.setattr("sys.argv", ["bbot", "-em", "csv,json", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 3/3 output modules, (python,stdout,txt)" in caplog.text
+    assert "Loaded 2/2 output modules, (stdout,txt)" in caplog.text
 
-    # output modules override
+    # -om adds non-default module on top of defaults
     caplog.clear()
     assert not caplog.text
     monkeypatch.setattr("sys.argv", ["bbot", "-om", "subdomains", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 6/6 output modules, (csv,json,python,stdout,subdomains,txt)" in caplog.text
+    assert "Loaded 5/5 output modules, (csv,json,stdout,subdomains,txt)" in caplog.text
 
-    # internal modules override
+    # -eom removes output modules
+    caplog.clear()
+    assert not caplog.text
+    monkeypatch.setattr("sys.argv", ["bbot", "-eom", "csv,txt", "-y"])
+    result = await cli._main()
+    assert result is True
+    assert "Loaded 2/2 output modules, (json,stdout)" in caplog.text
+
+    # internal modules (python is now internal)
     caplog.clear()
     assert not caplog.text
     monkeypatch.setattr("sys.argv", ["bbot", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 6/6 internal modules (aggregate,cloudcheck,dnsresolve,excavate,speculate,unarchive)" in caplog.text
+    assert (
+        "Loaded 7/7 internal modules (aggregate,cloudcheck,dnsresolve,excavate,python,speculate,unarchive)"
+        in caplog.text
+    )
     caplog.clear()
     monkeypatch.setattr("sys.argv", ["bbot", "-em", "excavate", "speculate", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 4/4 internal modules (aggregate,cloudcheck,dnsresolve,unarchive)" in caplog.text
+    assert "Loaded 5/5 internal modules (aggregate,cloudcheck,dnsresolve,python,unarchive)" in caplog.text
     caplog.clear()
     monkeypatch.setattr("sys.argv", ["bbot", "-c", "speculate=false", "-y"])
     result = await cli._main()
     assert result is True
-    assert "Loaded 5/5 internal modules (aggregate,cloudcheck,dnsresolve,excavate,unarchive)" in caplog.text
+    assert "Loaded 6/6 internal modules (aggregate,cloudcheck,dnsresolve,excavate,python,unarchive)" in caplog.text
 
     # custom target type
     out, err = capsys.readouterr()
@@ -631,7 +642,7 @@ def test_cli_module_validation(monkeypatch, caplog):
     monkeypatch.setattr("sys.argv", ["bbot", "-om", "websocket", "-c", "modules.websocket.url=", "-y"])
     cli.main()
     lines = caplog.text.splitlines()
-    assert "Loaded 6/6 output modules, (csv,json,python,stdout,txt,websocket)" in caplog.text
+    assert "Loaded 5/5 output modules, (csv,json,stdout,txt,websocket)" in caplog.text
     assert 1 == len(
         [
             l

--- a/bbot/test/test_step_1/test_manager_scope_accuracy.py
+++ b/bbot/test/test_step_1/test_manager_scope_accuracy.py
@@ -540,7 +540,7 @@ async def test_manager_scope_accuracy_correct(bbot_scanner, bbot_httpserver, bbo
         "127.0.0.33",
         seeds=["127.0.0.111/31"],
         modules=["http"],
-        output_modules=["python"],
+        exclude_output_modules=["csv", "json", "txt"],
         _config={
             "dns": {"minimal": False, "search_distance": 2},
             "scope": {"search_distance": 0, "report_distance": 0},

--- a/bbot/test/test_step_1/test_modules_basic.py
+++ b/bbot/test/test_step_1/test_modules_basic.py
@@ -432,7 +432,7 @@ async def test_modules_basic_stats(helpers, events, bbot_scanner, blasthttp_mock
     scan = bbot_scanner(
         "evilcorp.com",
         config={"speculate": True, "dns": {"minimal": False}},
-        output_modules=["python"],
+        exclude_output_modules=["csv", "json", "txt"],
         force_start=True,
     )
 

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -241,10 +241,12 @@ async def test_preset_scope(clean_default_config):
     assert not preset1_baked.in_scope("evilcorp.com")
     assert not preset1_baked.in_scope("asdf.test.www.evilcorp.ce")
 
-    preset4 = Preset(output_modules="neo4j")
-    set(preset1.output_modules) == {"python", "csv", "txt", "json", "stdout"}
+    preset4 = Preset(output_modules=["neo4j"])
     preset1.merge(preset4)
-    set(preset1.output_modules) == {"python", "csv", "txt", "json", "stdout", "neo4j"}
+    merged_baked = preset1.validate().bake()
+    assert "neo4j" in merged_baked.output_modules
+    for default in ("csv", "txt", "json"):
+        assert default in merged_baked.output_modules
 
     # test preset merging + seeds/target interaction
 
@@ -511,10 +513,11 @@ async def test_preset_module_resolution(clean_default_config):
 
     # make sure we have the expected defaults
     assert not preset.scan_modules
-    assert set(preset.output_modules) == {"python", "csv", "txt", "json"}
+    assert set(preset.output_modules) == {"csv", "txt", "json"}
     assert set(preset.internal_modules) == {
         "aggregate",
         "excavate",
+        "python",
         "unarchive",
         "speculate",
         "cloudcheck",
@@ -973,13 +976,14 @@ async def test_preset_module_disablement(clean_default_config):
     assert "excavate" not in preset.internal_modules
     assert "aggregate" in preset.internal_modules
 
-    # internal module disablement
+    # output module disablement
     preset = Preset().validate().bake()
-    assert set(preset.output_modules) == {"python", "txt", "csv", "json"}
+    assert set(preset.output_modules) == {"txt", "csv", "json"}
     preset = Preset(exclude_modules=["txt", "csv"]).validate().bake()
-    assert set(preset.output_modules) == {"python", "json"}
-    preset = Preset(output_modules=["json"]).validate().bake()
     assert set(preset.output_modules) == {"json"}
+    # output_modules is additive, so specifying json still includes defaults
+    preset = Preset(output_modules=["subdomains"]).validate().bake()
+    assert set(preset.output_modules) == {"csv", "txt", "json", "subdomains"}
 
 
 async def test_preset_override(clean_default_config):

--- a/bbot/test/test_step_1/test_python_api.py
+++ b/bbot/test/test_step_1/test_python_api.py
@@ -49,11 +49,15 @@ async def test_python_api(clean_default_config):
     await scan4._prep()
     assert os.environ["BBOT_TOOLS"] == str(Path(bbot_home) / "tools")
 
-    # output modules override
+    # output modules are additive
     scan5 = Scanner()
-    assert set(scan5.preset.output_modules) == {"csv", "json", "python", "txt"}
+    assert set(scan5.preset.output_modules) == {"csv", "json", "txt"}
+    # adding json is a no-op (already a default), defaults stay
     scan6 = Scanner(output_modules=["json"])
-    assert set(scan6.preset.output_modules) == {"json"}
+    assert set(scan6.preset.output_modules) == {"csv", "json", "txt"}
+    # use exclude_output_modules to remove defaults
+    scan6b = Scanner(exclude_output_modules=["csv", "txt"])
+    assert set(scan6b.preset.output_modules) == {"json"}
 
     # custom target types
     custom_target_scan = Scanner("ORG:evilcorp")

--- a/bbot/test/test_step_2/module_tests/base.py
+++ b/bbot/test/test_step_2/module_tests/base.py
@@ -54,11 +54,13 @@ class ModuleTestBase:
 
             seeds = module_test_base.seeds or None
 
+            default_output_modules = [m for m in ("csv", "json", "txt") if m not in output_modules]
+
             self.scan = Scanner(
                 *module_test_base.targets,
                 modules=modules,
                 output_modules=output_modules,
-                exclude_output_modules=["csv", "json", "txt"],
+                exclude_output_modules=default_output_modules,
                 scan_name=module_test_base._scan_name,
                 config=self.config,
                 seeds=seeds,

--- a/bbot/test/test_step_2/module_tests/base.py
+++ b/bbot/test/test_step_2/module_tests/base.py
@@ -41,9 +41,8 @@ class ModuleTestBase:
             self.preloaded = DEFAULT_PRESET.module_loader.preloaded()
 
             # handle output, internal module types
-            output_modules = None
+            output_modules = []
             modules = list(module_test_base.modules)
-            output_modules = ["python"]
             for module in list(modules):
                 module_type = self.preloaded[module]["type"]
                 if module_type in ("internal", "output"):
@@ -59,6 +58,7 @@ class ModuleTestBase:
                 *module_test_base.targets,
                 modules=modules,
                 output_modules=output_modules,
+                exclude_output_modules=["csv", "json", "txt"],
                 scan_name=module_test_base._scan_name,
                 config=self.config,
                 seeds=seeds,

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -68,7 +68,7 @@ For more details, including which types of targets are valid, see [Targets](../s
 
 #### Other Custom Options
 
-In many cases, using a [Preset](../scanning/presets.md) like `subdomain-enum` is sufficient. However, the `Scanner` is flexible and accepts many other arguments that can override the default functionality. You can specify [`flags`](../scanning/index.md#flags-f), [`modules`](../scanning/index.md#modules-m), [`output_modules`](../output.md), a [target list / `seeds` / `blacklist`](../scanning/index.md#targets-seeds-and-blacklists), and custom [`config` options](../scanning/configuration.md):
+In many cases, using a [Preset](../scanning/presets.md) like `subdomain-enum` is sufficient. However, the `Scanner` is flexible and accepts many other arguments. You can specify [`flags`](../scanning/index.md#flags-f), [`modules`](../scanning/index.md#modules-m), [`output_modules`](../output.md) (additive on top of defaults), a [target list / `seeds` / `blacklist`](../scanning/index.md#targets-seeds-and-blacklists), and custom [`config` options](../scanning/configuration.md):
 
 ```python
 # create a scan against multiple targets

--- a/docs/scanning/index.md
+++ b/docs/scanning/index.md
@@ -65,7 +65,7 @@ Modules fall into three categories:
 - **Scan Modules**:
     - These make up the majority of modules. Examples are `portscan`, `sslcert`, `http`, etc. Enable with `-m`.
 - **Output Modules**:
-    - These output scan data to different formats/destinations. `human`, `json`, and `csv` are enabled by default. Enable others with `-om`. (See: [Output](output.md))
+    - These output scan data to different formats/destinations. `txt`, `json`, and `csv` are enabled by default. Add others with `-om`, or remove defaults with `-eom`. (See: [Output](output.md))
 - **Internal Modules**:
     - These modules perform essential, common-sense tasks. They are always enabled, unless explicitly disabled via the config (e.g. `-c speculate=false`).
         - `aggregate`: Summarizes results at the end of a scan

--- a/docs/scanning/output.md
+++ b/docs/scanning/output.md
@@ -11,6 +11,36 @@ If you reuse a scan name, it will append to its original output files and levera
 
 Multiple simultaneous output formats are possible because of **output modules**. Output modules are similar to normal modules except they are enabled with `-om`.
 
+By default, `csv`, `txt`, and `json` output modules are always enabled. The `-om` flag is **additive** -- it adds modules on top of the defaults:
+
+```bash
+# default output: csv, txt, json
+bbot -t evilcorp.com -f subdomain-enum
+
+# add discord on top of defaults (csv + txt + json + discord)
+bbot -t evilcorp.com -f subdomain-enum -om discord
+
+# add multiple output modules
+bbot -t evilcorp.com -f subdomain-enum -om discord slack
+```
+
+To remove default output modules, use `-eom` (`--exclude-output-modules`):
+
+```bash
+# only json output (exclude csv and txt)
+bbot -t evilcorp.com -f subdomain-enum -eom csv txt
+```
+
+In a preset YAML, the same behavior applies:
+
+```yaml title="my_preset.yml"
+output_modules:
+  - discord  # added on top of defaults
+
+exclude_output_modules:
+  - csv  # remove csv from defaults
+```
+
 ### STDOUT
 
 The `stdout` output module is what you see when you execute BBOT in the terminal. By default it looks the same as the [`txt`](#txt) module, but it has options you can customize. You can filter by event type, choose the data format (`text`, `json`), and which fields you want to see:


### PR DESCRIPTION
## Summary

- **output_modules is now purely additive** -- `-om discord` adds discord on top of defaults (csv, txt, json), never replaces them. The old override hack in `bake()` silently dropped defaults when any default module name appeared in the list, which was confusing and inconsistent.
- **New `-eom` / `--exclude-output-modules`** flag (and `exclude_output_modules` preset key / Python API param) for explicitly removing output modules, including defaults.
- **Moved python module from `output/` to `internal/`** -- it was never a real output module; it's the Python API event bridge. Still inherits `BaseOutputModule` for behavioral properties (`accept_dupes`, `scope_distance_modifier=None`).
- Fixed `bake()` safety check that silently re-added excluded default output modules.
- Updated docs (output.md, index.md, dev/index.md) to document additive behavior and `-eom`.

Closes #3146