### PR TITLE
fix virtualhost.finish() crash on None baseline_response

### DIFF
--- a/bbot/modules/virtualhost.py
+++ b/bbot/modules/virtualhost.py
@@ -990,6 +990,10 @@ class virtualhost(BaseModule):
 
                 self.verbose(f"FINISH METHOD: Starting wildcard check for {host}")
                 baseline_response = await self._get_baseline_response(event, host, host_ip)
+                if not baseline_response:
+                    self.debug(f"FINISH METHOD: Failed to get baseline response for {host}, skipping wordcloud check")
+                    self.wordcloud_tried_hosts.add(host)
+                    continue
                 if not await self._wildcard_canary_check(
                     host_parsed_url.scheme, host_parsed_url.netloc, event, host_ip, baseline_response
                 ):

--- a/bbot/test/test_step_2/module_tests/test_module_virtualhost.py
+++ b/bbot/test/test_step_2/module_tests/test_module_virtualhost.py
@@ -892,6 +892,113 @@ class TestVirtualhostHTTPResponse(VirtualhostTestBase):
         )
 
 
+class TestVirtualhostFinishNoneBaseline(VirtualhostTestBase):
+    """Regression: finish() must not crash when _get_baseline_response returns None.
+
+    Previously, finish() passed the baseline response straight into
+    _wildcard_canary_check without a null check. A failed baseline request
+    surfaced as: `'NoneType' object has no attribute 'status_code'`.
+    """
+
+    targets = ["http://finishnone.test:8888"]
+    modules_overrides = ["http", "virtualhost"]
+    config_overrides = {
+        "modules": {
+            "virtualhost": {
+                "subdomain_brute": False,
+                "mutation_check": False,
+                "special_hosts": False,
+                "certificate_sans": False,
+                "wordcloud_check": True,
+                "require_inaccessible": False,
+            }
+        }
+    }
+
+    async def setup_after_prep(self, module_test):
+        await super().setup_after_prep(module_test)
+
+        await module_test.mock_dns({"finishnone.test": {"A": ["127.0.0.1"]}})
+
+        def mock_wordcloud_keys(self):
+            return ["staging", "prod", "dev"]
+
+        module_test.monkeypatch.setattr("bbot.core.helpers.wordcloud.WordCloud.keys", mock_wordcloud_keys)
+
+        vh_module = module_test.scan.modules["virtualhost"]
+        original_get_baseline = vh_module._get_baseline_response
+        original_wildcard_check = vh_module._wildcard_canary_check
+        self.baseline_calls = 0
+        self.wildcard_check_probes = []
+
+        async def flaky_baseline(event, normalized_url, host_ip):
+            self.baseline_calls += 1
+            # First call (from handle_event) returns a real response so the
+            # host gets recorded in scanned_hosts. Subsequent calls (from
+            # finish()) return None to reproduce the crash.
+            if self.baseline_calls == 1:
+                return await original_get_baseline(event, normalized_url, host_ip)
+            return None
+
+        async def spying_wildcard_check(probe_scheme, probe_host, event, host_ip, probe_response):
+            self.wildcard_check_probes.append(probe_response)
+            return await original_wildcard_check(probe_scheme, probe_host, event, host_ip, probe_response)
+
+        module_test.monkeypatch.setattr(vh_module, "_get_baseline_response", flaky_baseline)
+        module_test.monkeypatch.setattr(vh_module, "_wildcard_canary_check", spying_wildcard_check)
+
+        from bbot.modules.base import BaseModule
+
+        class DummyModule(BaseModule):
+            _name = "dummy_module_finish_none"
+            watched_events = ["SCAN"]
+
+            async def handle_event(self, event):
+                if event.type == "SCAN":
+                    url_event = self.scan.make_event(
+                        "http://finishnone.test:8888/",
+                        "URL",
+                        parent=event,
+                        tags=["status-200", "ip-127.0.0.1"],
+                    )
+                    await self.emit_event(url_event)
+
+        module_test.scan.modules["dummy_module_finish_none"] = DummyModule(module_test.scan)
+
+        orig_handle_event = vh_module.handle_event
+
+        async def patched_handle_event(ev):
+            ev._resolved_hosts = {"127.0.0.1"}
+            return await orig_handle_event(ev)
+
+        module_test.monkeypatch.setattr(vh_module, "handle_event", patched_handle_event)
+
+    def request_handler(self, request):
+        host_header = request.headers.get("Host", "").lower()
+
+        if not host_header or host_header in ["finishnone.test", "finishnone.test:8888"]:
+            return Response("baseline response from finishnone.test", status=200)
+
+        if re.match(r"[a-z]inishnone\.test(?::8888)?$", host_header):
+            return Response("wildcard canary response", status=404)
+
+        if re.match(r"^[a-z]{12}\.com(?::8888)?$", host_header):
+            return Response("random canary response", status=404)
+
+        return Response("default response", status=404)
+
+    def check(self, module_test, events):
+        assert self.baseline_calls >= 2, (
+            f"finish() wordcloud path did not run; only {self.baseline_calls} baseline call(s)"
+        )
+        # finish() must guard against None baseline_response before calling
+        # _wildcard_canary_check. Passing None causes the crash.
+        assert None not in self.wildcard_check_probes, (
+            "finish() invoked _wildcard_canary_check with probe_response=None; "
+            "expected the None baseline to be skipped instead"
+        )
+
+
 class TestVirtualhostCertificateSANs(VirtualhostTestBase):
     """Exercise the certificate-SAN code path on HTTPS URL events."""
 


### PR DESCRIPTION
## Summary

`virtualhost.finish()` passed the `_get_baseline_response()` return value straight into `_wildcard_canary_check()` without a null check. When the baseline request failed, `probe_response` was `None` and `_wildcard_canary_check` crashed on `probe_response.status_code`:

```
[ERROR] bbot.scanner scanner.py:1499 Error in virtualhost.finish(): virtualhost.py:425:_wildcard_canary_check(): 'NoneType' object has no attribute 'status_code'
```

`handle_event()` already guards this case; `finish()` was missing the same check.

## Changes

- `bbot/modules/virtualhost.py` — early `continue` when `baseline_response` is `None`, mark host as tried.
- `bbot/test/test_step_2/module_tests/test_module_virtualhost.py` — regression test `TestVirtualhostFinishNoneBaseline` that stubs the second `_get_baseline_response` call to return `None` and asserts `_wildcard_canary_check` is never invoked with `probe_response=None`.