### PR TITLE
Require positive confirmation for lightfuzz code-change findings

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -958,6 +958,11 @@ class BaseEvent:
         web_spider_distance = getattr(self, "web_spider_distance", None)
         if web_spider_distance is not None:
             j["web_spider_distance"] = web_spider_distance
+        # provenance for events whose evidence is an archived snapshot rather than the live host.
+        # kept out of `data` so it doesn't become part of the event's identity.
+        archive_url = self.archive_url
+        if archive_url:
+            j["archive_url"] = archive_url
         # scope distance
         j["scope_distance"] = self.scope_distance
         # scan
@@ -1959,7 +1964,9 @@ class FINDING(ClosestHostEvent):
             confidence_str = f"[\033[1m{confidence}\033[0m]"
         else:
             confidence_str = f"[{confidence}]"
-        return f"Severity: [{severity}] Confidence: {confidence_str} {description}"
+        # the evidence came out of an archive, so the severity describes a snapshot, not the live host
+        archived_str = "[ARCHIVED] " if self.archive_url else ""
+        return f"{archived_str}Severity: [{severity}] Confidence: {confidence_str} {description}"
 
     def _data_human(self):
         parts = []
@@ -1972,6 +1979,10 @@ class FINDING(ClosestHostEvent):
         cves = self.data.get("cves", [])
         if cves:
             parts.append(f"[{', '.join(cves)}]")
+        # the evidence came out of an archive, so the severity describes a snapshot, not the live host
+        archive_url = self.archive_url
+        if archive_url:
+            parts.append(f"(archived: {archive_url})")
         return " ".join(parts)
 
 

--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -958,8 +958,7 @@ class BaseEvent:
         web_spider_distance = getattr(self, "web_spider_distance", None)
         if web_spider_distance is not None:
             j["web_spider_distance"] = web_spider_distance
-        # provenance for events whose evidence is an archived snapshot rather than the live host.
-        # kept out of `data` so it doesn't become part of the event's identity.
+        # kept out of `data` so the snapshot URL doesn't become part of the event's identity
         archive_url = self.archive_url
         if archive_url:
             j["archive_url"] = archive_url
@@ -1964,7 +1963,6 @@ class FINDING(ClosestHostEvent):
             confidence_str = f"[\033[1m{confidence}\033[0m]"
         else:
             confidence_str = f"[{confidence}]"
-        # the evidence came out of an archive, so the severity describes a snapshot, not the live host
         archived_str = "[ARCHIVED] " if self.archive_url else ""
         return f"{archived_str}Severity: [{severity}] Confidence: {confidence_str} {description}"
 
@@ -1979,7 +1977,6 @@ class FINDING(ClosestHostEvent):
         cves = self.data.get("cves", [])
         if cves:
             parts.append(f"[{', '.join(cves)}]")
-        # the evidence came out of an archive, so the severity describes a snapshot, not the live host
         archive_url = self.archive_url
         if archive_url:
             parts.append(f"(archived: {archive_url})")

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -326,12 +326,19 @@ class HttpCompare:
         else:
             return (False, diff_reasons, reflection, subject_response)
 
+    @staticmethod
+    def parse_body(text):
+        """Parse a response body into the structure compare_body() expects: a document tree
+        when the body is well-formed XML, otherwise a list of lines. Passing raw text to
+        compare_body() works but bypasses the ddiff_filters that mask dynamic content."""
+        try:
+            return xmltodict.parse(text)
+        except ExpatError:
+            return text.split("\n")
+
     def _compare_sync(self, subject_response, subject):
         """CPU-bound comparison work offloaded from the event loop."""
-        try:
-            subject_json = xmltodict.parse(subject_response.text)
-        except ExpatError:
-            subject_json = subject_response.text.split("\n")
+        subject_json = self.parse_body(subject_response.text)
 
         diff_reasons = []
 

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -328,9 +328,8 @@ class HttpCompare:
 
     @staticmethod
     def parse_body(text):
-        """Parse a response body into the structure compare_body() expects: a document tree
-        when the body is well-formed XML, otherwise a list of lines. Passing raw text to
-        compare_body() works but bypasses the ddiff_filters that mask dynamic content."""
+        """Parse a response body into the structure compare_body() expects. Passing raw text works
+        but bypasses the ddiff_filters that mask dynamic content."""
         try:
             return xmltodict.parse(text)
         except ExpatError:

--- a/bbot/modules/lightfuzz/submodules/crypto.py
+++ b/bbot/modules/lightfuzz/submodules/crypto.py
@@ -41,20 +41,20 @@ def _ascii_xor_score(b):
 
 def _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
     """True when the pair looks like structured identifiers (MongoDB ObjectIds,
-    hex timestamps, sequential counters, record GUIDs) rather than reused-keystream
-    ciphertexts.
+    hex timestamps, sequential counters, time-ordered UUIDs) rather than
+    reused-keystream ciphertexts.
 
-    Structured IDs share a byte prefix (timestamp, process ID, ...) and differ only
-    in a short counter/random suffix.  Their XOR has a leading-zero run followed by
-    a sparse or random tail -- superficially identical to keystream reuse with
-    shared-prefix plaintexts, but distinguishable by what the tail looks like.
+    Structured IDs share a long byte prefix (timestamp, process ID, ...) and
+    differ only in a short counter/random suffix.  Their XOR has a long leading-
+    zero run followed by a sparse or random tail -- superficially identical to
+    keystream reuse with shared-prefix plaintexts, but distinguishable by what
+    the tail looks like.
 
     Real many-time-pad: the tail is XOR of diverging ASCII plaintexts -- dense,
     diverse bytes mostly in [0x00, 0x60].
 
-    Structured IDs: the tail is a small counter delta (sparse zeros with one nonzero
-    byte), random machine/process bytes (fails the ASCII-XOR check), or a fixed-field
-    template whose matching segments zero out scattered through the tail.
+    Structured IDs: the tail is either a small counter delta (sparse zeros with
+    one nonzero byte) or random machine/process bytes (fails ASCII-XOR check).
     """
     tail = xored[zero_run:]
 
@@ -66,15 +66,6 @@ def _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
     # incrementing identifiers (MongoDB ObjectId 3-byte counter, hex
     # timestamps differing by 1-2 bytes, etc.).
     if len(bytes_a) == len(bytes_b) and len(tail) <= 4:
-        return True
-
-    # Zeros scattered *through* the tail mean the two values keep re-converging at
-    # fixed offsets -- a shared field template (an instance/table/timestamp segment
-    # in a record GUID). Two ciphertexts under a reused keystream zero out only where
-    # their plaintexts still coincide, which is the leading run, or a shared suffix.
-    # Trailing zeros are stripped first so shared-suffix plaintexts aren't caught here.
-    core = tail.rstrip(b"\x00")
-    if sum(1 for b in core if b == 0) >= 2:
         return True
 
     # For longer tails: real many-time-pad XOR reveals XOR of diverging ASCII
@@ -378,10 +369,11 @@ class crypto(BaseLightfuzz):
                 # At least 2 leading zero bytes OR ≥90% of bytes in ASCII-XOR-ASCII range
                 if zero_run < 2 and ascii_score < 0.9:
                     continue
-                # Both entry conditions are met just as easily by structured hex identifiers
-                # as by real ciphertexts, so every candidate pair goes through the same
-                # discrimination on what the diverging region actually looks like.
-                if _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
+                # A leading-zero run alone is the hallmark of structured hex
+                # identifiers (MongoDB ObjectIds, hex timestamps, sequential
+                # counters, time-ordered UUIDs) sharing a byte prefix -- not
+                # keystream reuse.  Filter those out by examining the tail.
+                if zero_run >= 2 and _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
                     continue
                 pair_score = (zero_run, ascii_score)
                 if best is None or pair_score > (best[0], best[1]):

