### PR TITLE
Consolidate HTTP timeout settings

### DIFF
--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -282,12 +282,11 @@ class WebConfig(BaseModel):
     spider_depth: Optional[int] = None
     spider_links_per_page: Optional[int] = None
     http_timeout: Optional[int] = None
-    blasthttp_timeout: Optional[int] = None
+    http_timeout_infrastructure: Optional[int] = None
     http_headers: Optional[dict[str, str]] = None
     http_cookies: Optional[dict[str, str]] = Field(default=None, sensitive=True)
     api_retries: Optional[int] = None
     http_retries: Optional[int] = None
-    blasthttp_retries: Optional[int] = None
     http_rate_limit: Optional[int] = None
     body_spill: Optional[BodySpillConfig] = None
     # The `429_*` keys start with a digit, so we expose them via aliases.

--- a/bbot/core/helpers/web/web.py
+++ b/bbot/core/helpers/web/web.py
@@ -79,7 +79,7 @@ class WebHelper:
         self.ssl_verify_target = self.web_config.get("ssl_verify_target", False)
         self.ssl_verify_infrastructure = self.web_config.get("ssl_verify_infrastructure", True)
         # Pre-compute config values for request preprocessing
-        self._http_timeout = self.web_config.get("http_timeout", 20)
+        self._http_timeout = self.web_config.get("http_timeout", 10)
         self._http_retries = self.web_config.get("http_retries", 1)
         self._http_proxy = self.web_config.get("http_proxy", None)
         self._http_proxy_exclude = self.web_config.get("http_proxy_exclude", []) or []
@@ -331,7 +331,8 @@ class WebHelper:
             # Classify error for appropriate log level
             lower = error_msg.lower()
             if "timeout" in lower:
-                log.verbose(f"HTTP timeout to URL: {url}")
+                attempts = blast_kwargs.get("retries", 0) + 1
+                log.verbose(f"HTTP timeout to URL: {url} (after {attempts} attempt(s))")
             elif "connect" in lower or "connection" in lower:
                 log.debug(f"HTTP connect failed to URL: {url}")
             else:

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -107,10 +107,10 @@ web:
   spider_depth: 1
   # Set the maximum number of links that can be followed per page
   spider_links_per_page: 25
-  # HTTP timeout (for Python requests; API calls, etc.)
+  # HTTP timeout for target-directed traffic (probes, crawls, etc.)
   http_timeout: 10
-  # HTTP timeout (for blasthttp)
-  blasthttp_timeout: 5
+  # HTTP timeout for non-target traffic (APIs, wordlist downloads, etc.)
+  http_timeout_infrastructure: 10
   # Custom HTTP headers (e.g. cookies, etc.)
   # in the format { "Header-Key": "header_value" }
   # These are attached to all in-scope HTTP requests
@@ -122,8 +122,6 @@ web:
   api_retries: 2
   # HTTP retries - try again if the raw connection fails
   http_retries: 1
-  # HTTP retries (for blasthttp)
-  blasthttp_retries: 1
   # Default sleep interval when rate limited by 429 (and retry-after isn't provided)
   429_sleep_interval: 30
   # Maximum sleep interval when rate limited by 429 (and an excessive retry-after is provided)

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -1342,6 +1342,8 @@ class BaseModule:
                 kwargs["headers"] = {}
             if "ssl_verify" not in kwargs:
                 kwargs["ssl_verify"] = self.helpers.web.ssl_verify_infrastructure
+            if "timeout" not in kwargs:
+                kwargs["timeout"] = self.http_timeout_infrastructure
             new_url, kwargs = self.prepare_api_request(url, kwargs)
             kwargs["url"] = new_url
 
@@ -1553,9 +1555,16 @@ class BaseModule:
     @property
     def http_timeout(self):
         """
-        Convenience shortcut to `http_timeout` in the config
+        Convenience shortcut to `http_timeout` in the config (target-directed traffic)
         """
         return self.scan.web_config.get("http_timeout", 10)
+
+    @property
+    def http_timeout_infrastructure(self):
+        """
+        Convenience shortcut to `http_timeout_infrastructure` in the config (APIs, wordlist downloads, etc.)
+        """
+        return self.scan.web_config.get("http_timeout_infrastructure", 10)
 
     @property
     def log(self):

--- a/bbot/modules/crt.py
+++ b/bbot/modules/crt.py
@@ -21,7 +21,7 @@ class crt(subdomain_enum):
     async def request_url(self, query):
         params = {"q": f"%.{query}", "output": "json"}
         url = self.helpers.add_get_params(self.base_url, params).geturl()
-        return await self.api_request(url, timeout=self.http_timeout + 30)
+        return await self.api_request(url, timeout=self.http_timeout_infrastructure + 30)
 
     def _api_response_is_success(self, r):
         # crt.sh returns 404/503 transiently; the default treats 404 as "no data" which is wrong here

--- a/bbot/modules/http.py
+++ b/bbot/modules/http.py
@@ -185,7 +185,12 @@ class http(BaseModule):
     async def _process_result(self, result, parent_event):
         """Emit URL + HTTP_RESPONSE events for one batch result. Returns True if status was usable."""
         if not result.success:
-            self.debug(f"blasthttp error for {result.url}: {result.error}")
+            error_str = str(result.error)
+            retries = self.scan.http_retries
+            if "timeout" in error_str.lower():
+                self.verbose(f"HTTP timeout for {result.url} (after {retries + 1} attempt(s))")
+            else:
+                self.debug(f"HTTP error for {result.url}: {error_str}")
             return False
 
         response = result.response
