### PR TITLE
Add --reset-config / --reset-secrets

### DIFF
--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -68,12 +68,21 @@ async def _main():
         # that don't construct a full Scanner.
         preset.apply_log_level(apply_core=True)
 
-        # warn (once) if the on-disk config predates / doesn't match the current option set
-        if not options.reset_config and preset.module_loader.config_is_stale():
+        # which generated config files the user is regenerating this run
+        reset_labels = [
+            label
+            for label, requested in (("config", options.reset_config), ("secrets", options.reset_secrets))
+            if requested
+        ]
+
+        # warn (once) about any generated config file that predates / no longer
+        # matches the current option set -- but not one we're about to reset
+        for spec in preset.module_loader.stale_config_files():
+            if spec["label"] in reset_labels:
+                continue
             log.warning(
-                f"Your BBOT config at {preset.core.files_config.config_filename} was generated with an "
-                "older version of bbot with different settings. Run `bbot --reset-config` to regenerate it "
-                "from current defaults."
+                f"Your BBOT {spec['label']} at {spec['path']} was generated with an older version of bbot "
+                f"with different settings. Run `bbot {spec['reset_flag']}` to regenerate it from current defaults."
             )
 
         # print help if no arguments
@@ -88,14 +97,19 @@ async def _main():
             sys.exit(0)
             return
 
-        # --reset-config
-        if options.reset_config:
-            files = preset.core.files_config
+        # --reset-config / --reset-secrets
+        if reset_labels:
+            reset_paths = [
+                spec["path"]
+                for spec in preset.module_loader._generated_config_files()
+                if spec["label"] in reset_labels
+            ]
             log.hugewarning(
-                "Resetting your BBOT config to current defaults. Any settings you have customized "
-                "(uncommented) WILL BE WIPED OUT."
+                "Regenerating from current defaults. Any settings you have customized "
+                "(uncommented) in these files WILL BE WIPED OUT:"
             )
-            log.warning(f"Files to reset: {files.config_filename} , {files.secrets_filename}")
+            for p in reset_paths:
+                log.warning(f"  {p}")
             log.warning("A backup of each existing file will be saved with a .bak extension.")
             try:
                 stdin_is_tty = sys.stdin.isatty()
@@ -111,8 +125,8 @@ async def _main():
                     log.info("Aborted. No changes made.")
                     sys.exit(0)
                     return
-            backups = preset.module_loader.reset_config_files()
-            log.success(f"Reset BBOT config at {files.config_filename}")
+            backups = preset.module_loader.reset_config_files(reset_labels)
+            log.success("Regenerated config files from current defaults.")
             for b in backups:
                 log.info(f"Backup saved: {b}")
             sys.exit(0)

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -68,6 +68,14 @@ async def _main():
         # that don't construct a full Scanner.
         preset.apply_log_level(apply_core=True)
 
+        # warn (once) if the on-disk config predates / doesn't match the current option set
+        if not options.reset_config and preset.module_loader.config_is_stale():
+            log.warning(
+                f"Your BBOT config at {preset.core.files_config.config_filename} was generated with an "
+                "older version of bbot with different settings. Run `bbot --reset-config` to regenerate it "
+                "from current defaults."
+            )
+
         # print help if no arguments
         if len(sys.argv) == 1:
             print(preset.args.parser.format_help())
@@ -77,6 +85,36 @@ async def _main():
         # --version
         if options.version:
             print(__version__)
+            sys.exit(0)
+            return
+
+        # --reset-config
+        if options.reset_config:
+            files = preset.core.files_config
+            log.hugewarning(
+                "Resetting your BBOT config to current defaults. Any settings you have customized "
+                "(uncommented) WILL BE WIPED OUT."
+            )
+            log.warning(f"Files to reset: {files.config_filename} , {files.secrets_filename}")
+            log.warning("A backup of each existing file will be saved with a .bak extension.")
+            try:
+                stdin_is_tty = sys.stdin.isatty()
+            except (ValueError, io.UnsupportedOperation):
+                stdin_is_tty = False
+            if not options.yes:
+                if not stdin_is_tty:
+                    log.error("Refusing to reset config without confirmation; re-run with --yes to proceed.")
+                    sys.exit(1)
+                    return
+                answer = input("Continue? [y/N] ").strip().lower()
+                if answer not in ("y", "yes"):
+                    log.info("Aborted. No changes made.")
+                    sys.exit(0)
+                    return
+            backups = preset.module_loader.reset_config_files()
+            log.success(f"Reset BBOT config at {files.config_filename}")
+            for b in backups:
+                log.info(f"Backup saved: {b}")
             sys.exit(0)
             return
 

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -219,9 +219,10 @@ async def _main():
                 if isinstance(file_config, dict) and validate_preset(
                     {"config": file_config}, module_loader=preset.module_loader
                 ):
-                    log.info(
-                        f"Some options in {spec['path']} are not recognized. If they are left over from an "
-                        f"older version of BBOT, regenerate it from current defaults with: bbot {spec['reset_flag']}"
+                    log.warning(
+                        f"Some options in {spec['path']} are not recognized. They may be left over from an "
+                        f"older version of BBOT. You have the option of regenerating from current defaults "
+                        f"with: bbot {spec['reset_flag']}"
                     )
             return
         baked_preset = preset.bake()

--- a/bbot/cli.py
+++ b/bbot/cli.py
@@ -75,16 +75,6 @@ async def _main():
             if requested
         ]
 
-        # warn (once) about any generated config file that predates / no longer
-        # matches the current option set -- but not one we're about to reset
-        for spec in preset.module_loader.stale_config_files():
-            if spec["label"] in reset_labels:
-                continue
-            log.warning(
-                f"Your BBOT {spec['label']} at {spec['path']} was generated with an older version of bbot "
-                f"with different settings. Run `bbot {spec['reset_flag']}` to regenerate it from current defaults."
-            )
-
         # print help if no arguments
         if len(sys.argv) == 1:
             print(preset.args.parser.format_help())
@@ -209,7 +199,31 @@ async def _main():
                 print(row)
             return
 
-        preset.validate()
+        try:
+            preset.validate()
+        except ValidationError as e:
+            log.error(str(e))
+            # if a bad option actually lives in one of the user's generated
+            # config files (vs, say, a -c CLI typo), point them at the matching
+            # reset flag -- validate each file's own contents to be sure
+            import yaml
+            from bbot.scanner.preset.validate import validate_preset
+
+            for spec in preset.module_loader._generated_config_files():
+                if not spec["path"].exists():
+                    continue
+                try:
+                    file_config = yaml.safe_load(spec["path"].read_text()) or {}
+                except yaml.YAMLError:
+                    continue
+                if isinstance(file_config, dict) and validate_preset(
+                    {"config": file_config}, module_loader=preset.module_loader
+                ):
+                    log.info(
+                        f"Some options in {spec['path']} are not recognized. If they are left over from an "
+                        f"older version of BBOT, regenerate it from current defaults with: bbot {spec['reset_flag']}"
+                    )
+            return
         baked_preset = preset.bake()
 
         # --current-preset / --current-preset-full

