### PR TITLE
Tighten lightfuzz false positives

### DIFF
--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -287,6 +287,7 @@ parameter_blacklist:
   - PHPSESSID
   - sessionid
   - csrftoken
+  - XSRF-TOKEN
   - __cf_bm
   - _cfuvid
   - cf_clearance
@@ -336,6 +337,7 @@ parameter_blacklist_prefixes:
   - _hjSession
   - _gat_
   - intercom-
+  - OAMRequestContext_
 
 # Don't output these types of events (they are still distributed to modules)
 omit_event_types:

--- a/bbot/modules/lightfuzz/submodules/serial.py
+++ b/bbot/modules/lightfuzz/submodules/serial.py
@@ -289,6 +289,15 @@ class serial(BaseLightfuzz):
                     )
                     continue
 
+                # Skip inherently unstable baselines: 429 (rate limit) and 403 (often WAF challenge pages)
+                # flip between error and success unpredictably, producing false positives.
+                if baseline_status in (403, 429):
+                    self.debug(
+                        f"Baseline status {baseline_status} is transient (WAF/rate-limit), "
+                        f"skipping Error Resolution for {payload_type}"
+                    )
+                    continue
+
                 general_error_matches = await self.lightfuzz.helpers.yara.match(
                     self.general_error_yara_rules, response.text
                 )


### PR DESCRIPTION
## Summary

- Add `OAMRequestContext_` to `parameter_blacklist_prefixes` (Oracle Access Manager infrastructure cookies)
- Add `XSRF-TOKEN` to `parameter_blacklist` (missing CSRF token variant)
- Reject Error Resolution baselines with status 403/429 in the serial submodule (transient WAF/rate-limit states produce unstable baselines)

Validated against a recent scan with 400 lightfuzz findings: these three changes catch 23 additional false positives on top of the 247 already eliminated by the `nlbi_` blacklist prefix (b87e5ae75).