### PR TITLE
Bump badsecrets to 1.2.1

### DIFF
--- a/bbot/modules/badsecrets.py
+++ b/bbot/modules/badsecrets.py
@@ -19,7 +19,7 @@ class badsecrets(BaseModule):
     class Config(BaseModuleConfig):
         custom_secrets: Optional[str] = Field(None, description="Include custom secrets loaded from a local file")
 
-    deps_pip = ["badsecrets~=1.1.0"]
+    deps_pip = ["badsecrets~=1.2.1"]
 
     async def setup(self):
         self.custom_secrets = None


### PR DESCRIPTION
Bumps the `badsecrets` module's pip dependency from `~=1.1.0` to `~=1.2.1`.