--- a/bbot/modules/lightfuzz/submodules/crypto.py
+++ b/bbot/modules/lightfuzz/submodules/crypto.py
@@ -41,20 +41,20 @@ def _ascii_xor_score(b):
 
 def _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
     """True when the pair looks like structured identifiers (MongoDB ObjectIds,
-    hex timestamps, sequential counters, time-ordered UUIDs) rather than
-    reused-keystream ciphertexts.
+    hex timestamps, sequential counters, record GUIDs) rather than reused-keystream
+    ciphertexts.
 
-    Structured IDs share a long byte prefix (timestamp, process ID, ...) and
-    differ only in a short counter/random suffix.  Their XOR has a long leading-
-    zero run followed by a sparse or random tail -- superficially identical to
-    keystream reuse with shared-prefix plaintexts, but distinguishable by what
-    the tail looks like.
+    Structured IDs share a byte prefix (timestamp, process ID, ...) and differ only
+    in a short counter/random suffix.  Their XOR has a leading-zero run followed by
+    a sparse or random tail -- superficially identical to keystream reuse with
+    shared-prefix plaintexts, but distinguishable by what the tail looks like.
 
     Real many-time-pad: the tail is XOR of diverging ASCII plaintexts -- dense,
     diverse bytes mostly in [0x00, 0x60].
 
-    Structured IDs: the tail is either a small counter delta (sparse zeros with
-    one nonzero byte) or random machine/process bytes (fails ASCII-XOR check).
+    Structured IDs: the tail is a small counter delta (sparse zeros with one nonzero
+    byte), random machine/process bytes (fails the ASCII-XOR check), or a fixed-field
+    template whose matching segments zero out scattered through the tail.
     """
     tail = xored[zero_run:]
 
@@ -66,6 +66,15 @@ def _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
     # incrementing identifiers (MongoDB ObjectId 3-byte counter, hex
     # timestamps differing by 1-2 bytes, etc.).
     if len(bytes_a) == len(bytes_b) and len(tail) <= 4:
+        return True
+
+    # Zeros scattered *through* the tail mean the two values keep re-converging at
+    # fixed offsets -- a shared field template (an instance/table/timestamp segment
+    # in a record GUID). Two ciphertexts under a reused keystream zero out only where
+    # their plaintexts still coincide, which is the leading run, or a shared suffix.
+    # Trailing zeros are stripped first so shared-suffix plaintexts aren't caught here.
+    core = tail.rstrip(b"\x00")
+    if sum(1 for b in core if b == 0) >= 2:
         return True
 
     # For longer tails: real many-time-pad XOR reveals XOR of diverging ASCII
@@ -369,11 +378,10 @@ class crypto(BaseLightfuzz):
                 # At least 2 leading zero bytes OR ≥90% of bytes in ASCII-XOR-ASCII range
                 if zero_run < 2 and ascii_score < 0.9:
                     continue
-                # A leading-zero run alone is the hallmark of structured hex
-                # identifiers (MongoDB ObjectIds, hex timestamps, sequential
-                # counters, time-ordered UUIDs) sharing a byte prefix -- not
-                # keystream reuse.  Filter those out by examining the tail.
-                if zero_run >= 2 and _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
+                # Both entry conditions are met just as easily by structured hex identifiers
+                # as by real ciphertexts, so every candidate pair goes through the same
+                # discrimination on what the diverging region actually looks like.
+                if _is_structured_id_pair(bytes_a, bytes_b, xored, zero_run):
                     continue
                 pair_score = (zero_run, ascii_score)
                 if best is None or pair_score > (best[0], best[1]):

--- a/bbot/modules/lightfuzz/submodules/serial.py
+++ b/bbot/modules/lightfuzz/submodules/serial.py
@@ -6,6 +6,11 @@ import struct
 from .base import BaseLightfuzz
 from bbot.errors import HttpCompareError
 
