### PR TITLE
asn: filter non-global IPs and serialize asndb lookups

### DIFF
--- a/bbot/core/helpers/asn.py
+++ b/bbot/core/helpers/asn.py
@@ -1,6 +1,7 @@
 import logging
 
 from bbot.errors import ASNResolutionError
+from bbot.core.helpers.async_helpers import NamedLock
 
 log = logging.getLogger("bbot.core.helpers.asn")
 
@@ -30,6 +31,8 @@ class ASNHelper:
         self._client = None
         self._consecutive_failures = 0
         self._circuit_broken = False
+        # serialize asndb requests so concurrent callers don't stampede the rate-limited API
+        self._request_lock = NamedLock()
 
     @property
     def client(self):
@@ -69,7 +72,8 @@ class ASNHelper:
         if self._circuit_broken:
             return self.UNKNOWN_ASN
         try:
-            response = await self.client.lookup_ip(str(ip), include_subnets=True)
+            async with self._request_lock.lock("asndb"):
+                response = await self.client.lookup_ip(str(ip), include_subnets=True)
         except Exception as e:
             log.warning(f"ASN lookup failed for IP {ip}: {e}")
             self._record_failure()
@@ -89,7 +93,8 @@ class ASNHelper:
         last_error = None
         for attempt in range(1, self.MAX_RETRIES + 1):
             try:
-                response = await self.client.lookup_asn(asn, include_subnets=True)
+                async with self._request_lock.lock("asndb"):
+                    response = await self.client.lookup_asn(asn, include_subnets=True)
                 return self._normalize(response)
             except Exception as e:
                 last_error = e

--- a/bbot/modules/report/asn.py
+++ b/bbot/modules/report/asn.py
@@ -24,7 +24,8 @@ class asn(BaseReportModule):
     async def filter_event(self, event):
         if str(event.module) == "ipneighbor":
             return False
-        if getattr(event.host, "is_private", False):
+        # only look up globally-routable IPs; private/CGNAT/reserved space has no public ASN
+        if not getattr(event.host, "is_global", True):
             return False
         return True
 

--- a/bbot/test/test_step_2/module_tests/test_module_asn.py
+++ b/bbot/test/test_step_2/module_tests/test_module_asn.py
@@ -32,6 +32,22 @@ class TestASNUnknownHandling(ModuleTestBase):
         )
 
 
+class TestASNCGNATFiltered(ModuleTestBase):
+    """CGNAT space (100.64.0.0/10) is not globally routable and has no public ASN, so it must be
+    filtered out before any lookup (is_global check, not just is_private)."""
+
+    targets = ["100.64.0.1"]
+    module_name = "asn"
+    modules_overrides = ["asn", "speculate"]
+    config_overrides = {"scope": {"report_distance": 2}, "speculate": True}
+
+    def check(self, module_test, events):
+        asn_events = [e for e in events if e.type == "ASN"]
+        assert not asn_events, (
+            f"Should not emit any ASN events for CGNAT IP, but found: {[e.data for e in asn_events]}"
+        )
+
+
 class TestASNReportNoNetwork(ModuleTestBase):
     """Regression: report() uses metadata stored during handle_event() with zero network calls."""
 


### PR DESCRIPTION
Two independent hardening fixes for the `asn` report module's ASN lookups (which run through the bbot.io asndb API).

**1. Skip non-globally-routable IPs** (`report/asn.py`)

`filter_event` previously dropped only `is_private` IPs, which misses CGNAT (`100.64.0.0/10`) and other special-use space. Those have no public ASN, so each lookup is a wasted request (the API returns 404). The filter now uses `not is_global`, covering private, CGNAT, link-local, and reserved ranges in one check. On a passive netflix scan this alone accounted for 73 wasted CGNAT lookups (Open Connect appliances living in ISP NAT space), all 404s against a rate-limited API. Added `TestASNCGNATFiltered`; existing tests still pass (4/4).

**2. Serialize asndb requests** (`core/helpers/asn.py`)

The asndb client has no shared backoff, so concurrent callers (the asn module, waf_bypass, ASN-target expansion) each retry independently and can stampede the rate-limited API, losing lookups to timeouts. The client calls are now wrapped in a `NamedLock("asndb")` so they serialize instead of contending. On a rate-limited API, serial is strictly better than concurrent (measured: 24 concurrent cold lookups dropped 14 to timeout, whereas the same 24 run serially all completed).