--- a/bbot/core/config/files.py
+++ b/bbot/core/config/files.py
@@ -1,5 +1,9 @@
+import os
 import sys
 import yaml
+import atexit
+import shutil
+import tempfile
 from pathlib import Path
 
 from .merge import deep_merge
@@ -9,15 +13,39 @@ from ...errors import ConfigLoadError
 
 bbot_code_dir = Path(__file__).parent.parent.parent
 
+# cached per-process so every BBOTConfigFiles in a run resolves to the same dir
+_test_config_dir = None
+
+
+def isolated_test_config_dir():
+    """A throwaway config dir for tests, so we never read or write the user's
+    real ~/.config/bbot. It's created fresh per run (so previous or concurrent
+    runs can't interfere) and shared across the run's processes via an env var
+    so spawned children resolve to the same dir."""
+    global _test_config_dir
+    if _test_config_dir is None:
+        env_dir = os.environ.get("BBOT_TEST_CONFIG_DIR")
+        if env_dir:
+            _test_config_dir = Path(env_dir)
+        else:
+            _test_config_dir = Path(tempfile.mkdtemp(prefix="bbot_test_config_"))
+            os.environ["BBOT_TEST_CONFIG_DIR"] = str(_test_config_dir)
+            atexit.register(lambda: shutil.rmtree(_test_config_dir, ignore_errors=True))
+    return _test_config_dir
+
 
 class BBOTConfigFiles:
-    config_dir = (Path.home() / ".config" / "bbot").resolve()
     defaults_filename = (bbot_code_dir / "defaults.yml").resolve()
-    config_filename = (config_dir / "bbot.yml").resolve()
-    secrets_filename = (config_dir / "secrets.yml").resolve()
 
     def __init__(self, core):
         self.core = core
+        if os.environ.get("BBOT_TESTING", "") == "True":
+            base_dir = isolated_test_config_dir()
+        else:
+            base_dir = Path.home() / ".config" / "bbot"
+        self.config_dir = base_dir.resolve()
+        self.config_filename = (self.config_dir / "bbot.yml").resolve()
+        self.secrets_filename = (self.config_dir / "secrets.yml").resolve()
 
     def _get_config(self, filename, name="config") -> dict:
         filename = Path(filename).resolve()

--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -1,12 +1,15 @@
+import os
 import re
 import ast
 import sys
+import stat
 import yaml
 import atexit
 import shutil
 import pickle
 import hashlib
 import logging
+import tempfile
 import importlib
 import traceback
 from copy import copy
@@ -1064,62 +1067,82 @@ class ModuleLoader:
     # header line that stamps the option set a config file was generated against
     _config_hash_prefix = "bbot-config-hash: "
 
+    def _generated_config_files(self):
+        """The config files BBOT generates, each paired with the content it
+        should currently hold and the CLI flag that regenerates it.
+
+        Creation, staleness detection, and reset all iterate this list, so the
+        two files stay fully independent: a `secrets.yml` full of API keys is
+        never touched just because `bbot.yml`'s options changed, and vice versa.
+        """
+        files = self.core.files_config
+        config_obj = dict(self.core.default_config)
+        return [
+            {
+                "label": "config",
+                "path": files.config_filename,
+                "content": self.core.no_secrets_config(config_obj),
+                "secret": False,
+                "reset_flag": "--reset-config",
+            },
+            {
+                "label": "secrets",
+                "path": files.secrets_filename,
+                "content": self.core.secrets_only_config(config_obj),
+                "secret": True,
+                "reset_flag": "--reset-secrets",
+            },
+        ]
+
     def ensure_config_files(self):
-        """Create the user's `bbot.yml` / `secrets.yml` if missing.
+        """Create any of the user's generated config files that are missing.
 
-        The generated files are a fully-commented snapshot of the current
-        defaults, written once and never overwritten. Each one carries a hash
-        of the current option key-paths in its header, so a later run can tell
-        (via `config_is_stale`) whether the options have since changed.
+        Each file is a fully-commented snapshot of the current defaults,
+        written once and never overwritten, carrying a hash of its own option
+        key-paths in its header so a later run can tell (via
+        `stale_config_files`) whether that file's options have since changed.
         """
-        files = self.core.files_config
-        mkdir(files.config_dir)
+        mkdir(self.core.files_config.config_dir)
+        for spec in self._generated_config_files():
+            if not spec["path"].exists():
+                log_to_stderr(f"Creating BBOT {spec['label']} at {spec['path']}")
+                self._write_config_template(spec["path"], spec["content"], secret=spec["secret"])
 
-        config_obj = dict(self.core.default_config)
-        schema_hash = self._config_schema_hash(config_obj)
+    def stale_config_files(self):
+        """Generated config files that exist but were stamped against a
+        different option set, or predate stamping (no header stamp). Each
+        returned spec includes the file path and the CLI flag that regenerates
+        just that file."""
+        stale = []
+        for spec in self._generated_config_files():
+            if not spec["path"].exists():
+                continue
+            stored_hash = self._read_config_hash(spec["path"])
+            if stored_hash is None or stored_hash != self._config_schema_hash(spec["content"]):
+                stale.append(spec)
+        return stale
 
-        if not files.config_filename.exists():
-            log_to_stderr(f"Creating BBOT config at {files.config_filename}")
-            self._write_config_template(files.config_filename, self.core.no_secrets_config(config_obj), schema_hash)
-        if not files.secrets_filename.exists():
-            log_to_stderr(f"Creating BBOT secrets at {files.secrets_filename}")
-            self._write_config_template(files.secrets_filename, self.core.secrets_only_config(config_obj), schema_hash)
-            files.secrets_filename.chmod(0o600)
+    def reset_config_files(self, labels):
+        """Regenerate the named generated config files (`"config"` and/or
+        `"secrets"`) from current defaults, backing up existing files to
+        `*.bak`. Returns the backup paths.
 
-    def config_is_stale(self):
-        """True if the user's config exists but was generated against a different
-        option set, or predates option-set stamping (no stamp in its header).
-        False for a config that doesn't exist yet or matches the current set.
+        Destructive: a regenerated file is a fresh commented template, so any
+        options the user uncommented in it are not carried over.
         """
-        if not self.core.files_config.config_filename.exists():
-            return False
-        stored_hash = self._read_config_hash(self.core.files_config.config_filename)
-        if stored_hash is None:
-            return True
-        return stored_hash != self._config_schema_hash(dict(self.core.default_config))
-
-    def reset_config_files(self):
-        """Regenerate `bbot.yml` / `secrets.yml` from the current defaults,
-        backing up any existing files to `*.bak`. Returns the backup paths.
-
-        Destructive: the regenerated files are a fresh commented template, so
-        any options the user uncommented are not carried over.
-        """
-        files = self.core.files_config
-        mkdir(files.config_dir)
-        config_obj = dict(self.core.default_config)
-        schema_hash = self._config_schema_hash(config_obj)
-
+        mkdir(self.core.files_config.config_dir)
         backups = []
-        for path in (files.config_filename, files.secrets_filename):
+        for spec in self._generated_config_files():
+            if spec["label"] not in labels:
+                continue
+            path = spec["path"]
             if path.exists():
                 backup = self._next_backup_path(path)