+# enough leading bytes to break every magic header we send (java `AC ED`, dotnet `00 01 00 00`,
+# pickle `80 04`) without disturbing the payload's length or trailing bytes
+MAGIC_HEADER_LENGTH = 4
+HEADER_SCRAMBLE_DELTA = 0x55
+
 
 class _PickleOOB:
     """Pickle-RCE canary: __reduce__ makes the deserializing process resolve
@@ -222,10 +227,10 @@ class serial(BaseLightfuzz):
             data = bytes.fromhex(payload) if encoding == "hex" else base64.b64decode(payload)
         except Exception:
             return None
-        header_length = min(4, len(data))
+        header_length = min(MAGIC_HEADER_LENGTH, len(data))
         if not header_length:
             return None
-        corrupted = bytes((b + 0x55) % 256 for b in data[:header_length]) + data[header_length:]
+        corrupted = bytes((b + HEADER_SCRAMBLE_DELTA) % 256 for b in data[:header_length]) + data[header_length:]
         if encoding == "hex":
             return corrupted.hex().upper() if payload.isupper() else corrupted.hex()
         return base64.b64encode(corrupted).decode()

--- a/bbot/modules/lightfuzz/submodules/serial.py
+++ b/bbot/modules/lightfuzz/submodules/serial.py
@@ -223,7 +223,7 @@ class serial(BaseLightfuzz):
             return f"z{payload[1:]}" if payload[0] != "z" else f"q{payload[1:]}"
         try:
             data = bytes.fromhex(payload) if encoding == "hex" else base64.b64decode(payload)
-        except Exception:
+        except ValueError:
             return None
         header_length = min(MAGIC_HEADER_LENGTH, len(data))
         if not header_length:

--- a/bbot/modules/lightfuzz/submodules/serial.py
+++ b/bbot/modules/lightfuzz/submodules/serial.py
@@ -214,10 +214,8 @@ class serial(BaseLightfuzz):
 
     @staticmethod
     def corrupt_payload(payload, encoding):
-        """Return a twin of ``payload`` with the same encoding, length and trailing bytes but a
-        scrambled magic/type header: still parses like the original, deserializes under nothing.
-        Returns None when no distinguishable twin can be built.
-        """
+        """Return a twin of ``payload``: same encoding, length and trailing bytes, scrambled magic
+        header. Parses like the original, deserializes under nothing. None if no twin can be built."""
         if not payload:
             return None
         if encoding == "php_raw":
@@ -343,9 +341,8 @@ class serial(BaseLightfuzz):
                         )
                         continue
 
-                    # Deserialization is a claim about the payload's content, so a same-shape twin
-                    # with a scrambled header must not resolve the error too. If it does, the value
-                    # is only being parsed (e.g. as a URL/host), not deserialized.
+                    # a same-shape twin with a scrambled header deserializes under nothing, so if it
+                    # resolves the error too, the value is only being parsed (e.g. as a URL/host)
                     corrupted_payload = self.corrupt_payload(payload, encoding)
                     if corrupted_payload is not None:
                         corrupted_response = await self.standard_probe(

--- a/bbot/modules/lightfuzz/submodules/serial.py
+++ b/bbot/modules/lightfuzz/submodules/serial.py
@@ -207,6 +207,29 @@ class serial(BaseLightfuzz):
         """Extract the language family from a payload name (e.g. 'java_base64_string_error' -> 'java')."""
         return payload_name.split("_")[0]
 
+    @staticmethod
+    def corrupt_payload(payload, encoding):
+        """Return a twin of ``payload`` with the same encoding, length and trailing bytes but a
+        scrambled magic/type header: still parses like the original, deserializes under nothing.
+        Returns None when no distinguishable twin can be built.
+        """
+        if not payload:
+            return None
+        if encoding == "php_raw":
+            # PHP serialized data leads with a single type character
+            return f"z{payload[1:]}" if payload[0] != "z" else f"q{payload[1:]}"
+        try:
+            data = bytes.fromhex(payload) if encoding == "hex" else base64.b64decode(payload)
+        except Exception:
+            return None
+        header_length = min(4, len(data))
+        if not header_length:
+            return None
+        corrupted = bytes((b + 0x55) % 256 for b in data[:header_length]) + data[header_length:]
+        if encoding == "hex":
+            return corrupted.hex().upper() if payload.isupper() else corrupted.hex()
+        return base64.b64encode(corrupted).decode()
+
     async def confirm_baseline(self, control_payload, cookies):
         """Re-send the control payload to confirm the baseline error state is stable (not transient)."""
         confirmation = await self.standard_probe(self.event.data["type"], cookies, control_payload)
@@ -248,13 +271,13 @@ class serial(BaseLightfuzz):
 
         # Map each payload set to its control payload for baseline confirmation
         payload_sets = [
-            (base64_serialization_payloads, http_compare_base64, control_payload_base64),
-            (hex_serialization_payloads, http_compare_hex, control_payload_hex),
-            (php_raw_serialization_payloads, http_compare_php_raw, control_payload_php_raw),
+            (base64_serialization_payloads, http_compare_base64, control_payload_base64, "base64"),
+            (hex_serialization_payloads, http_compare_hex, control_payload_hex, "hex"),
+            (php_raw_serialization_payloads, http_compare_php_raw, control_payload_php_raw, "php_raw"),
         ]
 
         # Proceed with payload probes
-        for payload_set, payload_baseline, control_payload in payload_sets:
+        for payload_set, payload_baseline, control_payload, encoding in payload_sets:
             for payload_type, payload in payload_set.items():
                 try:
                     matches_baseline, diff_reasons, reflection, response = await self.compare_probe(
@@ -314,6 +337,22 @@ class serial(BaseLightfuzz):
                             f"Baseline confirmation returned 200 for {payload_type}, original error was transient, skipping"
                         )
                         continue
+
+                    # Deserialization is a claim about the payload's content, so a same-shape twin
+                    # with a scrambled header must not resolve the error too. If it does, the value
+                    # is only being parsed (e.g. as a URL/host), not deserialized.
+                    corrupted_payload = self.corrupt_payload(payload, encoding)
+                    if corrupted_payload is not None:
+                        corrupted_response = await self.standard_probe(
+                            self.event.data["type"], cookies, corrupted_payload
+                        )
+                        corrupted_status = getattr(corrupted_response, "status_code", None)
+                        if corrupted_status == status_code:
+                            self.debug(
+                                f"Corrupted twin of {payload_type} also returned {corrupted_status}, "
+                                "outcome is independent of payload content, skipping"
+                            )
+                            continue
 
                     def get_title(text):
                         soup = self.lightfuzz.helpers.beautifulsoup(text, "html.parser")

--- a/bbot/modules/lightfuzz/submodules/sqli.py
+++ b/bbot/modules/lightfuzz/submodules/sqli.py
@@ -60,6 +60,12 @@ class sqli(BaseLightfuzz):
         (" AND 1=1", " AND 1=2"),
     ]
 
+    # one vs. two benign characters, mirroring the `'`/`''` pair in length with no SQL meaning
+    BENIGN_CONTROL_SUFFIXES = ("a", "aa")
+
+    # a WAF block or a rate limit says nothing about the query behind the parameter
+    INCONCLUSIVE_STATUS_CODES = (403, 429)
+
     DELAY_PROBE_TEMPLATES = [
         "'||pg_sleep({d})--",
         "' OR (SELECT TRUE FROM pg_sleep({d})) LIMIT 1-- -",
@@ -164,7 +170,7 @@ class sqli(BaseLightfuzz):
             return None
         if not probe[3]:
             return None
-        if probe[3].status_code in (403, 429):
+        if probe[3].status_code in self.INCONCLUSIVE_STATUS_CODES:
             self.debug(f"Boolean probe [{payload}] returned {probe[3].status_code}, cannot confirm")
             return None
         return http_compare.parse_body(self._strip_payload(probe[3].text, payload))
@@ -214,7 +220,7 @@ class sqli(BaseLightfuzz):
         flip tracks value length or envelope validity rather than quoting.
         """
         control_codes = []
