### PR TITLE
Escape control characters in console output

### DIFF
--- a/bbot/core/config/logger.py
+++ b/bbot/core/config/logger.py
@@ -28,6 +28,12 @@ class ColoredFormatter(logging.Formatter):
         # escape control characters in scan-derived text so they can't corrupt the terminal
         colored_record.msg = make_printable(colored_record.getMessage())
         colored_record.args = None
+        if colored_record.exc_info and not colored_record.exc_text:
+            colored_record.exc_text = self.formatException(colored_record.exc_info)
+        if colored_record.exc_text:
+            colored_record.exc_text = make_printable(colored_record.exc_text)
+        if colored_record.stack_info:
+            colored_record.stack_info = make_printable(colored_record.stack_info)
         levelname = colored_record.levelname
         levelshort = loglevel_mapping.get(levelname, "INFO")
         colored_record.levelname = colorize(f"[{levelshort}]", level=levelname)

--- a/bbot/core/config/logger.py
+++ b/bbot/core/config/logger.py
@@ -8,7 +8,7 @@ import logging.handlers
 from pathlib import Path
 from contextlib import suppress
 
-from ..helpers.misc import mkdir, error_and_exit
+from ..helpers.misc import mkdir, error_and_exit, make_printable
 from ..multiprocess import SHARED_INTERPRETER_STATE
 from ...logger import colorize, loglevel_mapping, GzipRotatingFileHandler
 
@@ -25,6 +25,9 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         colored_record = copy(record)
+        # escape control characters in scan-derived text so they can't corrupt the terminal
+        colored_record.msg = make_printable(colored_record.getMessage())
+        colored_record.args = None
         levelname = colored_record.levelname
         levelshort = loglevel_mapping.get(levelname, "INFO")
         colored_record.levelname = colorize(f"[{levelshort}]", level=levelname)

--- a/bbot/core/helpers/misc.py
+++ b/bbot/core/helpers/misc.py
@@ -2999,3 +2999,18 @@ def is_printable(s):
     # Exclude control characters that break display/printing
     s = set(s)
     return all(ord(c) >= 32 or c in "\t\n\r" for c in s)
+
+
+_control_char_re = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def make_printable(s):
+    """
+    Escape non-printable control characters so a string is safe to write to a terminal.
+
+    Keeps tab, newline, and carriage return; renders other control bytes (e.g. 0x0e Shift Out) as \\xNN.
+    Inverse of is_printable().
+    """
+    if not isinstance(s, str):
+        s = smart_decode(s)
+    return _control_char_re.sub(lambda m: f"\\x{ord(m.group()):02x}", s)

--- a/bbot/logger.py
+++ b/bbot/logger.py
@@ -46,8 +46,11 @@ def log_to_stderr(msg, level="INFO", logname=True):
     """
     Print to stderr with BBOT logger colors
     """
+    from bbot.core.helpers.misc import make_printable
+
     levelname = level.upper()
     if not any(x in sys.argv for x in ("-s", "--silent")):
+        msg = make_printable(msg)
         levelshort = f"[{loglevel_mapping.get(level, 'INFO')}]"
         levelshort = f"{colorize(levelshort, level=levelname)}"
         if levelname == "CRITICAL" or levelname.startswith("HUGE"):

--- a/bbot/modules/output/stdout.py
+++ b/bbot/modules/output/stdout.py
@@ -70,6 +70,9 @@ class Stdout(BaseOutputModule):
         else:
             event_str = self.human_event_str(event)
 
+        # escape control characters so they can't corrupt the terminal
+        event_str = self.helpers.make_printable(event_str)
+
         # color findings: severity picks the hue, confidence dims the brightness
         if event.type == "FINDING" and isinstance(event.data, dict) and self.use_color:
             event_str = self._colorize_finding(event_str, event)

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -958,6 +958,38 @@ async def test_cli_console_control_chars(monkeypatch, capsys):
     assert "\x0e" not in err and "\x1b(0" not in err
     assert "\\x0e" in err
 
+    # tracebacks and stack info are also sanitized (an exception carrying scan-derived
+    # bytes must not reach the terminal unescaped via logger.exception / exc_info=True)
+    try:
+        raise ValueError(dirty)
+    except ValueError:
+        exc_record = logging.LogRecord(
+            name="bbot.modules.nuclei",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="boom",
+            args=None,
+            exc_info=sys.exc_info(),
+        )
+    formatted = formatter.format(exc_record)
+    assert "\x0e" not in formatted and "\x1b(0" not in formatted
+    assert "\\x0e" in formatted and "ValueError" in formatted
+
+    stack_record = logging.LogRecord(
+        name="bbot.modules.nuclei",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=1,
+        msg="boom",
+        args=None,
+        exc_info=None,
+    )
+    stack_record.stack_info = f"Stack: {dirty}"
+    formatted = formatter.format(stack_record)
+    assert "\x0e" not in formatted and "\x1b(0" not in formatted
+    assert "\\x0e" in formatted
+
 
 @pytest.mark.asyncio
 async def test_cli_reset_config(monkeypatch, caplog, tmp_path):