+                # copy2 preserves the file's permissions, so a backup of a
+                # hardened secrets.yml stays just as locked-down
                 shutil.copy2(path, backup)
                 backups.append(backup)
-
-        self._write_config_template(files.config_filename, self.core.no_secrets_config(config_obj), schema_hash)
-        self._write_config_template(files.secrets_filename, self.core.secrets_only_config(config_obj), schema_hash)
-        files.secrets_filename.chmod(0o600)
+            self._write_config_template(path, spec["content"], secret=spec["secret"])
         return backups
 
     @staticmethod
@@ -1145,16 +1168,47 @@ class ModuleLoader:
         return None
 
     @classmethod
-    def _write_config_template(cls, path, config_dict, schema_hash):
+    def _write_config_template(cls, path, config_dict, secret=False):
         header = (
             "# NOTICE: THESE ENTRIES ARE COMMENTED BY DEFAULT\n"
             "# Please be sure to uncomment when inserting API keys, etc.\n"
-            f"# {cls._config_hash_prefix}{schema_hash}\n"
+            f"# {cls._config_hash_prefix}{cls._config_schema_hash(config_dict)}\n"
         )
         yaml_str = yaml.dump(config_dict, sort_keys=False)
         yaml_str = header + "\n".join(f"# {line}" for line in yaml_str.splitlines())
-        with open(str(path), "w") as f:
-            f.write(yaml_str)
+        if secret:
+            cls._write_secret_text(path, yaml_str)
+        else:
+            with open(str(path), "w") as f:
+                f.write(yaml_str)
+
+    @staticmethod
+    def _write_secret_text(path, text):
+        """Write a secrets file so it is never readable by anyone but the owner,
+        even for an instant. The content is written to a private temp file
+        (mkstemp creates it 0600) and atomically renamed into place; an existing
+        file's own permissions are preserved in case the user hardened them
+        further (e.g. 0400). If owner-only permissions can't be guaranteed, the
+        secret is not written."""
+        path = Path(path)
+        mode = 0o600
+        with suppress(FileNotFoundError):
+            existing_mode = stat.S_IMODE(path.stat().st_mode)
+            # keep the user's perms only if they're already owner-only
+            if not existing_mode & 0o077:
+                mode = existing_mode
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+        try:
+            os.fchmod(fd, mode)
+            with os.fdopen(fd, "w") as f:
+                f.write(text)
+            if stat.S_IMODE(os.stat(tmp).st_mode) & 0o077:
+                raise BBOTError(f"Refusing to write secrets to {path}: could not restrict permissions to owner-only")
+            os.replace(tmp, str(path))
+        except BaseException:
+            with suppress(FileNotFoundError):
+                os.unlink(tmp)
+            raise
 
     @classmethod
     def _config_schema_hash(cls, config_obj):

--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -3,7 +3,9 @@ import ast
 import sys
 import yaml
 import atexit
+import shutil
 import pickle
+import hashlib
 import logging
 import importlib
 import traceback
@@ -1059,35 +1061,118 @@ class ModuleLoader:
         module_list.sort(key=lambda x: x[-1]["type"], reverse=True)
         return module_list
 
+    # header line that stamps the option set a config file was generated against
+    _config_hash_prefix = "bbot-config-hash: "
+
     def ensure_config_files(self):
+        """Create the user's `bbot.yml` / `secrets.yml` if missing.
+
+        The generated files are a fully-commented snapshot of the current
+        defaults, written once and never overwritten. Each one carries a hash
+        of the current option key-paths in its header, so a later run can tell
+        (via `config_is_stale`) whether the options have since changed.
+        """
         files = self.core.files_config
         mkdir(files.config_dir)
 
-        comment_notice = (
-            "# NOTICE: THESE ENTRIES ARE COMMENTED BY DEFAULT\n"
-            + "# Please be sure to uncomment when inserting API keys, etc.\n"
-        )
-
         config_obj = dict(self.core.default_config)
+        schema_hash = self._config_schema_hash(config_obj)
 
-        # ensure bbot.yml
         if not files.config_filename.exists():
             log_to_stderr(f"Creating BBOT config at {files.config_filename}")
-            no_secrets_config = self.core.no_secrets_config(config_obj)
-            yaml_str = yaml.dump(no_secrets_config, sort_keys=False)
-            yaml_str = comment_notice + "\n".join(f"# {line}" for line in yaml_str.splitlines())
-            with open(str(files.config_filename), "w") as f:
-                f.write(yaml_str)
-
-        # ensure secrets.yml
+            self._write_config_template(files.config_filename, self.core.no_secrets_config(config_obj), schema_hash)
         if not files.secrets_filename.exists():
             log_to_stderr(f"Creating BBOT secrets at {files.secrets_filename}")
-            secrets_only_config = self.core.secrets_only_config(config_obj)
-            yaml_str = yaml.dump(secrets_only_config, sort_keys=False)
-            yaml_str = comment_notice + "\n".join(f"# {line}" for line in yaml_str.splitlines())
-            with open(str(files.secrets_filename), "w") as f:
-                f.write(yaml_str)
+            self._write_config_template(files.secrets_filename, self.core.secrets_only_config(config_obj), schema_hash)
             files.secrets_filename.chmod(0o600)
+
+    def config_is_stale(self):
+        """True if the user's config exists but was generated against a different
+        option set, or predates option-set stamping (no stamp in its header).
+        False for a config that doesn't exist yet or matches the current set.
+        """
+        if not self.core.files_config.config_filename.exists():
+            return False
+        stored_hash = self._read_config_hash(self.core.files_config.config_filename)
+        if stored_hash is None:
+            return True
+        return stored_hash != self._config_schema_hash(dict(self.core.default_config))
+
+    def reset_config_files(self):
+        """Regenerate `bbot.yml` / `secrets.yml` from the current defaults,
+        backing up any existing files to `*.bak`. Returns the backup paths.
+
+        Destructive: the regenerated files are a fresh commented template, so
+        any options the user uncommented are not carried over.
+        """
+        files = self.core.files_config
+        mkdir(files.config_dir)
+        config_obj = dict(self.core.default_config)
+        schema_hash = self._config_schema_hash(config_obj)
+
+        backups = []
+        for path in (files.config_filename, files.secrets_filename):
+            if path.exists():
+                backup = self._next_backup_path(path)
+                shutil.copy2(path, backup)
+                backups.append(backup)
+
+        self._write_config_template(files.config_filename, self.core.no_secrets_config(config_obj), schema_hash)
+        self._write_config_template(files.secrets_filename, self.core.secrets_only_config(config_obj), schema_hash)
+        files.secrets_filename.chmod(0o600)
+        return backups
+
+    @staticmethod
+    def _next_backup_path(path):
+        """First free `<name>.bak`, `<name>.bak.1`, `<name>.bak.2`, ... so an
+        existing backup from a previous reset isn't clobbered."""
+        backup = path.with_name(path.name + ".bak")
+        i = 1
+        while backup.exists():
+            backup = path.with_name(f"{path.name}.bak.{i}")
+            i += 1
+        return backup
+
+    @classmethod
+    def _read_config_hash(cls, path):
+        """Read the option-set stamp from a config file's header, or None if it
+        has no stamp (e.g. a config generated before stamping existed)."""
+        marker = f"# {cls._config_hash_prefix}"
+        with open(path) as f:
+            for line in f:
+                if line.startswith(marker):
+                    return line[len(marker) :].strip()
+        return None
+
+    @classmethod
+    def _write_config_template(cls, path, config_dict, schema_hash):
+        header = (
+            "# NOTICE: THESE ENTRIES ARE COMMENTED BY DEFAULT\n"
+            "# Please be sure to uncomment when inserting API keys, etc.\n"
+            f"# {cls._config_hash_prefix}{schema_hash}\n"
+        )
+        yaml_str = yaml.dump(config_dict, sort_keys=False)
+        yaml_str = header + "\n".join(f"# {line}" for line in yaml_str.splitlines())
+        with open(str(path), "w") as f:
+            f.write(yaml_str)
+
+    @classmethod
+    def _config_schema_hash(cls, config_obj):
+        """Hash the set of option key-paths (not their values), so the stamp
+        only changes when options are added, removed, or renamed."""
+        paths = "\n".join(sorted(cls._config_leaf_paths(config_obj)))
+        return hashlib.sha256(paths.encode()).hexdigest()
+
+    @classmethod
+    def _config_leaf_paths(cls, config_obj, prefix=""):
+        paths = []
+        for key, value in config_obj.items():
+            path = f"{prefix}{key}"
+            if isinstance(value, dict) and value:
+                paths.extend(cls._config_leaf_paths(value, prefix=f"{path}."))
+            else:
+                paths.append(path)
+        return paths
 
 
 MODULE_LOADER = ModuleLoader()