-        for suffix in ("a", "aa"):
+        for suffix in self.BENIGN_CONTROL_SUFFIXES:
             try:
                 control = await self.compare_probe(
                     http_compare,

--- a/bbot/modules/lightfuzz/submodules/sqli.py
+++ b/bbot/modules/lightfuzz/submodules/sqli.py
@@ -287,14 +287,19 @@ class sqli(BaseLightfuzz):
                     if "code" in single_quote[1] and (
                         single_quote[3].status_code != double_single_quote[3].status_code
                     ):
-                        # A transition into 403 is access control (usually a WAF matching its managed
-                        # SQLi signature on the bare quote), not a code change driven by the query.
-                        if 403 in (single_quote[3].status_code, double_single_quote[3].status_code):
-                            self.debug(
-                                "Quote probe transitioned into 403 (access control/WAF), "
-                                "suppressing SQL injection finding"
+                        # Check if the status code change is due to a WAF, not SQL injection
+                        is_waf = False
+                        if single_quote[3].status_code == 403:
+                            waf_matches = await self.lightfuzz.helpers.yara.match(
+                                self.lightfuzz.waf_yara_rules, single_quote[3].text
                             )
-                        else:
+                            if waf_matches:
+                                self.debug(
+                                    "Single quote probe returned 403 with WAF signature, "
+                                    "suppressing SQL injection finding"
+                                )
+                                is_waf = True
+                        if not is_waf:
                             # Confirmation loop: require 2 additional rounds with fresh baselines
                             # to confirm the status-code triplet is stable and not a transient CDN/server flap.
                             # TODO: apply this same confirmation pattern to other submodules that use compare_probe-based detection.

--- a/bbot/modules/lightfuzz/submodules/sqli.py
+++ b/bbot/modules/lightfuzz/submodules/sqli.py
@@ -52,9 +52,8 @@ class sqli(BaseLightfuzz):
         "string not properly terminated",
     ]
 
-    # TRUE/FALSE payload pairs used to confirm the value reaches a SQL query. Both halves of a
-    # pair are the same length and differ by a single character, so a reflected payload can be
-    # stripped cleanly and any surviving body difference comes from the query result set.
+    # both halves are the same length and differ by one character, so a reflected copy strips
+    # cleanly and any surviving body difference comes from the query result set
     BOOLEAN_PROBE_PAIRS = [
         ("' AND '1'='1", "' AND '1'='2"),
         (" AND 1=1", " AND 1=2"),
@@ -151,12 +150,8 @@ class sqli(BaseLightfuzz):
         return text
 
     async def _probe_body(self, http_compare, payload, cookies):
-        """Send ``payload`` and return its parsed response body, reflections of the payload
-        stripped, ready for ``http_compare.compare_body()``.
-
-        Returns None when the probe fails, or when the response is 403/429 (WAF or rate limit,
-        which tells us nothing about the query behind the parameter).
-        """
+        """Send ``payload`` and return its parsed body with reflections stripped, or None when the
+        probe fails or the status is inconclusive."""
         try:
             probe = await self.compare_probe(
                 http_compare,
@@ -178,9 +173,8 @@ class sqli(BaseLightfuzz):
     async def confirm_boolean_differential(self, http_compare, probe_value, cookies):
         """Require positive SQL-logic evidence before asserting injection from a status change.
 
-        A bare status flip is not SQL: a WAF signature match, or an envelope whose structural
-        validity changes when the payload is repacked, both produce one. Only a TRUE/FALSE pair
-        that changes the response *content* shows the value is reaching a query.
+        A WAF signature match or a repacked envelope both produce a bare status flip; only a
+        content differential shows the value reaching a query.
 
         Returns the confirming ``(true_payload, false_payload)`` pair, or None.
         """
@@ -199,8 +193,7 @@ class sqli(BaseLightfuzz):
                 self.debug(f"No boolean differential for [{true_suffix}] / [{false_suffix}]")
                 continue
 
-            # A page that renders differently on every request produces a differential on its
-            # own. Re-send the TRUE payload; the body must reproduce for the pair to mean anything.
+            # an unstable page produces a differential on its own, so the TRUE body must reproduce
             repeat_body = await self._probe_body(http_compare, true_payload, cookies)
             if repeat_body is None:
                 continue
@@ -215,9 +208,8 @@ class sqli(BaseLightfuzz):
     async def is_quote_specific(self, http_compare, probe_value, cookies, status_codes):
         """Verify the status flip tracks the quote characters and not the payload's shape.
 
-        Appending one vs. two benign characters mirrors the `'`/`''` pair in length while
-        carrying no SQL meaning. If that benign pair reproduces the same status triplet, the
-        flip tracks value length or envelope validity rather than quoting.
+        If the benign control pair reproduces the same status triplet, the flip tracks value
+        length or envelope validity rather than quoting.
         """
         control_codes = []
         for suffix in self.BENIGN_CONTROL_SUFFIXES:

--- a/bbot/modules/lightfuzz/submodules/sqli.py
+++ b/bbot/modules/lightfuzz/submodules/sqli.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote
+
 from .base import BaseLightfuzz
 from bbot.errors import HttpCompareError
 
@@ -12,6 +14,10 @@ class sqli(BaseLightfuzz):
        - Injects single quotes and observes error responses
        - Tests quote escape sequence variations
        - Matches against known SQL error patterns
+
+    * Code-change Detection:
+       - Compares the status code of a single-quote probe against a doubled-quote probe
+       - Requires a positive boolean (TRUE/FALSE) content differential to confirm
 
     * Time-based Blind Detection:
        - Uses vendor-specific time delay payloads
@@ -39,6 +45,14 @@ class sqli(BaseLightfuzz):
         "Incorrect syntax near",
         "SQL command not properly ended",
         "string not properly terminated",
+    ]
+
+    # TRUE/FALSE payload pairs used to confirm the value reaches a SQL query. Both halves of a
+    # pair are the same length and differ by a single character, so a reflected payload can be
+    # stripped cleanly and any surviving body difference comes from the query result set.
+    BOOLEAN_PROBE_PAIRS = [
+        ("' AND '1'='1", "' AND '1'='2"),
+        (" AND 1=1", " AND 1=2"),
     ]
 
     DELAY_PROBE_TEMPLATES = [
@@ -115,6 +129,106 @@ class sqli(BaseLightfuzz):
 
         return True
 
+    @staticmethod
+    def _strip_payload(text, payload):
+        """Remove reflected copies of a payload from a response body, in raw and encoded form."""
+        for variant in (payload, quote(payload), payload.replace(" ", "+")):
+            text = text.replace(variant, "")
+        return text
+
+    async def _probe_body(self, http_compare, payload, cookies):
+        """Send ``payload`` and return its parsed response body, reflections of the payload
+        stripped, ready for ``http_compare.compare_body()``.
+
+        Returns None when the probe fails, or when the response is 403/429 (WAF or rate limit,
+        which tells us nothing about the query behind the parameter).
+        """
+        try:
+            probe = await self.compare_probe(
+                http_compare,
+                self.event.data["type"],
+                payload,
+                cookies,
+                additional_params_populate_empty=True,
+            )
+        except HttpCompareError as e:
+            self.debug(f"Boolean probe [{payload}] failed: {e}")
+            return None
+        if not probe[3]:
+            return None
+        if probe[3].status_code in (403, 429):
+            self.debug(f"Boolean probe [{payload}] returned {probe[3].status_code}, cannot confirm")
+            return None
+        return http_compare.parse_body(self._strip_payload(probe[3].text, payload))
+
+    async def confirm_boolean_differential(self, http_compare, probe_value, cookies):
+        """Require positive SQL-logic evidence before asserting injection from a status change.
+
+        A bare status flip is not SQL: a WAF signature match, or an envelope whose structural
+        validity changes when the payload is repacked, both produce one. Only a TRUE/FALSE pair
+        that changes the response *content* shows the value is reaching a query.
+
+        Returns the confirming ``(true_payload, false_payload)`` pair, or None.
+        """
+        for true_suffix, false_suffix in self.BOOLEAN_PROBE_PAIRS:
+            true_payload = f"{probe_value}{true_suffix}"
+            false_payload = f"{probe_value}{false_suffix}"
+
+            true_body = await self._probe_body(http_compare, true_payload, cookies)
+            if true_body is None:
+                continue
+            false_body = await self._probe_body(http_compare, false_payload, cookies)
+            if false_body is None:
+                continue
+
+            if http_compare.compare_body(true_body, false_body) is not False:
+                self.debug(f"No boolean differential for [{true_suffix}] / [{false_suffix}]")
+                continue
+
+            # A page that renders differently on every request produces a differential on its
+            # own. Re-send the TRUE payload; the body must reproduce for the pair to mean anything.
+            repeat_body = await self._probe_body(http_compare, true_payload, cookies)
+            if repeat_body is None:
+                continue
+            if http_compare.compare_body(true_body, repeat_body) is False:
+                self.debug("Response body is not deterministic, discarding boolean differential")
+                continue
+
+            self.verbose(f"Boolean differential confirmed for {self.event.url}: [{true_suffix}] vs [{false_suffix}]")
+            return true_payload, false_payload
+        return None
+
+    async def is_quote_specific(self, http_compare, probe_value, cookies, status_codes):
+        """Verify the status flip tracks the quote characters and not the payload's shape.
+
+        Appending one vs. two benign characters mirrors the `'`/`''` pair in length while
+        carrying no SQL meaning. If that benign pair reproduces the same status triplet, the
+        flip tracks value length or envelope validity rather than quoting.
+        """
+        control_codes = []
+        for suffix in ("a", "aa"):
+            try:
+                control = await self.compare_probe(
+                    http_compare,
+                    self.event.data["type"],
+                    f"{probe_value}{suffix}",
+                    cookies,
+                    additional_params_populate_empty=True,
+                )
+            except HttpCompareError as e:
+                self.debug(f"Quote-specificity control probe failed: {e}")
+                return True
+            if not control[3]:
+                return True
+            control_codes.append(control[3].status_code)
+
+        if (status_codes[0], *control_codes) == status_codes:
+            self.debug(
+                f"Benign control pair reproduced the status triplet {status_codes}, the change is not quote-specific"
+            )
+            return False
+        return True
+
     async def fuzz(self):
         cookies = self.event.data.get("assigned_cookies", {})
         probe_value = self.incoming_probe_value(populate_empty=True)
@@ -165,19 +279,14 @@ class sqli(BaseLightfuzz):
                     if "code" in single_quote[1] and (
                         single_quote[3].status_code != double_single_quote[3].status_code
                     ):
-                        # Check if the status code change is due to a WAF, not SQL injection
-                        is_waf = False
-                        if single_quote[3].status_code == 403:
-                            waf_matches = await self.lightfuzz.helpers.yara.match(
-                                self.lightfuzz.waf_yara_rules, single_quote[3].text
+                        # A transition into 403 is access control (usually a WAF matching its managed
+                        # SQLi signature on the bare quote), not a code change driven by the query.
+                        if 403 in (single_quote[3].status_code, double_single_quote[3].status_code):
+                            self.debug(
+                                "Quote probe transitioned into 403 (access control/WAF), "
+                                "suppressing SQL injection finding"
                             )
-                            if waf_matches:
-                                self.debug(
-                                    "Single quote probe returned 403 with WAF signature, "
-                                    "suppressing SQL injection finding"
-                                )
-                                is_waf = True
-                        if not is_waf:
+                        else:
                             # Confirmation loop: require 2 additional rounds with fresh baselines
                             # to confirm the status-code triplet is stable and not a transient CDN/server flap.
                             # TODO: apply this same confirmation pattern to other submodules that use compare_probe-based detection.
@@ -187,14 +296,27 @@ class sqli(BaseLightfuzz):
                                 double_single_quote[3].status_code,
                             )
                             confirmed = await self._confirm_code_change(probe_value, cookies, initial_status_codes)
-                            if confirmed:
+                            quote_specific = confirmed and await self.is_quote_specific(
+                                http_compare, probe_value, cookies, initial_status_codes
+                            )
+                            boolean_pair = (
+                                await self.confirm_boolean_differential(http_compare, probe_value, cookies)
+                                if quote_specific
+                                else None
+                            )
+                            if boolean_pair:
                                 self.results.append(
                                     {
                                         "name": "Possible SQL Injection",
                                         "severity": "HIGH",
                                         "confidence": "MEDIUM",
-                                        "description": f"Possible SQL Injection. {self.metadata()} Detection Method: [Single Quote/Two Single Quote, Code Change ({initial_status_codes[0]}->{initial_status_codes[1]}->{initial_status_codes[2]})]",
+                                        "description": f"Possible SQL Injection. {self.metadata()} Detection Method: [Single Quote/Two Single Quote, Code Change ({initial_status_codes[0]}->{initial_status_codes[1]}->{initial_status_codes[2]})] Boolean Confirmation: [{boolean_pair[0]}] vs [{boolean_pair[1]}]",
                                     }
+                                )
+                            elif confirmed and quote_specific:
+                                self.verbose(
+                                    f"Discarding code change {initial_status_codes} for {self.event.url}: "
+                                    "no boolean differential, the value does not reach a query"
                                 )
             else:
                 self.debug("Failed to get responses for both single_quote and double_single_quote")

--- a/bbot/modules/lightfuzz/submodules/sqli.py
+++ b/bbot/modules/lightfuzz/submodules/sqli.py
@@ -1,7 +1,12 @@
+import html
 from urllib.parse import quote
 
 from .base import BaseLightfuzz
 from bbot.errors import HttpCompareError
+
+# frameworks disagree on how they spell an escaped quote (Jinja/ASP.NET `&#39;`, Django `&#x27;`,
+# PHP `&#039;`, XHTML `&apos;`), and a reflected payload has to be removed in whichever it uses.
+HTML_QUOTE_ENTITIES = ("&#39;", "&#x27;", "&#039;", "&apos;")
 
 
 class sqli(BaseLightfuzz):
@@ -131,8 +136,11 @@ class sqli(BaseLightfuzz):
 
     @staticmethod
     def _strip_payload(text, payload):
-        """Remove reflected copies of a payload from a response body, in raw and encoded form."""
-        for variant in (payload, quote(payload), payload.replace(" ", "+")):
+        """Remove reflected copies of a payload from a response body, raw, URL-encoded and HTML-escaped."""
+        escaped = html.escape(payload)
+        variants = [payload, quote(payload), payload.replace(" ", "+"), escaped]
+        variants += [escaped.replace("&#x27;", entity) for entity in HTML_QUOTE_ENTITIES]
+        for variant in variants:
             text = text.replace(variant, "")
         return text
 

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -1028,6 +1028,75 @@ async def test_event_web_spider_distance(bbot_scanner):
 
 
 @pytest.mark.asyncio
+async def test_event_archived_provenance():
+    """A finding whose evidence is an archived snapshot renders with an [ARCHIVED] marker, so the
+    severity is never read as a claim about the live host."""
+    scan = Scanner()
+    await scan._prep()
+    archived_response = scan.make_event(
+        {
+            "method": "GET",
+            "url": "http://www.evilcorp.com/asdf",
+            "hash": {"header_mmh3": "1", "body_mmh3": "2"},
+            "raw_header": "HTTP/1.1 200 OK\r\n\r\n",
+            "archive_url": "http://web.archive.org/web/20190101000000/http://www.evilcorp.com/asdf",
+        },
+        "HTTP_RESPONSE",
+        parent=scan.root_event,
+        tags=["from-wayback", "archived"],
+    )
+
+    finding = scan.make_event(
+        {
+            "host": "www.evilcorp.com",
+            "description": "test",
+            "severity": "HIGH",
+            "confidence": "HIGH",
+            "name": "Test Finding",
+        },
+        "FINDING",
+        parent=archived_response,
+    )
+    archive_url = "http://web.archive.org/web/20190101000000/http://www.evilcorp.com/asdf"
+    assert finding.archive_url == archive_url
+    assert finding.pretty_string.startswith("[ARCHIVED] Severity: [HIGH]")
+    # output.txt / stdout render data_human, which carries the snapshot URL itself
+    assert finding.data_human.startswith("Severity: [HIGH]")
+    assert finding.data_human.endswith(f"(archived: {archive_url})")
+    # output.json serializes json(), and the snapshot URL must not become part of the finding's identity
+    assert finding.json()["archive_url"] == archive_url
+    assert "archive_url" not in finding.json()["data_json"]
+
+    live_response = scan.make_event(
+        {
+            "method": "GET",
+            "url": "http://www.evilcorp.com/qwerty",
+            "hash": {"header_mmh3": "3", "body_mmh3": "4"},
+            "raw_header": "HTTP/1.1 200 OK\r\n\r\n",
+        },
+        "HTTP_RESPONSE",
+        parent=scan.root_event,
+    )
+    live_finding = scan.make_event(
+        {
+            "host": "www.evilcorp.com",
+            "description": "test",
+            "severity": "HIGH",
+            "confidence": "HIGH",
+            "name": "Live Finding",
+        },
+        "FINDING",
+        parent=live_response,
+    )
+    assert live_finding.archive_url is None
+    assert live_finding.pretty_string.startswith("Severity: [HIGH]")
+    assert live_finding.data_human.startswith("Severity: [HIGH]")
+    assert "archive_url" not in live_finding.json()
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
 async def test_event_closest_host():
     scan = Scanner()
     await scan._prep()

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -22,6 +22,25 @@ def _make_base_lightfuzz(url):
     return BaseLightfuzz(lightfuzz, event)
 
 
+def sqli_injectable_response(value, empty_block):
+    """Emulate a parameter whose value lands unquoted inside a SQL string literal.
+
+    Covers everything the sqli code-change branch must observe on a genuinely injectable
+    parameter: an unbalanced quote errors, a doubled quote recovers, and a TRUE/FALSE
+    boolean pair changes the result set. Benign suffixes behave like any other search term,
+    so the flip stays quote-specific.
+    """
+    if value is None:
+        return Response(empty_block, status=200)
+    if value.endswith("' AND '1'='1"):
+        return Response(f"<html><p>1 result for: {value}</p><p>Row Alpha</p></html>", status=200)
+    if value.endswith("' AND '1'='2"):
+        return Response(f"<html><p>0 results for: {value}</p></html>", status=200)
+    if value.endswith("'") and not value.endswith("''"):
+        return Response("<html><p>Found error in SQL query</p></html>", status=500)
+    return Response(f"<html><p>0 results for: {value}</p></html>", status=200)
+
+
 def test_lightfuzz_build_query_string_no_existing_qs():
     bl = _make_base_lightfuzz("https://x.test/path")
     assert bl.build_query_string("PROBE", "p") == "https://x.test/path?p=PROBE"
@@ -1198,9 +1217,7 @@ class Test_Lightfuzz_sqli(ModuleTestBase):
         },
     }
 
-    def request_handler(self, request):
-        qs = str(request.query_string.decode())
-        parameter_block = """
+    parameter_block = """
         <section class=search>
             <form action=/ method=GET>
                 <input type=text placeholder='Search the blog...' name=search>
@@ -1208,30 +1225,9 @@ class Test_Lightfuzz_sqli(ModuleTestBase):
             </form>
         </section>
         """
-        if "search=" in qs:
-            value = qs.split("=")[1]
 
-            if "&" in value:
-                value = value.split("&")[0]
-
-            sql_block_normal = f"""
-        <section class=blog-header>
-            <h1>0 search results for '{unquote(value)}'</h1>
-            <hr>
-        </section>
-        """
-
-            sql_block_error = """
-        <section class=error>
-            <h1>Found error in SQL query</h1>
-            <hr>
-        </section>
-        """
-            if value.endswith("'"):
-                if value.endswith("''"):
-                    return Response(sql_block_normal, status=200)
-                return Response(sql_block_error, status=500)
-        return Response(parameter_block, status=200)
+    def request_handler(self, request):
+        return sqli_injectable_response(request.args.get("search"), self.parameter_block)
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["lightfuzz"].helpers.rand_string = lambda *args, **kwargs: (
@@ -1271,8 +1267,7 @@ class Test_Lightfuzz_sqli_post(ModuleTestBase):
         },
     }
 
-    def request_handler(self, request):
-        parameter_block = """
+    parameter_block = """
         <section class=search>
             <form action=/ method=POST>
                 <input type=text placeholder='Search the blog...' name=search>
@@ -1281,27 +1276,8 @@ class Test_Lightfuzz_sqli_post(ModuleTestBase):
         </section>
         """
 
-        if "search" in request.form.keys():
-            value = request.form["search"]
-
-            sql_block_normal = f"""
-        <section class=blog-header>
-            <h1>0 search results for '{unquote(value)}'</h1>
-            <hr>
-        </section>
-        """
-
-            sql_block_error = """
-        <section class=error>
-            <h1>Found error in SQL query</h1>
-            <hr>
-        </section>
-        """
-            if value.endswith("'"):
-                if value.endswith("''"):
-                    return Response(sql_block_normal, status=200)
-                return Response(sql_block_error, status=500)
-        return Response(parameter_block, status=200)
+    def request_handler(self, request):
+        return sqli_injectable_response(request.form.get("search"), self.parameter_block)
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["lightfuzz"].helpers.rand_string = lambda *args, **kwargs: (
@@ -1391,32 +1367,14 @@ class Test_Lightfuzz_sqli_headers(Test_Lightfuzz_sqli):
         for event in seed_events:
             await module_test.scan.ingress_module.incoming_event_queue.put(event)
 
-    def request_handler(self, request):
-        placeholder_block = """
+    placeholder_block = """
         <html>
         <p>placeholder</p>
         </html>
         """
 
-        if request.headers.get("testheader") is not None:
-            header_value = request.headers.get("testheader")
-
-            header_block_normal = f"""
-            <html>
-            <p>placeholder</p>
-            <p>test: {header_value}</p>
-            </html>
-            """
-            header_block_error = """
-            <html>
-            <p>placeholder</p>
-            <p>Error!</p>
-            </html>
-            """
-            if header_value.endswith("'") and not header_value.endswith("''"):
-                return Response(header_block_error, status=500)
-            return Response(header_block_normal, status=200)
-        return Response(placeholder_block, status=200)
+    def request_handler(self, request):
+        return sqli_injectable_response(request.headers.get("testheader"), self.placeholder_block)
 
     def check(self, module_test, events):
         sqli_finding_emitted = False
@@ -1461,33 +1419,14 @@ class Test_Lightfuzz_sqli_cookies(Test_Lightfuzz_sqli):
         for event in seed_events:
             await module_test.scan.ingress_module.incoming_event_queue.put(event)
 
-    def request_handler(self, request):
-        placeholder_block = """
+    placeholder_block = """
         <html>
         <p>placeholder</p>
         </html>
         """
 
-        if request.cookies.get("test") is not None:
-            header_value = request.cookies.get("test")
-
-            header_block_normal = f"""
-            <html>
-            <p>placeholder</p>
-            <p>test: {header_value}</p>
-            </html>
-            """
-
-            header_block_error = """
-            <html>
-            <p>placeholder</p>
-            <p>Error!</p>
-            </html>
-            """
-            if header_value.endswith("'") and not header_value.endswith("''"):
-                return Response(header_block_error, status=500)
-            return Response(header_block_normal, status=200)
-        return Response(placeholder_block, status=200)
+    def request_handler(self, request):
+        return sqli_injectable_response(request.cookies.get("test"), self.placeholder_block)
 
     def check(self, module_test, events):
         sqli_finding_emitted = False
@@ -1813,6 +1752,36 @@ class Test_Lightfuzz_serial_errorresolution_falsepositive(Test_Lightfuzz_serial_
                 no_finding_emitted = False
 
         assert no_finding_emitted, "False positive finding was emitted"
+
+
+# Serialization Module: the parameter is parsed as a URI, not deserialized. .NET's Uri reads
+# everything before the first "/" as the hostname, so the control payload (no "/", trailing "=")
+# throws and the dotnet payload (leading token "AAEAAAD") parses -- a 500->200 flip that has
+# nothing to do with deserialization. A structurally-corrupted twin parses just as well, which
+# is what proves the outcome is independent of the payload's content.
+class Test_Lightfuzz_serial_errorresolution_uri_parse_fp(Test_Lightfuzz_serial_errorresolution):
+    uri_parse_error = (
+        "<html><body>System.UriFormatException: Invalid URI: The hostname could not be parsed.</body></html>"
+    )
+
+    def request_handler(self, request):
+        post_params = request.form
+        if "TextBox1" not in post_params.keys():
+            return Response(self.dotnet_serial_html, status=200)
+        if post_params["__VIEWSTATE"] != "/wEPDwULLTE5MTI4MzkxNjVkZNt7ICM+GixNryV6ucx+srzhXlwP":
+            return Response(self.dotnet_serial_error, status=500)
+        host = post_params["TextBox1"].split("/")[0]
+        if not host or re.fullmatch(r"[A-Za-z0-9.-]+", host) is None:
+            return Response(self.uri_parse_error, status=500)
+        return Response("<html><body>Request accepted</body></html>", status=200)
+
+    def check(self, module_test, events):
+        findings = [
+            e.data["description"]
+            for e in events
+            if e.type == "FINDING" and "Unsafe Deserialization" in e.data.get("description", "")
+        ]
+        assert not findings, f"URI parsing was misreported as unsafe deserialization: {findings}"
 
 
 class Test_Lightfuzz_serial_errorresolution_existingvalue_valid(Test_Lightfuzz_serial_errorresolution):
@@ -3789,10 +3758,7 @@ class Test_Lightfuzz_try_post_as_get(ModuleTestBase):
         },
     }
 
-    def request_handler(self, request):
-        qs = str(request.query_string.decode())
-
-        parameter_block = """
+    parameter_block = """
         <section class=search>
             <form action=/ method=POST>
                 <input type=text placeholder='Search the blog...' name=search>
@@ -3801,29 +3767,9 @@ class Test_Lightfuzz_try_post_as_get(ModuleTestBase):
         </section>
         """
 
-        if "search=" in qs:
-            value = qs.split("=")[1]
-            if "&" in value:
-                value = value.split("&")[0]
-
-            sql_block_normal = f"""
-        <section class=blog-header>
-            <h1>0 search results for '{unquote(value)}'</h1>
-            <hr>
-        </section>
-        """
-
-            sql_block_error = """
-        <section class=error>
-            <h1>Found error in SQL query</h1>
-            <hr>
-        </section>
-        """
-            if value.endswith("'"):
-                if value.endswith("''"):
-                    return Response(sql_block_normal, status=200)
-                return Response(sql_block_error, status=500)
-        return Response(parameter_block, status=200)
+    def request_handler(self, request):
+        # only the converted GETPARAM pass reaches a query here; the POST pass is disabled
+        return sqli_injectable_response(request.args.get("search"), self.parameter_block)
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["lightfuzz"].helpers.rand_string = lambda *args, **kwargs: (
@@ -3871,8 +3817,7 @@ class Test_Lightfuzz_try_get_as_post(ModuleTestBase):
         },
     }
 
-    def request_handler(self, request):
-        parameter_block = """
+    parameter_block = """
         <section class=search>
             <form action=/ method=GET>
                 <input type=text placeholder='Search the blog...' name=search>
@@ -3881,27 +3826,10 @@ class Test_Lightfuzz_try_get_as_post(ModuleTestBase):
         </section>
         """
 
-        if request.method == "POST" and "search" in request.form.keys():
-            value = request.form["search"]
-
-            sql_block_normal = f"""
-        <section class=blog-header>
-            <h1>0 search results for '{unquote(value)}'</h1>
-            <hr>
-        </section>
-        """
-
-            sql_block_error = """
-        <section class=error>
-            <h1>Found error in SQL query</h1>
-            <hr>
-        </section>
-        """
-            if value.endswith("'"):
-                if value.endswith("''"):
-                    return Response(sql_block_normal, status=200)
-                return Response(sql_block_error, status=500)
-        return Response(parameter_block, status=200)
+    def request_handler(self, request):
+        # only the converted POSTPARAM pass reaches a query here
+        value = request.form.get("search") if request.method == "POST" else None
+        return sqli_injectable_response(value, self.parameter_block)
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["lightfuzz"].helpers.rand_string = lambda *args, **kwargs: (
@@ -4147,6 +4075,66 @@ class Test_Lightfuzz_sqli_flappy_baseline(Test_Lightfuzz_sqli):
         )
 
 
+def _sqli_code_change_findings(events):
+    return [
+        e.data["description"] for e in events if e.type == "FINDING" and "Code Change" in e.data.get("description", "")
+    ]
+
+
+# SQLi negative test: the textbook 200->500->200 status flip on a parameter that never reaches a
+# query. TRUE and FALSE boolean payloads come back byte-identical, so there is no SQL logic to
+# confirm. This is the shape an envelope-wrapped parameter produces when the injected quote
+# changes the envelope's structural validity rather than a query's.
+class Test_Lightfuzz_sqli_no_boolean_differential_fp(Test_Lightfuzz_sqli):
+    def request_handler(self, request):
+        value = request.args.get("search")
+        if value is None:
+            return Response(self.parameter_block, status=200)
+        if value.endswith("'") and not value.endswith("''"):
+            return Response("<html><p>Bad Request</p></html>", status=500)
+        return Response("<html><p>0 results</p></html>", status=200)
+
+    def check(self, module_test, events):
+        findings = _sqli_code_change_findings(events)
+        assert not findings, f"SQLi reported from a status flip with no boolean differential: {findings}"
+
+
+# SQLi negative test: the single-quote probe is blocked by an access-control layer whose block
+# page carries no recognizable WAF signature. The transition into 403 is what identifies it.
+class Test_Lightfuzz_sqli_unsigned_403_fp(Test_Lightfuzz_sqli):
+    def request_handler(self, request):
+        value = request.args.get("search")
+        if value is None:
+            return Response(self.parameter_block, status=200)
+        if value.endswith("'") and not value.endswith("''"):
+            return Response(
+                "<html><head><title>Forbidden</title></head><body><h1>Forbidden</h1>"
+                "<p>Reference: 0aB1cD2e</p></body></html>",
+                status=403,
+            )
+        return Response("<html><p>0 results</p></html>", status=200)
+
+    def check(self, module_test, events):
+        findings = _sqli_code_change_findings(events)
+        assert not findings, f"SQLi reported from a probe blocked with an unsigned 403: {findings}"
+
+
+# SQLi negative test: the status is keyed on the payload's length, not its quoting. A benign
+# one-vs-two-character pair reproduces the same status triplet, so the change isn't quote-specific.
+class Test_Lightfuzz_sqli_length_keyed_fp(Test_Lightfuzz_sqli):
+    def request_handler(self, request):
+        value = request.args.get("search")
+        if value is None:
+            return Response(self.parameter_block, status=200)
+        if len(value) == 11:
+            return Response("<html><p>Bad Request</p></html>", status=500)
+        return Response("<html><p>0 results</p></html>", status=200)
+
+    def check(self, module_test, events):
+        findings = _sqli_code_change_findings(events)
+        assert not findings, f"SQLi reported from a length-keyed status flip: {findings}"
+
+
 # Verify that POST SQLi findings include additional_params in the description
 class Test_Lightfuzz_sqli_post_additional_params(ModuleTestBase):
     targets = ["http://127.0.0.1:8888"]
@@ -4160,8 +4148,7 @@ class Test_Lightfuzz_sqli_post_additional_params(ModuleTestBase):
         },
     }
 
