### PR TITLE
Fix docker_pull crash on failed registry request

### DIFF
--- a/bbot/modules/docker_pull.py
+++ b/bbot/modules/docker_pull.py
@@ -81,7 +81,10 @@ class docker_pull(BaseModule):
         """Make a request to the URL if that fails try to obtain an authentication token and try again."""
         for _ in range(2):
             response = await self.helpers.request(url, headers=self.headers, follow_redirects=True)
-            if response is not None and response.status_code != 401:
+            if response is None:
+                self.log.warning(f"Request to {url} failed")
+                break
+            if response.status_code != 401:
                 return response
             www_auth = response.headers.get("www-authenticate", "")
             realm, service, scope = self._parse_www_authenticate(www_auth)

--- a/bbot/test/test_step_2/module_tests/test_module_docker_pull.py
+++ b/bbot/test/test_step_2/module_tests/test_module_docker_pull.py
@@ -558,6 +558,28 @@ class TestDockerPullRealmValidation(ModuleTestBase):
         assert "test_token_value" not in auth_header, "Module followed a non-HTTPS realm"
 
 
+class TestDockerPullRequestFailure(ModuleTestBase):
+    modules_overrides = ["docker_pull"]
+
+    async def setup_after_prep(self, module_test):
+        m = module_test.scan.modules["docker_pull"]
+        # no mock is registered for this URL, so the request fails and returns None
+        try:
+            self.result = await m.docker_api_request("https://registry-1.docker.io/v2/nonexistent/tags/list")
+        except Exception as e:
+            self.result = f"error: {e}"
+        # a failed request must not prevent the higher-level helpers from returning sane defaults
+        self.tags = await m.get_tags("https://registry-1.docker.io", "nonexistent")
+        self.manifest = await m.get_manifest("https://registry-1.docker.io", "nonexistent", "latest")
+        self.blob = await m.download_blob("https://registry-1.docker.io", "nonexistent", "sha256:deadbeef")
+
+    def check(self, module_test, events):
+        assert self.result is None, f"expected None when the request fails, got {self.result!r}"
+        assert self.tags == ["latest"]
+        assert self.manifest == {}
+        assert self.blob is None
+
+
 class TestDockerPullPathTraversal(ModuleTestBase):
     modules_overrides = ["docker_pull"]
     config_overrides = {"modules": {"docker_pull": {"output_folder": str(bbot_test_dir / "test_docker_traversal")}}}


### PR DESCRIPTION
### Summary

`docker_pull.docker_api_request()` crashes with `AttributeError: 'NoneType' object has no attribute 'headers'` when the registry request fails outright.

The `response is not None` check only guarded the return path:

```python
response = await self.helpers.request(...)
if response is not None and response.status_code != 401:
    return response
www_auth = response.headers.get("www-authenticate", "")   # None here
```

When `helpers.request()` returns `None` (connection failure, timeout, WAF-fronted registry dropping the request) the `and` short-circuits, execution falls through, and `None.headers` raises.

Seen in the wild against a Cloudflare-fronted registry:

```
ERROR [bbot] Error in docker_pull.handle_event(CODE_REPOSITORY(...)):
  bbot/modules/docker_pull.py:86:docker_api_request(): 'NoneType' object has no attribute 'headers'
```

### Fix

Separate the two conditions so a failed request logs and breaks out of the retry loop, returning `None`. Every caller (`get_tags`, `get_manifest`, `download_blob`) already handles a `None` return correctly, so the crash was confined to this one line.

### Tests

Adds `TestDockerPullRequestFailure`, which calls `docker_api_request()` against an unmocked URL (yields `None`) and asserts it returns `None` without raising, plus that the three callers fall back to their defaults (`["latest"]`, `{}`, `None`). Verified it reproduces the traceback above when the fix is reverted.
