### PR TITLE
Skip mismatched protocol/port probes for well-known ports

### DIFF
--- a/bbot/modules/http.py
+++ b/bbot/modules/http.py
@@ -81,10 +81,15 @@ class http(BaseModule):
                 url_hash = hash((event.host, event.port, has_spider_max))
             urls = [url]
         else:
-            # OPEN_TCP_PORT — probe both http and https
+            # OPEN_TCP_PORT — probe both http and https (but skip mismatched well-known ports)
             host = event.host
             port = event.port
-            urls = [f"http://{host}:{port}/", f"https://{host}:{port}/"]
+            if port == 443:
+                urls = [f"https://{host}:{port}/"]
+            elif port == 80:
+                urls = [f"http://{host}:{port}/"]
+            else:
+                urls = [f"http://{host}:{port}/", f"https://{host}:{port}/"]
             url_hash = hash((host, port, has_spider_max))
         if url_hash is None:
             url_hash = hash((urls[0], has_spider_max))

--- a/bbot/modules/http.py
+++ b/bbot/modules/http.py
@@ -84,12 +84,13 @@ class http(BaseModule):
             # OPEN_TCP_PORT — probe both http and https (but skip mismatched well-known ports)
             host = event.host
             port = event.port
+            netloc = self.helpers.make_netloc(host, port)
             if port == 443:
-                urls = [f"https://{host}:{port}/"]
+                urls = [f"https://{netloc}/"]
             elif port == 80:
-                urls = [f"http://{host}:{port}/"]
+                urls = [f"http://{netloc}/"]
             else:
-                urls = [f"http://{host}:{port}/", f"https://{host}:{port}/"]
+                urls = [f"http://{netloc}/", f"https://{netloc}/"]
             url_hash = hash((host, port, has_spider_max))
         if url_hash is None:
             url_hash = hash((urls[0], has_spider_max))

--- a/bbot/test/test_step_2/module_tests/test_module_http.py
+++ b/bbot/test/test_step_2/module_tests/test_module_http.py
@@ -211,6 +211,45 @@ class TestHTTP_429_retry(ModuleTestBase):
         )
 
 
+class TestHTTP_url_metadata(ModuleTestBase):
+    """White-box test of make_url_metadata's OPEN_TCP_PORT probe set.
+
+    Well-known ports only probe their matching scheme (443→https, 80→http);
+    every other port probes both. url_hash stays scheme-independent so incoming
+    dedup is unaffected, and IPv6 hosts get bracketed netlocs.
+    """
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "http"
+    modules_overrides = ["http"]
+
+    def check(self, module_test, events):
+        module = module_test.module
+        make_event = module_test.scan.make_event
+
+        e443 = make_event("127.0.0.1:443", "OPEN_TCP_PORT", dummy=True)
+        urls, url_hash = module.make_url_metadata(e443)
+        assert urls == ["https://127.0.0.1:443/"], "port 443 should probe https only"
+        # url_hash is scheme-independent, so OPEN_TCP_PORT dedup is unaffected
+        assert url_hash == hash((e443.host, e443.port, False))
+
+        e80 = make_event("127.0.0.1:80", "OPEN_TCP_PORT", dummy=True)
+        urls, _ = module.make_url_metadata(e80)
+        assert urls == ["http://127.0.0.1:80/"], "port 80 should probe http only"
+
+        e8080 = make_event("127.0.0.1:8080", "OPEN_TCP_PORT", dummy=True)
+        urls, _ = module.make_url_metadata(e8080)
+        assert urls == ["http://127.0.0.1:8080/", "https://127.0.0.1:8080/"], (
+            "non-well-known ports should probe both schemes"
+        )
+
+        e6 = make_event("[dead::beef]:8080", "OPEN_TCP_PORT", dummy=True)
+        urls, _ = module.make_url_metadata(e6)
+        assert urls == ["http://[dead::beef]:8080/", "https://[dead::beef]:8080/"], (
+            "IPv6 hosts should produce bracketed netlocs"
+        )
+
+
 class TestHTTP_429_max_retries(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
     modules_overrides = ["http"]


### PR DESCRIPTION
## Summary

When the http module receives an `OPEN_TCP_PORT` event, it speculatively probes both `http://` and `https://` on that port. For well-known ports (80 and 443), this means every scan generates requests that are almost never useful:

- `http://host:443/` - plain HTTP to a TLS port. Almost always fails or returns garbage.
- `https://host:80/` - TLS handshake to a plain HTTP port. Almost always times out.

These add up to a lot of wasted requests across a scan, especially with many open ports 80/443 targets. The success rate is near zero and the cost is a full request + timeout per target per mismatched combo.

This change makes the http module only probe the expected protocol for ports 80 and 443:
- Port 443 -> only `https://`
- Port 80 -> only `http://`
- All other ports -> both (unchanged)

This only affects the speculative probing from `OPEN_TCP_PORT` events. If a user directly enters `http://host:443` as a target, or such a URL is discovered naturally (from a page link, redirect, etc.), it still gets probed normally via the `URL`/`URL_UNVERIFIED` path.