### PR TITLE
Fix openssl_dev_headers dep check to require the header

### DIFF
--- a/bbot/core/helpers/depsinstaller/installer.py
+++ b/bbot/core/helpers/depsinstaller/installer.py
@@ -453,14 +453,16 @@ class DepsInstaller:
         For special entries like openssl_dev_headers, use a custom check.
         """
         if command == "openssl_dev_headers":
-            # check for openssl headers by looking for the pkg-config file or header
+            # look for the actual header. the openssl binary is NOT a proxy: many minimal
+            # images (e.g. python:3.11-slim) ship openssl but not the -dev headers, and
+            # anything that compiles against libssl needs the header.
             return any(
                 Path(p).exists()
                 for p in [
                     "/usr/include/openssl/ssl.h",
                     "/usr/local/include/openssl/ssl.h",
                 ]
-            ) or bool(self.parent_helper.which("openssl"))
+            )
         return bool(self.parent_helper.which(command))
 
     async def install_core_deps(self):


### PR DESCRIPTION
Closes #3272.

`_core_dep_satisfied` treated the `openssl` binary as evidence that the
OpenSSL dev headers were installed:

```python
return any(Path(p).exists() for p in ["/usr/include/openssl/ssl.h", ...]) \
    or bool(self.parent_helper.which("openssl"))
```

Minimal images (e.g. `python:3.11-slim`) ship the `openssl` binary but
not `libssl-dev`, so the check returned True, the core-deps installer
skipped installing the headers, and source builds that compile against
libssl (medusa's `./configure`) failed with:

```
configure: error:  *** OpenSSL header files required for SSL support. ***
```

Fix: require the actual header. `libssl-dev` / `openssl-devel` / etc.
are already in `CORE_DEPS["openssl_dev_headers"]` for every distro, so
once the check reports "not satisfied" they get installed as intended
and medusa (and any other source-built dep) compiles cleanly.

Reproduced on `python:3.11-slim`: with the fix, `openssl_dev_headers`
correctly reports unsatisfied and `libssl-dev` gets installed.