### PR TITLE
Attribute automated docs update PRs to blsaccess

### DIFF
--- a/.github/workflows/docs_updater.yml
+++ b/.github/workflows/docs_updater.yml
@@ -32,3 +32,5 @@ jobs:
           base: dev
           title: "Automated Docs Update"
           body: "This is an automated pull request to update the documentation."
+          committer: blsaccess <info@blacklanternsecurity.com>
+          author: blsaccess <info@blacklanternsecurity.com>


### PR DESCRIPTION
`docs_updater.yml` did not set `author` / `committer` on the
`peter-evans/create-pull-request` step, so it defaulted to
`github.actor` and the commit on each automated docs PR was attributed
to whichever human last touched the workflow file.

`version_updater.yml` already pins both to the `blsaccess` service
account. This mirrors that so all automated updater PRs are attributed
consistently.