### PR TITLE
Point API-key docs to secrets.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ For more information, see [Targets](https://www.blacklanternsecurity.com/bbot/St
 
 Similar to Amass or Subfinder, BBOT supports API keys for various third-party services such as SecurityTrails, etc.
 
-The standard way to do this is to enter your API keys in **`~/.config/bbot/bbot.yml`**. Note that multiple API keys are allowed:
+The standard way to do this is to enter your API keys in **`~/.config/bbot/secrets.yml`**. Note that multiple API keys are allowed:
 ```yaml
 modules:
   shodan_dns:

--- a/docs/index.md
+++ b/docs/index.md
@@ -129,11 +129,11 @@ config:
       api_key: cafebabe
 ```
 
-...in BBOT's global YAML config (`~/.config/bbot/bbot.yml`):
+...in BBOT's global secrets file (`~/.config/bbot/secrets.yml`):
 
 Note: this will ensure the API keys are used in all scans, regardless of preset.
 
-```yaml title="~/.config/bbot/bbot.yml"
+```yaml title="~/.config/bbot/secrets.yml"
 modules:
   shodan_dns:
     api_key: deadbeef

--- a/docs/scanning/configuration.md
+++ b/docs/scanning/configuration.md
@@ -2,7 +2,7 @@
 
 Normally, [Presets](presets.md) are used to configure a scan. However, there may be cases where you want to change BBOT's global defaults so a certain option is always set, even if it's not specified in a preset.
 
-BBOT has a YAML config at `~/.config/bbot/bbot.yml`. This is the first config that BBOT loads, so it's a good place to put default settings like `http_proxy`, `max_threads`, or `http_user_agent`. You can also put any module settings here, including **API keys**.
+BBOT has a YAML config at `~/.config/bbot/bbot.yml`. This is the first config that BBOT loads, so it's a good place to put default settings like `http_proxy`, `max_threads`, or `http_user_agent`. **API keys** and other sensitive values go in a companion file at `~/.config/bbot/secrets.yml`.
 
 For a list of all possible config options, see:
 
@@ -15,11 +15,12 @@ For examples of common config changes, see [Tips and Tricks](tips_and_tricks.md)
 
 BBOT loads its config from the following files, in this order (last one loaded == highest priority):
 
-- `~/.config/bbot/bbot.yml`  <-- Global BBOT config
-- presets (`-p`)             <-- Presets are good for scan-specific settings
-- command line (`-c`)        <-- CLI overrides everything
+- `~/.config/bbot/bbot.yml`      <-- Global BBOT config
+- `~/.config/bbot/secrets.yml`   <-- API keys and other sensitive values
+- presets (`-p`)                 <-- Presets are good for scan-specific settings
+- command line (`-c`)            <-- CLI overrides everything
 
-`bbot.yml` will be automatically created for you when you first run BBOT.
+Both `bbot.yml` and `secrets.yml` are automatically created for you when you first run BBOT.
 
 ## YAML Config vs Command Line
 
@@ -40,8 +41,8 @@ These two are equivalent.
 
 Config options specified via the command-line take precedence over all others. You can give BBOT a custom config file with `-c myconf.yml`, or individual arguments like this: `-c modules.shodan_dns.api_key=deadbeef`. To display the full and current BBOT config, including any command-line arguments, use `bbot -c`.
 
-Note that placing the following in `bbot.yml`:
-```yaml title="~/.config/bbot/bbot.yml"
+Note that placing the following in `secrets.yml`:
+```yaml title="~/.config/bbot/secrets.yml"
 modules:
   shodan_dns:
     api_key: deadbeef

--- a/docs/scanning/index.md
+++ b/docs/scanning/index.md
@@ -273,7 +273,7 @@ Wildcard hosts are collapsed into a single host beginning with `_wildcard`:
 
 If you don't want this, you can disable wildcard detection on a domain-to-domain basis in the [config](configuration.md):
 
-```yaml title="~/.bbot/config/bbot.yml"
+```yaml title="~/.config/bbot/bbot.yml"
 dns:
   wildcard_ignore:
     - evilcorp.com
@@ -282,7 +282,7 @@ dns:
 
 There are certain edge cases (such as with dynamic DNS rules) where BBOT's wildcard detection fails. In these cases, you can try increasing the number of wildcard checks in the config:
 
-```yaml title="~/.bbot/config/bbot.yml"
+```yaml title="~/.config/bbot/bbot.yml"
 # default == 10
 dns:
   wildcard_tests: 20

--- a/docs/scanning/tips_and_tricks.md
+++ b/docs/scanning/tips_and_tricks.md
@@ -133,7 +133,7 @@ bbot -t evilcorp.com -f subdomain-enum -m gowitness -c web.http_proxy=http://127
 
 BBOT's `http` module emits `HTTP_RESPONSE` events, but by default they're hidden from output. These events contain the full raw HTTP body along with headers, etc. If you want to see them, you can modify `omit_event_types` in the config:
 
-```yaml title="~/.bbot/config/bbot.yml"
+```yaml title="~/.config/bbot/bbot.yml"
 omit_event_types:
   - URL_UNVERIFIED
   # - HTTP_RESPONSE


### PR DESCRIPTION
Closes #3270.

A few sections of the docs still directed users to put API keys in
`bbot.yml` when they belong in `secrets.yml` (which is what
`api_key: str = Field(..., sensitive=True)` and the auto-generated
template both dictate).

Verified against the code:
- Both `bbot.yml` and `secrets.yml` are auto-created on first run
  (`ModuleLoader.ensure_config_files`).
- `secrets.yml` is loaded after `bbot.yml` and overrides it on
  conflict (`get_custom_config` -> `deep_merge(bbot.yml, secrets.yml)`).
- The auto-generated `secrets.yml` template is built from
  `secrets_only_config()`, which filters to fields marked
  `sensitive=True` (i.e. `api_key`, etc.).

Files updated:
- `README.md` (the line called out in the issue)
- `docs/index.md` (API keys section)
- `docs/scanning/configuration.md` (intro, file list, and the
  `shodan_dns.api_key` example; the `http_proxy` example is left in
  `bbot.yml` since it's not sensitive)