### PR TITLE
Skip test and distro suites on docs-only changes

### DIFF
--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           filters: |
             code:
-              - '!(docs/**|**/*.md|mkdocs.yml|LICENSE|.gitignore)'
+              - '!{docs/**,**/*.md,*.md,mkdocs.yml,LICENSE,.gitignore}'
 
   test-distros:
     needs: changes

--- a/.github/workflows/distro_tests.yml
+++ b/.github/workflows/distro_tests.yml
@@ -7,7 +7,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!(docs/**|**/*.md|mkdocs.yml|LICENSE|.gitignore)'
+
   test-distros:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # Anything that is not documentation. Listing what counts as docs and
+          # negating it means a new top-level directory runs the suite by
+          # default, rather than being silently skipped.
+          filters: |
+            code:
+              - '!(docs/**|**/*.md|mkdocs.yml|LICENSE|.gitignore)'
+
   test:
+    needs: changes
+    # Skipped jobs report success to required status checks, where a job that
+    # never runs at all reports nothing and blocks the PR forever. The matrix
+    # contexts here are required, so this has to be a job-level `if`, not a
+    # workflow-level `paths-ignore`.
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       # if one python version fails, let the others finish
@@ -54,7 +76,13 @@ jobs:
   publish_code:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stable')
+    # !failure() && !cancelled() rather than success(): `test` is skipped on a
+    # docs-only push, and a skipped dependency would otherwise take the publish
+    # down with it.
+    if: |
+      !failure() && !cancelled()
+      && github.event_name == 'push'
+      && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stable')
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,20 +20,13 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          # Anything that is not documentation. Listing what counts as docs and
-          # negating it means a new top-level directory runs the suite by
-          # default, rather than being silently skipped.
           filters: |
             code:
-              - '!(docs/**|**/*.md|mkdocs.yml|LICENSE|.gitignore)'
+              - '!{docs/**,**/*.md,*.md,mkdocs.yml,LICENSE,.gitignore}'
 
   test:
     needs: changes
-    # Skipped jobs report success to required status checks, where a job that
-    # never runs at all reports nothing and blocks the PR forever. The matrix
-    # contexts here are required, so this has to be a job-level `if`, not a
-    # workflow-level `paths-ignore`.
-    if: needs.changes.outputs.code == 'true'
+    if: github.event_name != 'pull_request' || needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       # if one python version fails, let the others finish
@@ -76,13 +69,7 @@ jobs:
   publish_code:
     needs: test
     runs-on: ubuntu-latest
-    # !failure() && !cancelled() rather than success(): `test` is skipped on a
-    # docs-only push, and a skipped dependency would otherwise take the publish
-    # down with it.
-    if: |
-      !failure() && !cancelled()
-      && github.event_name == 'push'
-      && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stable')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/stable')
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Every pull request currently runs the full test suite across 5 Python versions and the distro suite across 6 containers, no matter what changed. A README typo costs the same as a change to the scan engine.

This adds a `changes` job that classifies the diff, and gates `test` and `test-distros` on its result. Docs-only pull requests skip both.

## Two things that make this less trivial than it looks

**Required status checks are matrix contexts.** The ruleset on `dev` requires `test (3.10)` through `test (3.13)`. The obvious implementation, a workflow-level `paths-ignore`, means those jobs never run and therefore never report, and GitHub blocks the PR on permanently pending checks. A *skipped* job reports success, so the gate has to be a job-level `if:` instead. That is the only reason this is a `changes` job rather than five lines of `paths-ignore`.

**Pushes always run the suite.** The skip is scoped to `pull_request`. A push to `dev` or `stable` feeds `publish_code`, and skipping the suite there would publish a release whose tests never ran. `publish_code` keeps its plain `success()` dependency on `test`.

## Filter behavior

The filter lists what counts as documentation and negates it, so a new top-level directory runs the suite by default rather than being silently skipped:

```yaml
code:
  - '!{docs/**,**/*.md,*.md,mkdocs.yml,LICENSE,.gitignore}'
```

Braces rather than a `!(a|b)` extglob, which matters. paths-filter matches with picomatch, and picomatch treats `!(...)` as a single-path-segment extglob: the `docs/**` inside it never applies to nested paths. An earlier version of this PR used that form, and it classified `docs/scanning/index.md` as **code** while classifying `bbot/README.md` as **docs** — close to the exact inverse of the intent. `*.md` is listed alongside `**/*.md` because picomatch does not match root-level files with a leading `**/`.

Verified directly against picomatch 2.3.1, the version paths-filter pins:

| changed files | result |
|---|---|
| `docs/scanning/index.md` | skip |
| `docs/assets/diagram.png` | skip |
| `README.md`, `CONTRIBUTING.md` | skip |
| `bbot/README.md` | skip |
| `mkdocs.yml`, `LICENSE`, `.gitignore` | skip |
| `bbot/modules/foo.py` | run |
| `bbot/modules/foo.py` + `docs/index.md` | run |
| `pyproject.toml`, `uv.lock` | run |
| `.github/workflows/tests.yml` | run |
| a new `whatever/thing.py` | run |

Mixed code+docs PRs run everything, which is the important case: the filter can only skip when *nothing* outside the docs set changed.

## Scope

About 7% of recent merged PRs (4 of the last 60) were docs-only, so this is not a huge fraction of CI spend. It is a clean win on those, and it costs one small job on everything else.

The larger cost is the matrices themselves: 5 Python versions and 6 distros on every code PR. Trimming those on PRs while keeping the full set on merge to `dev` would save considerably more, but that is a policy call about coverage rather than a mechanical change, so it is not in this PR.

## Testing

The filter patterns are verified against picomatch 2.3.1 directly, case by case, per the table above.

I cannot exercise the required-status-check interaction from a fork, since the ruleset applies to `dev` in the upstream repo. The skip-satisfies-required-check behavior is worth confirming on a real docs-only PR before this is relied on.

If #3356 lands first, the `test matrix passed` job there is what should be required, and it is already configured to accept a skipped `test`.

I re-verified every row of the table above against picomatch 2.3.1 directly, including the broken `!(a|b)` extglob form, which does classify `docs/scanning/index.md` as code and `bbot/README.md` as docs. The braces form in this PR is correct.

## Conflicts

This and #3356 both insert a new job at the top of `tests.yml` and will conflict textually. Whichever lands second needs a trivial rebase; the two changes are independent in substance.

## Known gaps

- `dorny/paths-filter@v3` is a mutable tag. Every other third-party action in this repo is pinned the same way, so this is consistent with existing practice rather than a new risk, but it is worth noting given #3356 argues for pinning the gate action to a sha. Happy to pin this one too if preferred.
- The `changes` job relies on the default `GITHUB_TOKEN` permissions. If the repo default is ever tightened, this job needs `pull-requests: read` declared explicitly.

## CI status

`test (3.10)` failed here on `test_manager_scope_accuracy_correct`:

```
assert 1 == len([e for e in all_events_nodups
                 if e.type == "OPEN_TCP_PORT" and e.data == "127.0.0.33:8889" ...])
E       assert 1 == 0
```

This branch changes only workflow YAML, no Python at all, so it cannot be the cause. I reproduced it on unmodified `dev` serially: **1 failure in 9 runs**.

The test discovers `127.0.0.222:8889` and `127.0.0.33:8889` from links on the same page and then asserts on the deduplicated event set. Which of the pair survives dedup depends on arrival order, so occasionally the `.33` OPEN_TCP_PORT is not the one kept and the assertion sees zero.

Pre-existing flake on `dev`, unrelated to this PR and out of scope for it, but worth a separate issue. The other four Python versions passed, and the distro suite passed.

The `changes` job resolved `code=true` on this PR, which is correct: it touches workflow files, not just docs, so the full suite ran as intended.