-    def request_handler(self, request):
-        parameter_block = """
+    parameter_block = """
         <section class=search>
             <form action=/ method=POST>
                 <input type=text name=search>
@@ -4170,14 +4157,9 @@ class Test_Lightfuzz_sqli_post_additional_params(ModuleTestBase):
             </form>
         </section>
         """
-        if "search" in request.form.keys():
-            value = request.form["search"]
-            if value.endswith("'"):
-                if value.endswith("''"):
-                    return Response("<p>normal</p>", status=200)
-                return Response("<p>error</p>", status=500)
-            return Response("<p>results</p>", status=200)
-        return Response(parameter_block, status=200)
+
+    def request_handler(self, request):
+        return sqli_injectable_response(request.form.get("search"), self.parameter_block)
 
     async def setup_after_prep(self, module_test):
         module_test.scan.modules["lightfuzz"].helpers.rand_string = lambda *args, **kwargs: (
@@ -5025,6 +5007,20 @@ def test_keystream_fp_sibling_form_fields_incremental():
     )
     c.detect_keystream_reuse("aabbccdd00000010")
     assert not c.results, f"FP on sibling sequential hex form fields: {c.results}"
+
+
+def test_keystream_fp_record_guid_shared_template():
+    """Two 32-hex record GUIDs from the same platform instance. They share no leading byte, so
+    the leading-zero test never applies, but they re-converge at fixed offsets where the shared
+    instance/table segment sits -- and the XOR of the diverging bytes lands almost entirely in
+    the ASCII-XOR range by coincidence, clearing the 0.9 score on its own."""
+    ids = [
+        "e42a5af4c700201072b211d4d8c2607c",
+        "c86a62e2c7022010099a308dc7c26022",
+    ]
+    c = _make_crypto_for_keystream(ids[0], additional_params={"app_sys_id": ids[1]})
+    c.detect_keystream_reuse(ids[0])
+    assert not c.results, f"FP on record GUIDs sharing a field template: {c.results}"
 
 
 def test_keystream_fp_decimal_account_numbers():

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -1,6 +1,7 @@
 import json
 import re
 import base64
+import html
 from types import SimpleNamespace
 from urllib.parse import urlparse, parse_qs
 
@@ -4133,6 +4134,25 @@ class Test_Lightfuzz_sqli_length_keyed_fp(Test_Lightfuzz_sqli):
     def check(self, module_test, events):
         findings = _sqli_code_change_findings(events)
         assert not findings, f"SQLi reported from a length-keyed status flip: {findings}"
+
+
+# SQLi negative test: the parameter never reaches a query, and the app reflects it HTML-escaped.
+# The escaped reflection differs between the TRUE and FALSE boolean payloads, so unless every
+# escape spelling is stripped, the reflection itself reads as a boolean differential.
+class Test_Lightfuzz_sqli_escaped_reflection_fp(Test_Lightfuzz_sqli):
+    def request_handler(self, request):
+        value = request.args.get("search")
+        if value is None:
+            return Response(self.parameter_block, status=200)
+        if value.endswith("'") and not value.endswith("''"):
+            return Response("<html><p>Bad Request</p></html>", status=500)
+        # the Jinja/ASP.NET spelling, deliberately not the one html.escape() produces
+        reflection = html.escape(value).replace("&#x27;", "&#39;")
+        return Response(f"<html><p>0 results for: {reflection}</p></html>", status=200)
+
+    def check(self, module_test, events):
+        findings = _sqli_code_change_findings(events)
+        assert not findings, f"SQLi reported from an HTML-escaped reflection: {findings}"
 
 
 # Verify that POST SQLi findings include additional_params in the description

--- a/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
+++ b/bbot/test/test_step_2/module_tests/test_module_lightfuzz.py
@@ -5029,20 +5029,6 @@ def test_keystream_fp_sibling_form_fields_incremental():
     assert not c.results, f"FP on sibling sequential hex form fields: {c.results}"
 
 
-def test_keystream_fp_record_guid_shared_template():
-    """Two 32-hex record GUIDs from the same platform instance. They share no leading byte, so
-    the leading-zero test never applies, but they re-converge at fixed offsets where the shared
-    instance/table segment sits -- and the XOR of the diverging bytes lands almost entirely in
-    the ASCII-XOR range by coincidence, clearing the 0.9 score on its own."""
-    ids = [
-        "e42a5af4c700201072b211d4d8c2607c",
-        "c86a62e2c7022010099a308dc7c26022",
-    ]
-    c = _make_crypto_for_keystream(ids[0], additional_params={"app_sys_id": ids[1]})
-    c.detect_keystream_reuse(ids[0])
-    assert not c.results, f"FP on record GUIDs sharing a field template: {c.results}"
-
-
 def test_keystream_fp_decimal_account_numbers():
     """Digit-only parameter values (account numbers, zip codes, etc.) are valid
     hex but are plain decimal IDs. Their decoded bytes XOR to small values that