--- a/bbot/core/modules.py
+++ b/bbot/core/modules.py
@@ -7,7 +7,6 @@ import yaml
 import atexit
 import shutil
 import pickle
-import hashlib
 import logging
 import tempfile
 import importlib
@@ -1064,16 +1063,13 @@ class ModuleLoader:
         module_list.sort(key=lambda x: x[-1]["type"], reverse=True)
         return module_list
 
-    # header line that stamps the option set a config file was generated against
-    _config_hash_prefix = "bbot-config-hash: "
-
     def _generated_config_files(self):
         """The config files BBOT generates, each paired with the content it
         should currently hold and the CLI flag that regenerates it.
 
-        Creation, staleness detection, and reset all iterate this list, so the
-        two files stay fully independent: a `secrets.yml` full of API keys is
-        never touched just because `bbot.yml`'s options changed, and vice versa.
+        Creation and reset both iterate this list, so the two files stay fully
+        independent: a `secrets.yml` full of API keys is never touched just
+        because `bbot.yml`'s options changed, and vice versa.
         """
         files = self.core.files_config
         config_obj = dict(self.core.default_config)
@@ -1098,29 +1094,13 @@ class ModuleLoader:
         """Create any of the user's generated config files that are missing.
 
         Each file is a fully-commented snapshot of the current defaults,
-        written once and never overwritten, carrying a hash of its own option
-        key-paths in its header so a later run can tell (via
-        `stale_config_files`) whether that file's options have since changed.
+        written once and never overwritten.
         """
         mkdir(self.core.files_config.config_dir)
         for spec in self._generated_config_files():
             if not spec["path"].exists():
                 log_to_stderr(f"Creating BBOT {spec['label']} at {spec['path']}")
                 self._write_config_template(spec["path"], spec["content"], secret=spec["secret"])
