### PR TITLE
Restore description in VIRTUAL_HOST event display

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -2020,14 +2020,18 @@ class VIRTUAL_HOST(DictHostEvent):
         return f"{self.host}:{virtual_host}"
 
     def _pretty_string(self):
-        return self.data.get("virtual_host", "")
-
-    def _data_human(self):
         virtual_host = self.data.get("virtual_host", "")
         url = self.data.get("url", "")
+        description = self.data.get("description", "")
+        parts = [virtual_host]
         if url:
-            return f"{virtual_host} ({url})"
-        return virtual_host
+            parts.append(f"({url})")
+        if description:
+            parts.append(description)
+        return " ".join(parts)
+
+    def _data_human(self):
+        return self._pretty_string()
 
 
 class PROTOCOL(DictHostEvent):


### PR DESCRIPTION
## Summary

When the `VIRTUAL_HOST` event class was registered in `base.py` (commit 1f3adf13f), `_pretty_string` and `_data_human` were written to only show the `virtual_host` name. Previously, without a dedicated class, the event fell through to the default `_data_human` which JSON-serialized the full dict -- including the rich description built by `_build_description()`.

**Before:**
```
secret-admin.example.com (https://example.com/)
```

**After:**
```
secret-admin.example.com (https://example.com/) Discovery Technique: [SAN certificate], Discovered Content: [Status Code: 200] [Title: Admin Panel] [Size: 4821 bytes] [IP: 93.184.216.34] [Access: externally accessible]
```