--- a/bbot/test/test_step_1/test_cli.py
+++ b/bbot/test/test_step_1/test_cli.py
@@ -923,6 +923,43 @@ async def test_cli_no_color(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_cli_console_control_chars(monkeypatch, capsys):
+    import logging
+    from bbot.logger import log_to_stderr
+    from bbot.core.config.logger import ColoredFormatter
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    # scan-derived text carrying the bytes that flip a terminal into its line-drawing charset:
+    # 0x0e (Shift Out) and an "ESC ( 0" designate-line-drawing sequence
+    dirty = "matched banner: \x1b(0\x0edeadbeef"
+
+    # the stderr log formatter escapes control chars before adding its own colors
+    formatter = ColoredFormatter("%(levelname)s %(name)s: %(message)s")
+    record = logging.LogRecord(
+        name="bbot.modules.nuclei",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="%s",
+        args=(dirty,),
+        exc_info=None,
+    )
+    formatted = formatter.format(record)
+    assert "\x0e" not in formatted
+    assert "\x1b(0" not in formatted
+    assert "\\x0e" in formatted and "\\x1b(0" in formatted
+    # BBOT's own ANSI color codes survive (escaping happens on the message, before colorizing)
+    assert "\x1b[" in formatted
+
+    # same protection on the early bootstrap path
+    log_to_stderr(dirty, level="INFO")
+    out, err = capsys.readouterr()
+    assert "\x0e" not in err and "\x1b(0" not in err
+    assert "\\x0e" in err
+
+
+@pytest.mark.asyncio
 async def test_cli_reset_config(monkeypatch, caplog, tmp_path):
     from bbot.core import CORE
 

--- a/bbot/test/test_step_1/test_helpers.py
+++ b/bbot/test/test_step_1/test_helpers.py
@@ -472,6 +472,17 @@ async def test_helpers_misc(helpers, scan, bbot_scanner, bbot_httpserver):
     assert helpers.is_printable("4") is True
     assert helpers.is_printable("asdf\x00") is False
 
+    # make_printable
+    assert helpers.make_printable("asdf") == "asdf"
+    assert helpers.make_printable("ドメイン.テスト") == "ドメイン.テスト"
+    # 0x0e (Shift Out) is the byte that flips a terminal into its line-drawing charset
+    assert helpers.make_printable("a\x0eb") == "a\\x0eb"
+    assert helpers.make_printable("\x00\x1b\x7f") == "\\x00\\x1b\x7f"
+    # tab, newline, and carriage return are preserved
+    assert helpers.make_printable("tab\tnl\ncr\r") == "tab\tnl\ncr\r"
+    # bytes are decoded before escaping
+    assert helpers.make_printable(b"a\x0eb") == "a\\x0eb"
+
     # punycode
     assert helpers.smart_encode_punycode("ドメイン.テスト") == "xn--eckwd4c7c.xn--zckzah"
     assert helpers.smart_decode_punycode("xn--eckwd4c7c.xn--zckzah") == "ドメイン.テスト"

--- a/bbot/test/test_step_2/module_tests/test_module_stdout.py
+++ b/bbot/test/test_step_2/module_tests/test_module_stdout.py
@@ -124,6 +124,34 @@ class TestStdoutFindingColor(TestStdout):
         assert colored_info == "\033[38;2;62;88;140mtest\033[0m"
 
 
+class TestStdoutControlChars(TestStdout):
+    module_name = "stdout"
+
+    async def check(self, module_test, events):
+        module = module_test.module
+        # a FINDING whose description carries a raw 0x0e (Shift Out), as matched response content can
+        finding = module_test.scan.make_event(
+            {
+                "host": "evilcorp.com",
+                "severity": "INFO",
+                "confidence": "UNKNOWN",
+                "name": "Test",
+                "description": "matched banner \x0e deadbeef",
+            },
+            "FINDING",
+            dummy=True,
+        )
+        # sanity: the raw control byte really does reach the human-readable string
+        assert "\x0e" in module.human_event_str(finding)
+
+        module_test.capsys.readouterr()  # discard captured scan output
+        await module.handle_text(finding, finding.json(mode="human"))
+        out, err = module_test.capsys.readouterr()
+        # the byte that would flip the terminal into its line-drawing charset is escaped, not printed raw
+        assert "\x0e" not in out
+        assert "\\x0e" in out
+
+
 class TestStdoutNoDupes(TestStdoutDupes):
     config_overrides = {
         "dns": {"minimal": False},


### PR DESCRIPTION
Fixes #3258.

Raw control bytes in scan data (e.g. `0x0e`, Shift Out) could reach the terminal through BBOT's console output and flip it into its line-drawing charset, garbling all subsequent output until `reset`. The scan and output files are unaffected; it's display-only corruption, and rare since it only triggers when a target returns such a byte in a spot that gets echoed.

This sanitizes scan-derived text at the three console boundaries, escaping C0 control bytes to a visible `\xNN` form (keeping tab/newline/carriage return) via a shared `make_printable()` helper:

- `ColoredFormatter` (stderr log handler): escapes the rendered message before adding ANSI colors
- `stdout` output module: escapes event strings before printing
- `log_to_stderr`: the early bootstrap path