### PR TITLE
wpscan: handle missing wpscan binary

### DIFF
--- a/bbot/modules/wpscan.py
+++ b/bbot/modules/wpscan.py
@@ -64,6 +64,7 @@ class wpscan(BaseModule):
 
     async def setup(self):
         self.processed = set()
+        self.run_warning = False
         self.ignore_events = ["xmlrpc", "readme"]
         self.api_key = self.config.get("api_key", "")
         self.enumerate = self.config.get("enumerate", "vp,vt,cb,dbe")
@@ -73,6 +74,8 @@ class wpscan(BaseModule):
         self.connection_timeout = self.config.get("connection_timeout", 2)
         self.disable_tls_checks = self.config.get("disable_tls_checks", True)
         self.force = self.config.get("force", False)
+        if not self.helpers.which("wpscan"):
+            return None, "wpscan is not installed (could not find 'wpscan' on PATH)"
         return True
 
     async def filter_event(self, event):
@@ -97,15 +100,21 @@ class wpscan(BaseModule):
 
     async def handle_http_response(self, source_event):
         url = source_event.parsed_url._replace(path="/").geturl()
-        command = self.construct_command(url)
-        output = await self.run_process(command)
-        for new_event in self.parse_wpscan_output(output.stdout, url, source_event):
-            await self.emit_event(new_event)
+        await self.run_wpscan(url, source_event)
 
     async def handle_technology(self, source_event):
         url = self.get_base_url(source_event)
+        await self.run_wpscan(url, source_event)
+
+    async def run_wpscan(self, url, source_event):
         command = self.construct_command(url)
         output = await self.run_process(command)
+        if output is None:
+            # wpscan could not be executed (e.g. not installed); warn once instead of erroring per event
+            if not self.run_warning:
+                self.run_warning = True
+                self.warning("Failed to execute wpscan. Is it installed and on your PATH?")
+            return
         for new_event in self.parse_wpscan_output(output.stdout, url, source_event):
             await self.emit_event(new_event)
 

--- a/bbot/test/test_step_2/module_tests/test_module_wpscan.py
+++ b/bbot/test/test_step_2/module_tests/test_module_wpscan.py
@@ -1068,6 +1068,18 @@ class Testwpscan(ModuleTestBase):
   "used_memory_humanised": "214.957 MB"
 }"""
 
+    async def setup_before_prep(self, module_test):
+        # wpscan's setup() verifies the binary is present; pretend it is so the
+        # happy-path test doesn't depend on wpscan actually being installed.
+        original_which = module_test.scan.helpers.which
+
+        def which(*executables, **kwargs):
+            if "wpscan" in executables:
+                return "/usr/bin/wpscan"
+            return original_which(*executables, **kwargs)
+
+        module_test.monkeypatch.setattr(module_test.scan.helpers, "which", which)
+
     async def setup_after_prep(self, module_test):
         async def wpscan_mock_run(*command, **kwargs):
             return CompletedProcess(command, 0, self.wpscan_output_json, "")
@@ -1080,3 +1092,38 @@ class Testwpscan(ModuleTestBase):
         # Original expectation: 1 finding + 59 vulnerabilities = 60 FINDING events (all are now FINDING events)
         assert len(findings) == 60, f"Expected 60 FINDING events, got {len(findings)}"
         assert len(technologies) == 4
+
+
+class TestwpscanError(Testwpscan):
+    """wpscan is installed but fails to execute (run() returns None) -- must degrade gracefully."""
+
+    async def setup_after_prep(self, module_test):
+        async def wpscan_mock_run(*command, **kwargs):
+            return None
+
+        module_test.monkeypatch.setattr(module_test.scan.helpers, "run", wpscan_mock_run)
+
+    def check(self, module_test, events):
+        assert not [e for e in events if e.type == "FINDING"], "wpscan emitted findings despite failing to run"
+        log_text = "\n".join(r.message for r in module_test.caplog.records)
+        assert "object has no attribute 'stdout'" not in log_text, "wpscan crashed instead of degrading gracefully"
+
+
+class TestwpscanNotInstalled(Testwpscan):
+    """wpscan is not installed -- setup() soft-fails and the module is disabled."""
+
+    async def setup_before_prep(self, module_test):
+        original_which = module_test.scan.helpers.which
+
+        def which(*executables, **kwargs):
+            if "wpscan" in executables:
+                return None
+            return original_which(*executables, **kwargs)
+
+        module_test.monkeypatch.setattr(module_test.scan.helpers, "which", which)
+
+    async def setup_after_prep(self, module_test):
+        pass
+
+    def check(self, module_test, events):
+        assert "wpscan" not in module_test.scan.modules, "wpscan should be disabled when not installed"


### PR DESCRIPTION
## Problem

When the `wpscan` gem isn't installed, `wpscan.setup()` still returned `True`
unconditionally, so the module ran on every `HTTP_RESPONSE` / `TECHNOLOGY`
event. Each run failed to spawn the binary -> `helpers.run()` returned `None`
-> `output.stdout` raised `'NoneType' object has no attribute 'stdout'`,
flooding the scan log with one `Error in wpscan.handle_event(...)` per event.

## Fix

- `setup()` now checks for the binary via `self.helpers.which("wpscan")` and
  soft-fails (disabling the module) when it's missing, matching the
  gowitness/chrome pattern -- a missing dependency disables the module cleanly
  instead of erroring on every event.
- As defense for a mid-scan failure, the shared `run_wpscan()` helper guards
  against `run()` returning `None`, warning once instead of raising per event.

Adds regression tests for both the not-installed (soft-fail) and failed-run
paths.