-
-    def stale_config_files(self):
-        """Generated config files that exist but were stamped against a
-        different option set, or predate stamping (no header stamp). Each
-        returned spec includes the file path and the CLI flag that regenerates
-        just that file."""
-        stale = []
-        for spec in self._generated_config_files():
-            if not spec["path"].exists():
-                continue
-            stored_hash = self._read_config_hash(spec["path"])
-            if stored_hash is None or stored_hash != self._config_schema_hash(spec["content"]):
-                stale.append(spec)
-        return stale
 
     def reset_config_files(self, labels):
         """Regenerate the named generated config files (`"config"` and/or
@@ -1157,22 +1137,10 @@ class ModuleLoader:
         return backup
 
     @classmethod
-    def _read_config_hash(cls, path):
-        """Read the option-set stamp from a config file's header, or None if it
-        has no stamp (e.g. a config generated before stamping existed)."""
-        marker = f"# {cls._config_hash_prefix}"
-        with open(path) as f:
-            for line in f:
-                if line.startswith(marker):
-                    return line[len(marker) :].strip()
-        return None
-
-    @classmethod
     def _write_config_template(cls, path, config_dict, secret=False):
         header = (
             "# NOTICE: THESE ENTRIES ARE COMMENTED BY DEFAULT\n"
             "# Please be sure to uncomment when inserting API keys, etc.\n"
-            f"# {cls._config_hash_prefix}{cls._config_schema_hash(config_dict)}\n"
         )
         yaml_str = yaml.dump(config_dict, sort_keys=False)
         yaml_str = header + "\n".join(f"# {line}" for line in yaml_str.splitlines())
@@ -1209,24 +1177,6 @@ class ModuleLoader:
             with suppress(FileNotFoundError):
                 os.unlink(tmp)
             raise
-
-    @classmethod
-    def _config_schema_hash(cls, config_obj):
-        """Hash the set of option key-paths (not their values), so the stamp
-        only changes when options are added, removed, or renamed."""
-        paths = "\n".join(sorted(cls._config_leaf_paths(config_obj)))
-        return hashlib.sha256(paths.encode()).hexdigest()
-
-    @classmethod
-    def _config_leaf_paths(cls, config_obj, prefix=""):
-        paths = []
-        for key, value in config_obj.items():
-            path = f"{prefix}{key}"
-            if isinstance(value, dict) and value:
-                paths.extend(cls._config_leaf_paths(value, prefix=f"{path}."))
-            else:
-                paths.append(path)
-        return paths
 
 
 MODULE_LOADER = ModuleLoader()

--- a/bbot/scanner/preset/args.py
+++ b/bbot/scanner/preset/args.py
@@ -414,7 +414,12 @@ class BBOTArgs:
         misc.add_argument(
             "--reset-config",
             action="store_true",
-            help="Regenerate config files from current defaults (overwrites; backs up to .bak)",
+            help="Regenerate bbot.yml from current defaults (overwrites; backs up to .bak)",
+        )
+        misc.add_argument(
+            "--reset-secrets",
+            action="store_true",
+            help="Regenerate secrets.yml from current defaults (overwrites; backs up to .bak)",
         )
         misc.add_argument("--proxy", help="Use this proxy for all HTTP requests", metavar="HTTP_PROXY")
         misc.add_argument(

--- a/bbot/scanner/preset/args.py
+++ b/bbot/scanner/preset/args.py
@@ -411,6 +411,11 @@ class BBOTArgs:
 
         misc = p.add_argument_group(title="Misc")
         misc.add_argument("--version", action="store_true", help="show BBOT version and exit")
+        misc.add_argument(
+            "--reset-config",
+            action="store_true",
+            help="Regenerate config files from current defaults (overwrites; backs up to .bak)",
+        )
         misc.add_argument("--proxy", help="Use this proxy for all HTTP requests", metavar="HTTP_PROXY")
         misc.add_argument(
             "--no-proxy",

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -925,7 +925,6 @@ async def test_cli_no_color(monkeypatch):
 @pytest.mark.asyncio
 async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     from bbot.core import CORE
-    from bbot.core.modules import MODULE_LOADER
 
     monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
     monkeypatch.setattr(os, "_exit", lambda *args, **kwargs: True)
@@ -938,17 +937,8 @@ async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     config_file = tmp_path / "bbot.yml"
     secrets_file = tmp_path / "secrets.yml"
 
-    config_hash = MODULE_LOADER._config_schema_hash(CORE.no_secrets_config(dict(CORE.default_config)))
-
-    # a stale bbot.yml on disk (wrong stamp)
-    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
-
-    # a normal run warns about the stale file and names its reset flag
-    monkeypatch.setattr("sys.argv", ["bbot", "--version"])
-    caplog.clear()
-    await cli._main()
-    assert "was generated with an older version of bbot" in caplog.text
-    assert "--reset-config" in caplog.text
+    # a customized bbot.yml on disk
+    config_file.write_text("scope:\n  strict: false\n")
 
     # without --yes and no TTY, it refuses and changes nothing
     monkeypatch.setattr("sys.argv", ["bbot", "--reset-config"])
@@ -956,7 +946,7 @@ async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     await cli._main()
     assert "Refusing to reset config without confirmation" in caplog.text
     assert not (tmp_path / "bbot.yml.bak").exists()
-    assert MODULE_LOADER._read_config_hash(config_file) == "deadbeef"
+    assert config_file.read_text() == "scope:\n  strict: false\n"
 
     # --reset-config -y regenerates bbot.yml and backs it up, but never touches secrets.yml
     monkeypatch.setattr("sys.argv", ["bbot", "--reset-config", "-y"])
@@ -964,7 +954,8 @@ async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     await cli._main()
     assert "Regenerated config files" in caplog.text
     assert (tmp_path / "bbot.yml.bak").is_file()
-    assert MODULE_LOADER._read_config_hash(config_file) == config_hash
+    assert (tmp_path / "bbot.yml.bak").read_text() == "scope:\n  strict: false\n"
+    assert "# NOTICE" in config_file.read_text()
     assert not (tmp_path / "secrets.yml.bak").exists()
 
     # --reset-secrets -y regenerates secrets.yml (owner-only) and backs it up
@@ -973,3 +964,55 @@ async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     await cli._main()
     assert (tmp_path / "secrets.yml.bak").is_file()
     assert stat.S_IMODE(secrets_file.stat().st_mode) & 0o077 == 0
+
+
+@pytest.mark.asyncio
+async def test_cli_reset_config_hint(monkeypatch, caplog, tmp_path):
+    from bbot.core import CORE
+
+    monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
+    monkeypatch.setattr(os, "_exit", lambda *args, **kwargs: True)
+    caplog.set_level(logging.INFO)
+
+    files = CORE.files_config
+    monkeypatch.setattr(files, "config_dir", tmp_path)
+    monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
+    monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
+
+    # a bbot.yml carrying an option that no longer exists (e.g. left over from
+    # an older version of BBOT), loaded into the config
+    (tmp_path / "bbot.yml").write_text("scope:\n  strct: false\n")
+    monkeypatch.setattr(CORE, "_custom_config", {"scope": {"strct": False}})
+
+    monkeypatch.setattr("sys.argv", ["bbot", "-t", "example.com"])
+    caplog.clear()
+    await cli._main()
+
+    # validation fails on the bad option, and (because it lives in bbot.yml) we
+    # point the user at --reset-config -- but not at --reset-secrets
+    assert "scope.strct" in caplog.text
+    assert "regenerate it from current defaults with: bbot --reset-config" in caplog.text
+    assert "--reset-secrets" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_cli_reset_config_hint_skips_cli_typo(monkeypatch, caplog, tmp_path):
+    from bbot.core import CORE
+
+    monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
+    monkeypatch.setattr(os, "_exit", lambda *args, **kwargs: True)
+    caplog.set_level(logging.INFO)
+
+    files = CORE.files_config
+    monkeypatch.setattr(files, "config_dir", tmp_path)
+    monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
+    monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
+
+    # the bad option comes from the CLI, not from any config file on disk
+    monkeypatch.setattr("sys.argv", ["bbot", "-t", "example.com", "-c", "scope.strct=false"])
+    caplog.clear()
+    await cli._main()
+
+    # validation still fails, but there's nothing to reset -- so no hint
+    assert "scope.strct" in caplog.text
+    assert "regenerate it from current defaults" not in caplog.text

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -991,7 +991,7 @@ async def test_cli_reset_config_hint(monkeypatch, caplog, tmp_path):
     # validation fails on the bad option, and (because it lives in bbot.yml) we
     # point the user at --reset-config -- but not at --reset-secrets
     assert "scope.strct" in caplog.text
-    assert "regenerate it from current defaults with: bbot --reset-config" in caplog.text
+    assert "regenerating from current defaults with: bbot --reset-config" in caplog.text
     assert "--reset-secrets" not in caplog.text
 
 
@@ -1015,4 +1015,4 @@ async def test_cli_reset_config_hint_skips_cli_typo(monkeypatch, caplog, tmp_pat
 
     # validation still fails, but there's nothing to reset -- so no hint
     assert "scope.strct" in caplog.text
-    assert "regenerate it from current defaults" not in caplog.text
+    assert "regenerating from current defaults" not in caplog.text

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -1,3 +1,4 @@
+import stat
 import yaml
 
 from ..bbot_fixtures import *
@@ -919,3 +920,56 @@ async def test_cli_no_color(monkeypatch):
     preset = Preset()
     preset.parse_args()
     assert os.environ.get("NO_COLOR") == "1"
+
+
+@pytest.mark.asyncio
+async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
+    from bbot.core import CORE
+    from bbot.core.modules import MODULE_LOADER
+
+    monkeypatch.setattr(sys, "exit", lambda *args, **kwargs: True)
+    monkeypatch.setattr(os, "_exit", lambda *args, **kwargs: True)
+    caplog.set_level(logging.INFO)
+
+    files = CORE.files_config
+    monkeypatch.setattr(files, "config_dir", tmp_path)
+    monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
+    monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
+    config_file = tmp_path / "bbot.yml"
+    secrets_file = tmp_path / "secrets.yml"
+
+    config_hash = MODULE_LOADER._config_schema_hash(CORE.no_secrets_config(dict(CORE.default_config)))
+
+    # a stale bbot.yml on disk (wrong stamp)
+    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
+
+    # a normal run warns about the stale file and names its reset flag
+    monkeypatch.setattr("sys.argv", ["bbot", "--version"])
+    caplog.clear()
+    await cli._main()
+    assert "was generated with an older version of bbot" in caplog.text
+    assert "--reset-config" in caplog.text
+
+    # without --yes and no TTY, it refuses and changes nothing
+    monkeypatch.setattr("sys.argv", ["bbot", "--reset-config"])
+    caplog.clear()
+    await cli._main()
+    assert "Refusing to reset config without confirmation" in caplog.text
+    assert not (tmp_path / "bbot.yml.bak").exists()
+    assert MODULE_LOADER._read_config_hash(config_file) == "deadbeef"
+
+    # --reset-config -y regenerates bbot.yml and backs it up, but never touches secrets.yml
+    monkeypatch.setattr("sys.argv", ["bbot", "--reset-config", "-y"])
+    caplog.clear()
+    await cli._main()
+    assert "Regenerated config files" in caplog.text
+    assert (tmp_path / "bbot.yml.bak").is_file()
+    assert MODULE_LOADER._read_config_hash(config_file) == config_hash
+    assert not (tmp_path / "secrets.yml.bak").exists()
+
+    # --reset-secrets -y regenerates secrets.yml (owner-only) and backs it up
+    monkeypatch.setattr("sys.argv", ["bbot", "--reset-secrets", "-y"])
+    caplog.clear()
+    await cli._main()
+    assert (tmp_path / "secrets.yml.bak").is_file()
+    assert stat.S_IMODE(secrets_file.stat().st_mode) & 0o077 == 0

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1,3 +1,4 @@
+import stat
 import tempfile
 
 from ..bbot_fixtures import *  # noqa F401
@@ -1460,6 +1461,10 @@ def test_config_isolated_during_tests():
     assert str(config_dir).startswith(str(Path(tempfile.gettempdir()).resolve()))
 
 
+def _stale_labels(module_loader):
+    return {spec["label"] for spec in module_loader.stale_config_files()}
+
+
 def test_config_reset_and_staleness(tmp_path, monkeypatch):
     from bbot.core import CORE
     from bbot.core.modules import MODULE_LOADER
@@ -1469,38 +1474,52 @@ def test_config_reset_and_staleness(tmp_path, monkeypatch):
     monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
     monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
     config_file = tmp_path / "bbot.yml"
+    secrets_file = tmp_path / "secrets.yml"
 
-    current = MODULE_LOADER._config_schema_hash(dict(CORE.default_config))
+    # the two files are stamped with independent, different hashes
+    config_hash = MODULE_LOADER._config_schema_hash(CORE.no_secrets_config(dict(CORE.default_config)))
+    secrets_hash = MODULE_LOADER._config_schema_hash(CORE.secrets_only_config(dict(CORE.default_config)))
+    assert config_hash != secrets_hash
 
-    # no config on disk yet -> not stale
-    assert MODULE_LOADER.config_is_stale() is False
+    # no config on disk yet -> nothing stale
+    assert _stale_labels(MODULE_LOADER) == set()
 
-    # first run: files don't exist -> generated, hash stamped in the header
+    # first run: files don't exist -> generated, each stamped with its own hash
     MODULE_LOADER.ensure_config_files()
-    assert config_file.is_file()
-    assert (tmp_path / "secrets.yml").is_file()
-    assert f"# bbot-config-hash: {current}" in config_file.read_text()
-    assert MODULE_LOADER._read_config_hash(config_file) == current
-    assert MODULE_LOADER.config_is_stale() is False
+    assert config_file.is_file() and secrets_file.is_file()
+    assert MODULE_LOADER._read_config_hash(config_file) == config_hash
+    assert MODULE_LOADER._read_config_hash(secrets_file) == secrets_hash
+    assert _stale_labels(MODULE_LOADER) == set()
+    # secrets.yml is owner-only from the start
+    assert stat.S_IMODE(secrets_file.stat().st_mode) == 0o600
 
-    # a pre-stamp (2.x) config has no header stamp -> stale
+    # only bbot.yml goes stale -> detection flags only "config"
+    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
+    assert _stale_labels(MODULE_LOADER) == {"config"}
+    # a pre-stamp (2.x) file (no header stamp) is also stale
     config_file.write_text("# NOTICE\n# scope:\n#   strict: false\n")
     assert MODULE_LOADER._read_config_hash(config_file) is None
-    assert MODULE_LOADER.config_is_stale() is True
-    # a changed option set -> stale
-    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
-    assert MODULE_LOADER.config_is_stale() is True
+    assert _stale_labels(MODULE_LOADER) == {"config"}
 
-    # reset: backs up existing files, regenerates, restamps
-    backups = MODULE_LOADER.reset_config_files()
-    assert set(backups) == {tmp_path / "bbot.yml.bak", tmp_path / "secrets.yml.bak"}
-    assert MODULE_LOADER._read_config_hash(config_file) == current
-    assert MODULE_LOADER.config_is_stale() is False
+    # resetting "config" must not touch secrets.yml (where API keys live)
+    secrets_before = secrets_file.read_text()
+    backups = MODULE_LOADER.reset_config_files(["config"])
+    assert set(backups) == {tmp_path / "bbot.yml.bak"}
+    assert secrets_file.read_text() == secrets_before
+    assert _stale_labels(MODULE_LOADER) == set()
+
+    # a backup of a hardened secrets.yml keeps its tightened permissions
+    secrets_file.chmod(0o400)
+    backups = MODULE_LOADER.reset_config_files(["secrets"])
+    assert set(backups) == {tmp_path / "secrets.yml.bak"}
+    assert stat.S_IMODE((tmp_path / "secrets.yml.bak").stat().st_mode) == 0o400
+    # the regenerated secrets.yml is still owner-only
+    assert stat.S_IMODE(secrets_file.stat().st_mode) & 0o077 == 0
 
     # a second reset must not clobber the first backup
-    backups2 = MODULE_LOADER.reset_config_files()
-    assert set(backups2) == {tmp_path / "bbot.yml.bak.1", tmp_path / "secrets.yml.bak.1"}
-    assert (tmp_path / "bbot.yml.bak").is_file()
+    backups2 = MODULE_LOADER.reset_config_files(["secrets"])
+    assert set(backups2) == {tmp_path / "secrets.yml.bak.1"}
+    assert (tmp_path / "secrets.yml.bak").is_file()
 
 
 def test_config_schema_hash_is_structural():
@@ -1515,3 +1534,70 @@ def test_config_schema_hash_is_structural():
     assert MODULE_LOADER._config_schema_hash(base) != MODULE_LOADER._config_schema_hash(
         {"web": {"http_timeout_target": 10}, "scope": {"strict": False}}
     )
+
+
+def test_config_reset_both_and_independent_detection(tmp_path, monkeypatch):
+    from bbot.core import CORE
+    from bbot.core.modules import MODULE_LOADER
+
+    files = CORE.files_config
+    monkeypatch.setattr(files, "config_dir", tmp_path)
+    monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
+    monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
+    config_file = tmp_path / "bbot.yml"
+    secrets_file = tmp_path / "secrets.yml"
+
+    MODULE_LOADER.ensure_config_files()
+    assert _stale_labels(MODULE_LOADER) == set()
+
+    # only secrets.yml goes stale -> detection flags only "secrets"
+    secrets_file.write_text("# bbot-config-hash: deadbeef\n# interactsh_token:\n")
+    assert _stale_labels(MODULE_LOADER) == {"secrets"}
+
+    # break both -> both reported
+    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n")
+    assert _stale_labels(MODULE_LOADER) == {"config", "secrets"}
+
+    # reset both at once
+    backups = MODULE_LOADER.reset_config_files(["config", "secrets"])
+    assert {b.name for b in backups} == {"bbot.yml.bak", "secrets.yml.bak"}
+    assert _stale_labels(MODULE_LOADER) == set()
+
+
+def test_config_secret_file_permissions(tmp_path):
+    from bbot.core.modules import MODULE_LOADER
+
+    target = tmp_path / "secrets.yml"
+
+    # a brand-new secret file is owner-only, never world/group readable
+    MODULE_LOADER._write_secret_text(target, "secret a")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert target.read_text() == "secret a"
+
+    # the user hardened it further -> rewrite preserves the tighter perms
+    target.chmod(0o400)
+    MODULE_LOADER._write_secret_text(target, "secret b")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o400
+    assert target.read_text() == "secret b"
+
+    # an existing file with loose perms -> tightened back to owner-only
+    target.chmod(0o644)
+    MODULE_LOADER._write_secret_text(target, "secret c")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert target.read_text() == "secret c"
+
+
+def test_config_secret_file_refuses_insecure(tmp_path, monkeypatch):
+    from bbot.core.modules import MODULE_LOADER
+    from bbot.errors import BBOTError
+
+    target = tmp_path / "secrets.yml"
+
+    # simulate a filesystem where we can't restrict permissions: the secret is
+    # not written, and no temp file is left behind
+    real_fchmod = os.fchmod
+    monkeypatch.setattr(os, "fchmod", lambda fd, mode: real_fchmod(fd, 0o644))
+    with pytest.raises(BBOTError, match="could not restrict permissions"):
+        MODULE_LOADER._write_secret_text(target, "secret stuff")
+    assert not target.exists()
+    assert list(tmp_path.glob(".secrets.yml.*")) == []

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1461,11 +1461,7 @@ def test_config_isolated_during_tests():
     assert str(config_dir).startswith(str(Path(tempfile.gettempdir()).resolve()))
 
 
-def _stale_labels(module_loader):
-    return {spec["label"] for spec in module_loader.stale_config_files()}
-
-
-def test_config_reset_and_staleness(tmp_path, monkeypatch):
+def test_config_reset(tmp_path, monkeypatch):
     from bbot.core import CORE
     from bbot.core.modules import MODULE_LOADER
 
@@ -1476,37 +1472,22 @@ def test_config_reset_and_staleness(tmp_path, monkeypatch):
     config_file = tmp_path / "bbot.yml"
     secrets_file = tmp_path / "secrets.yml"
 
-    # the two files are stamped with independent, different hashes
-    config_hash = MODULE_LOADER._config_schema_hash(CORE.no_secrets_config(dict(CORE.default_config)))
-    secrets_hash = MODULE_LOADER._config_schema_hash(CORE.secrets_only_config(dict(CORE.default_config)))
-    assert config_hash != secrets_hash
-
-    # no config on disk yet -> nothing stale
-    assert _stale_labels(MODULE_LOADER) == set()
-
-    # first run: files don't exist -> generated, each stamped with its own hash
+    # first run: files don't exist -> generated as commented templates
     MODULE_LOADER.ensure_config_files()
     assert config_file.is_file() and secrets_file.is_file()
-    assert MODULE_LOADER._read_config_hash(config_file) == config_hash
-    assert MODULE_LOADER._read_config_hash(secrets_file) == secrets_hash
-    assert _stale_labels(MODULE_LOADER) == set()
     # secrets.yml is owner-only from the start
     assert stat.S_IMODE(secrets_file.stat().st_mode) == 0o600
 
-    # only bbot.yml goes stale -> detection flags only "config"
-    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
-    assert _stale_labels(MODULE_LOADER) == {"config"}
-    # a pre-stamp (2.x) file (no header stamp) is also stale
-    config_file.write_text("# NOTICE\n# scope:\n#   strict: false\n")
-    assert MODULE_LOADER._read_config_hash(config_file) is None
-    assert _stale_labels(MODULE_LOADER) == {"config"}
-
-    # resetting "config" must not touch secrets.yml (where API keys live)
+    # resetting "config" backs up the existing file and must not touch
+    # secrets.yml (where API keys live)
+    config_file.write_text("scope:\n  strict: false\n")
     secrets_before = secrets_file.read_text()
     backups = MODULE_LOADER.reset_config_files(["config"])
     assert set(backups) == {tmp_path / "bbot.yml.bak"}
+    assert (tmp_path / "bbot.yml.bak").read_text() == "scope:\n  strict: false\n"
     assert secrets_file.read_text() == secrets_before
-    assert _stale_labels(MODULE_LOADER) == set()
+    # the regenerated file is a fresh commented template
+    assert "# NOTICE" in config_file.read_text()
 
     # a backup of a hardened secrets.yml keeps its tightened permissions
     secrets_file.chmod(0o400)
@@ -1522,21 +1503,7 @@ def test_config_reset_and_staleness(tmp_path, monkeypatch):
     assert (tmp_path / "secrets.yml.bak").is_file()
 
 
-def test_config_schema_hash_is_structural():
-    from bbot.core.modules import MODULE_LOADER
-
-    base = {"web": {"http_timeout": 10}, "scope": {"strict": False}}
-    # value changes don't move the hash
-    assert MODULE_LOADER._config_schema_hash(base) == MODULE_LOADER._config_schema_hash(
-        {"web": {"http_timeout": 99}, "scope": {"strict": True}}
-    )
-    # a renamed/added/removed option does
-    assert MODULE_LOADER._config_schema_hash(base) != MODULE_LOADER._config_schema_hash(
-        {"web": {"http_timeout_target": 10}, "scope": {"strict": False}}
-    )
-
-
-def test_config_reset_both_and_independent_detection(tmp_path, monkeypatch):
+def test_config_reset_both(tmp_path, monkeypatch):
     from bbot.core import CORE
     from bbot.core.modules import MODULE_LOADER
 
@@ -1545,23 +1512,18 @@ def test_config_reset_both_and_independent_detection(tmp_path, monkeypatch):
     monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
     monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
     config_file = tmp_path / "bbot.yml"
-    secrets_file = tmp_path / "secrets.yml"
 
     MODULE_LOADER.ensure_config_files()
-    assert _stale_labels(MODULE_LOADER) == set()
 
-    # only secrets.yml goes stale -> detection flags only "secrets"
-    secrets_file.write_text("# bbot-config-hash: deadbeef\n# interactsh_token:\n")
-    assert _stale_labels(MODULE_LOADER) == {"secrets"}
-
-    # break both -> both reported
-    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n")
-    assert _stale_labels(MODULE_LOADER) == {"config", "secrets"}
-
-    # reset both at once
+    # reset both at once -> both backed up
     backups = MODULE_LOADER.reset_config_files(["config", "secrets"])
     assert {b.name for b in backups} == {"bbot.yml.bak", "secrets.yml.bak"}
-    assert _stale_labels(MODULE_LOADER) == set()
+
+    # resetting only "secrets" leaves bbot.yml untouched
+    config_before = config_file.read_text()
+    backups = MODULE_LOADER.reset_config_files(["secrets"])
+    assert set(backups) == {tmp_path / "secrets.yml.bak.1"}
+    assert config_file.read_text() == config_before
 
 
 def test_config_secret_file_permissions(tmp_path):

--- a/bbot/test/test_step_1/test_presets.py
+++ b/bbot/test/test_step_1/test_presets.py
@@ -1,3 +1,5 @@
+import tempfile
+
 from ..bbot_fixtures import *  # noqa F401
 
 from bbot.scanner import Scanner, Preset
@@ -1446,3 +1448,70 @@ def test_all_presets_ignores_non_preset_yaml(tmp_path):
         preset_mod.DEFAULT_PRESETS = orig_default_presets
         preset_mod.PRESET_PATH = orig_preset_path
         path_mod.PRESET_PATH = orig_path_singleton
+
+
+def test_config_isolated_during_tests():
+    # the suite must never resolve to the user's real ~/.config/bbot
+    from bbot.core import CORE
+
+    config_dir = CORE.files_config.config_dir
+    real_config_dir = (Path.home() / ".config" / "bbot").resolve()
+    assert config_dir != real_config_dir
+    assert str(config_dir).startswith(str(Path(tempfile.gettempdir()).resolve()))
+
+
+def test_config_reset_and_staleness(tmp_path, monkeypatch):
+    from bbot.core import CORE
+    from bbot.core.modules import MODULE_LOADER
+
+    files = CORE.files_config
+    monkeypatch.setattr(files, "config_dir", tmp_path)
+    monkeypatch.setattr(files, "config_filename", tmp_path / "bbot.yml")
+    monkeypatch.setattr(files, "secrets_filename", tmp_path / "secrets.yml")
+    config_file = tmp_path / "bbot.yml"
+
+    current = MODULE_LOADER._config_schema_hash(dict(CORE.default_config))
+
+    # no config on disk yet -> not stale
+    assert MODULE_LOADER.config_is_stale() is False
+
+    # first run: files don't exist -> generated, hash stamped in the header
+    MODULE_LOADER.ensure_config_files()
+    assert config_file.is_file()
+    assert (tmp_path / "secrets.yml").is_file()
+    assert f"# bbot-config-hash: {current}" in config_file.read_text()
+    assert MODULE_LOADER._read_config_hash(config_file) == current
+    assert MODULE_LOADER.config_is_stale() is False
+
+    # a pre-stamp (2.x) config has no header stamp -> stale
+    config_file.write_text("# NOTICE\n# scope:\n#   strict: false\n")
+    assert MODULE_LOADER._read_config_hash(config_file) is None
+    assert MODULE_LOADER.config_is_stale() is True
+    # a changed option set -> stale
+    config_file.write_text("# bbot-config-hash: deadbeef\n# scope:\n#   strict: false\n")
+    assert MODULE_LOADER.config_is_stale() is True
+
+    # reset: backs up existing files, regenerates, restamps
+    backups = MODULE_LOADER.reset_config_files()
+    assert set(backups) == {tmp_path / "bbot.yml.bak", tmp_path / "secrets.yml.bak"}
+    assert MODULE_LOADER._read_config_hash(config_file) == current
+    assert MODULE_LOADER.config_is_stale() is False
+
+    # a second reset must not clobber the first backup
+    backups2 = MODULE_LOADER.reset_config_files()
+    assert set(backups2) == {tmp_path / "bbot.yml.bak.1", tmp_path / "secrets.yml.bak.1"}
+    assert (tmp_path / "bbot.yml.bak").is_file()
+
+
+def test_config_schema_hash_is_structural():
+    from bbot.core.modules import MODULE_LOADER
+
+    base = {"web": {"http_timeout": 10}, "scope": {"strict": False}}
+    # value changes don't move the hash
+    assert MODULE_LOADER._config_schema_hash(base) == MODULE_LOADER._config_schema_hash(
+        {"web": {"http_timeout": 99}, "scope": {"strict": True}}
+    )
+    # a renamed/added/removed option does
+    assert MODULE_LOADER._config_schema_hash(base) != MODULE_LOADER._config_schema_hash(
+        {"web": {"http_timeout_target": 10}, "scope": {"strict": False}}
+    )


### PR DESCRIPTION
## Summary

BBOT writes a fully-commented snapshot of the defaults into `~/.config/bbot/bbot.yml` and `~/.config/bbot/secrets.yml` on first install (`ensure_config_files`), guarded by `if not exists`. Across upgrades these freeze at install time, so old installs carry commented options that no longer exist, and a config can reference options that have since been renamed or removed.

This adds an opt-in way to regenerate those files, plus a targeted hint when an actually-invalid option is found.

- **Separate, independent resets**: `--reset-config` regenerates `bbot.yml` only; `--reset-secrets` regenerates `secrets.yml` only (combine the two to do both). Refreshing the `bbot.yml` template never disturbs the API keys in `secrets.yml`. Each requires confirmation (`y/N`, or `--yes`; refuses in a non-tty without `--yes`) and backs up existing files non-clobbering (`.bak`, `.bak.1`, ...).
- **Secrets are written securely** (`_write_secret_text`): `secrets.yml` is created owner-only (`0600`) atomically via a private temp file + rename, so it never exists world/group-readable even briefly; an existing file's hardened perms (e.g. `0400`) are preserved; if owner-only perms can't be guaranteed, the secret is not written. Backups preserve the source file's permissions.
- **Validation-driven reset hint** (`bbot/cli.py`): when config validation rejects an option, and that option actually lives in one of the generated config files, BBOT points the user at the matching reset flag. This rides on the existing pydantic validation (which only flags options the user is actually using), so it never fires on a config that is fine, and it does not fire for a `-c` CLI typo.
- **Test isolation** (`bbot/core/config/files.py`): under `BBOT_TESTING`, `config_dir` resolves to a fresh per-run `mkdtemp` (shared across child processes via `BBOT_TEST_CONFIG_DIR`, cleaned at exit) instead of the real `~/.config/bbot`. Fixes a pre-existing leak where the suite read/wrote the user's actual config, and is safe against previous/concurrent runs.

## Notes

An earlier revision stamped each file with a structural option-set hash and warned on every run when the hash no longer matched. That nag false-flagged hand-written and minimal configs as stale on every run (an unstamped file is indistinguishable from one generated by an old version) and duplicated what preset validation already does precisely. It was dropped in favor of the validation-driven hint above.

## Tests

- `test_presets.py`: config-dir isolation; independent reset (resetting `config` leaves `secrets` untouched, and vice versa); reset both; secret-file permissions (create `0600`, preserve hardened `0400`, tighten loose `0644`); refusal to write secrets when perms can't be secured.
- `test_cli.py`: `--reset-config` / `--reset-secrets` end-to-end (non-tty refusal without `--yes`, regeneration + backup, secrets untouched on a config reset); the reset hint fires when a bad option lives in `bbot.yml`, and does not fire for a `-c` CLI typo.
