### PR TITLE
Add module setup troubleshooting notes

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,51 @@ bbot --help
 ## `ModuleNotFoundError`
 If you run into a `ModuleNotFoundError`, try running your `bbot` command again with `--force-deps`. This will repair your modules' Python dependencies.
 
+## Missing module commands or API key warnings
+Some BBOT modules need an external command-line tool, an API key, or both. If a scan warns that a module is not installed, cannot import a dependency, or is missing an API key, use this quick checklist before filing an issue:
+
+```bash
+# show the BBOT version and confirm the active executable
+bbot --version
+which bbot
+
+# reinstall module dependencies that BBOT manages
+bbot --force-deps --help
+
+# inspect the module's documented options and requirements
+bbot -ml <module_name>
+bbot -m <module_name> --help
+```
+
+If the module requires an API key, put it under the module's name in your BBOT config. For example:
+
+```yaml
+modules:
+  shodan_dns:
+    api_key: "YOUR_API_KEY_HERE"
+```
+
+The default user config is usually `~/.config/bbot/bbot.yml`. You can also keep secrets outside that file and pass them for a single run:
+
+```bash
+bbot -t example.com -m shodan_dns -c modules.shodan_dns.api_key=$SHODAN_API_KEY
+```
+
+After changing config, run a small scan with only the affected module so the error is easier to read:
+
+```bash
+bbot -t example.com -m <module_name> --force-deps -v
+```
+
+For third-party command-line tools that BBOT does not install automatically, verify they are on your `PATH` from the same shell that runs BBOT:
+
+```bash
+command -v <tool_name>
+<tool_name> --version
+```
+
+If the command works in your terminal but BBOT still cannot find it, check that your shell startup files and service environment export the same `PATH`.
+
 ## Regenerate Config
 As a troubleshooting step it is sometimes useful to clear out your older configs and let BBOT generate new ones. This will ensure that new defaults are property restored, etc.
 ```bash


### PR DESCRIPTION
## Summary
- Add troubleshooting steps for missing module dependencies, external commands, and API keys
- Include commands to confirm BBOT version/path, reinstall managed dependencies, inspect module help, and test one affected module
- Document where to place API keys and how to pass them with `-c` for a single run

## Testing
- Ran a markdown sanity check to confirm the new section exists and fenced code blocks are balanced