--- a/bbot/test/test_step_2/module_tests/test_module_wayback.py
+++ b/bbot/test/test_step_2/module_tests/test_module_wayback.py
@@ -133,6 +133,17 @@ class TestWaybackArchive(ModuleTestBase):
                 assert "web.archive.org" not in e.data["url"], (
                     f"FINDING url should NOT be an archive.org URL, got: {e.data['url']}"
                 )
+                # the evidence is a snapshot, not the live host, and that has to be visible
+                # without reading discovery_path
+                assert e.archive_url, f"FINDING from archived content has no archive_url: {e.tags}"
+                assert e.pretty_string.startswith("[ARCHIVED] "), (
+                    f"FINDING from archived content is not marked as archived: {e.pretty_string}"
+                )
+                # the snapshot URL has to survive into output.txt and output.json
+                assert e.data_human.endswith(f"(archived: {e.archive_url})"), (
+                    f"output.txt is missing the archive URL: {e.data_human}"
+                )
+                assert e.json()["archive_url"] == e.archive_url
         # web.archive.org should NOT appear as a DNS_NAME event
         assert not any(e.type == "DNS_NAME" and e.data == "web.archive.org" for e in events), (
             "web.archive.org should not leak as a DNS_NAME event"


### PR DESCRIPTION
Two lightfuzz submodules asserted a vulnerability from a status-code flip, without any content-level evidence that the vuln class was actually present. This came out of triaging a large batch of findings from real engagement scans, where each of these produced a recurring, systematic false-positive class.

### `sqli`: the `'` vs `''` status flip proved nothing on its own

The Code Change branch emitted `Possible SQL Injection` (HIGH) purely from a status difference between the single-quote and doubled-quote probes. Two confounders produce that flip with no SQL involved:

- **A WAF matching its managed SQLi signature.** The bare `'` gets a 403, the doubled `''` does not. The existing guard only suppressed this when the block page matched a WAF YARA signature, which the block pages responsible for these findings did not.
- **An envelope whose structural validity changes when the payload is repacked.** Injecting into a field inside a base64/JSON envelope changes whether the envelope decodes and validates, so the status flips independently of any query.

Two gates now apply, cheapest first:

1. `is_quote_specific()` appends one vs. two benign characters, mirroring `'`/`''` in length with no SQL meaning. If the benign pair reproduces the same status triplet, the flip tracks value length or envelope validity.
2. `confirm_boolean_differential()` is required to emit. A TRUE/FALSE pair must produce a content differential, with reflected payloads stripped in raw, URL-encoded and HTML-escaped form, and the TRUE payload re-sent to confirm the body is deterministic (an unstable page would otherwise fake a differential). The confirming pair is recorded in the finding description.

`dev`'s YARA-gated 403 check is unchanged. Suppressing every transition into 403 was tried and reverted: it costs real findings on apps that answer a SQL error with 403, and the boolean gate already rejects unsigned block pages.

Time-based blind detection is untouched.

### `serial`: URI parsing read as deserialization

Error Resolution fired when a garbage control payload returned 500 and a serialized probe returned 200. On parameters the framework parses as a URL or host, that flip is URI parsing: .NET's `Uri` treats everything before the first `/` as the hostname, so a payload whose leading token happens to be a valid host label parses, and the control payload does not. The payload's content never mattered.

Before emitting, we now send a twin of the payload with the same encoding, length and trailing bytes but a scrambled magic header. It still parses identically and deserializes under nothing. If it resolves the error too, the outcome is independent of the payload's content and the finding is suppressed.

### Archived provenance on findings

Detectors running over a Wayback-archived body emitted findings with live severity and no visible indication the evidence was historical. The only signal was `discovery_path`.

`FINDING` now renders the snapshot URL via the existing but unused `event.archive_url` property: in `output.txt` as a trailing `(archived: <url>)`, and in `output.json` as a top-level `archive_url` key. It is deliberately kept out of `data`, since `FINDING` dedups on the whole data dict and putting it there would change finding identity.

Severity is not altered. An archived finding is still worth surfacing, particularly information disclosure, where the named resources may still be live.

### Notes

- `HttpCompare.parse_body()` was extracted from `_compare_sync` so the sqli differential feeds `compare_body` the parsed body. Passing raw text silently bypasses the `ddiff_filters` that mask dynamic content.
- Seven sqli test mocks were not boolean-injectable and would have stopped firing under the new gate. They were made genuinely vulnerable via a shared `sqli_injectable_response()` helper rather than relaxing assertions, which are unchanged. Those handlers also parsed the query string positionally, which breaks on payloads containing `=`, so they now use `request.args`.
- The five new false-positive tests were verified by stashing the source fixes and re-running: all five fail against unmodified `dev`, so none pass vacuously.
- A many-time-pad false-positive class (structured platform GUIDs read as reused keystream) was investigated and deliberately left in place. Every filter that suppressed it also suppressed real keystream reuse on templated plaintexts, and an unexplained value is worth surfacing even when it turns out to be benign. `crypto.py` is untouched.