@@ -295,8 +300,8 @@ class http(BaseModule):
 
         headers = self._build_headers()
         proxy = self.scan.http_proxy or None
-        timeout = self.scan.blasthttp_timeout
-        retries = self.scan.blasthttp_retries
+        timeout = self.scan.http_timeout
+        retries = self.scan.http_retries
 
         configs = []
         for url in stdin:

--- a/bbot/modules/rapiddns.py
+++ b/bbot/modules/rapiddns.py
@@ -15,7 +15,7 @@ class rapiddns(subdomain_enum):
 
     async def request_url(self, query):
         url = f"{self.base_url}/subdomain/{self.helpers.quote(query)}?full=1#result"
-        response = await self.api_request(url, timeout=self.http_timeout + 10)
+        response = await self.api_request(url, timeout=self.http_timeout_infrastructure + 10)
         return response
 
     async def parse_results(self, r, query):

--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -252,7 +252,7 @@ rule akamai_bot_manager_url
         for archive_url, (cleaned_url, raw_url) in url_metadata.items():
             try:
                 r = await self.helpers.request(
-                    archive_url, method="HEAD", timeout=self.http_timeout + 30, follow_redirects=True
+                    archive_url, method="HEAD", timeout=self.http_timeout_infrastructure + 30, follow_redirects=True
                 )
             except Exception as e:
                 self.debug(f"Interesting file HEAD check error for {raw_url}: {e}")
@@ -320,7 +320,9 @@ rule akamai_bot_manager_url
         last_error = None
         for i in range(3):
             try:
-                r = await self.helpers.request(waybackurl, timeout=self.http_timeout + 60, raise_error=True)
+                r = await self.helpers.request(
+                    waybackurl, timeout=self.http_timeout_infrastructure + 60, raise_error=True
+                )
             except Exception as e:
                 last_error = str(e)
                 r = None
@@ -610,7 +612,11 @@ rule akamai_bot_manager_url
         """
         try:
             r = await self.helpers.request(
-                archive_url, method="HEAD", timeout=self.http_timeout + 30, follow_redirects=True, raise_error=True
+                archive_url,
+                method="HEAD",
+                timeout=self.http_timeout_infrastructure + 30,
+                follow_redirects=True,
+                raise_error=True,
             )
         except Exception as e:
             self.debug(f"HEAD pre-check failed for {raw_url}: {e}")
@@ -638,7 +644,7 @@ rule akamai_bot_manager_url
         for attempt in range(self._archive_per_request_retries):
             try:
                 r = await self.helpers.request(
-                    archive_url, timeout=self.http_timeout + 60, follow_redirects=True, raise_error=True
+                    archive_url, timeout=self.http_timeout_infrastructure + 60, follow_redirects=True, raise_error=True
                 )
             except Exception as e:
                 r = None

--- a/bbot/scanner/scanner.py
+++ b/bbot/scanner/scanner.py
@@ -253,9 +253,8 @@ class Scanner:
         self.http_proxy = web_config.get("http_proxy", "")
         self.http_proxy_exclude = web_config.get("http_proxy_exclude", [])
         self.http_timeout = web_config.get("http_timeout", 10)
-        self.blasthttp_timeout = web_config.get("blasthttp_timeout", 5)
+        self.http_timeout_infrastructure = web_config.get("http_timeout_infrastructure", 10)
         self.http_retries = web_config.get("http_retries", 1)
-        self.blasthttp_retries = web_config.get("blasthttp_retries", 1)
         self.useragent = f"{web_config.get('user_agent', 'BBOT')} {web_config.get('user_agent_suffix') or ''}".strip()
         # custom HTTP headers warning
         self.custom_http_headers = web_config.get("http_headers", {})

--- a/bbot/test/test_step_2/module_tests/test_module_http.py
+++ b/bbot/test/test_step_2/module_tests/test_module_http.py
@@ -180,7 +180,7 @@ class TestHTTP_custom_cookies(ModuleTestBase):
 class TestHTTP_429_retry(ModuleTestBase):
     """Test the module's own defer→cooldown→retry→succeed path.
 
-    blasthttp_retries=1 means blasthttp makes up to 2 wire attempts per request.
+    http_retries=1 means blasthttp makes up to 2 wire attempts per request.
     We return 429 for the first 2 requests (exhausting blasthttp's retry),
     so the module's 429 handler engages and defers with a cooldown. The 3rd
     request (from the module's retry after cooldown) succeeds.


### PR DESCRIPTION
## Summary

- Removed the confusing `blasthttp_timeout` / `blasthttp_retries` config keys (both went through blasthttp anyway)
- Replaced with a clean `http_timeout` / `http_timeout_infrastructure` split, mirroring the existing `ssl_verify_target` / `ssl_verify_infrastructure` pattern
- `http_timeout` (10s) controls target-directed traffic (probes, crawls, etc.)
- `http_timeout_infrastructure` (10s) controls non-target traffic (API calls, wordlist downloads, etc.)
- `api_request()` now defaults to `http_timeout_infrastructure` (same as it already defaults `ssl_verify` to `ssl_verify_infrastructure`)
- HTTP timeouts now log as `verbose` (instead of `debug`) with retry attempt counts
- Consolidated `http_retries` (removed duplicate `blasthttp_retries`)