### PR TITLE
Fix stale baddns config key in kitchen-sink preset

### DIFF
--- a/bbot/presets/kitchen-sink.yml
+++ b/bbot/presets/kitchen-sink.yml
@@ -14,8 +14,6 @@ include:
 
 config:
   modules:
-    baddns:
-      enable_references: True
     dnsbrute:
       recursive_mutations: true
     dnscommonsrv:

--- a/bbot/test/test_step_1/test_validate_preset.py
+++ b/bbot/test/test_step_1/test_validate_preset.py
@@ -212,6 +212,23 @@ def test_validate_preset_interactsh_server_rejects_invalid():
         assert repr(v) in errs[0].message
 
 
+def test_bundled_presets_validate_clean():
+    """Every YAML preset shipped under bbot/presets/ must pass validation."""
+    from pathlib import Path
+    import bbot
+    from bbot.scanner import validate_preset_file
+
+    presets_dir = Path(bbot.__file__).parent / "presets"
+    failures = {}
+    for preset_path in sorted(presets_dir.rglob("*.yml")):
+        errs = validate_preset_file(preset_path)
+        if errs:
+            failures[str(preset_path.relative_to(presets_dir))] = [str(e) for e in errs]
+    assert not failures, "bundled presets failed validation:\n" + "\n".join(
+        f"  {name}:\n    " + "\n    ".join(msgs) for name, msgs in failures.items()
+    )
+
+
 def test_defaults_yml_validates_against_schema():
     """BBOT's own defaults.yml must pass its own validator. Guards against the pydantic
     schema (core/config/models.py) silently drifting from defaults.yml -- if a key is


### PR DESCRIPTION
Closes #3279.

`kitchen-sink.yml` set `modules.baddns.enable_references: True`, which
is no longer a valid config option (the current key is
`enabled_submodules`). Preset validation fails before the scan starts.

The override is also redundant: `kitchen-sink` already includes
`baddns-heavy`, which sets
`enabled_submodules: [CNAME, NS, MX, TXT, references, DMARC, SPF, MTA-STS, WILDCARD]`.
So the fix is to drop the block entirely.

Also adds `test_bundled_presets_validate_clean`, which runs
`validate_preset_file` against every YAML under `bbot/presets/` and
fails on any error. Would have caught this drift when the baddns option
was renamed.