### PR TITLE
Verify hosts are alive before emitting wayback URLs

### DIFF
--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -172,7 +172,14 @@ rule akamai_bot_manager_url
 
         Any response counts as alive -- only connect failures and timeouts (after retries)
         mark a host dead. Verdicts are cached for the rest of the scan.
+
+        Probing is skipped entirely when a proxy is configured, since the proxy answers on the
+        target's behalf: an unreachable upstream comes back as a proxy 502, which is
+        indistinguishable from a real one. With no trustworthy verdict available we emit every
+        host's URLs rather than guess.
         """
+        if not self._liveness_probing:
+            return set(keys)
         live = set()
         probes = []
         probe_kwargs = {
@@ -235,6 +242,9 @@ rule akamai_bot_manager_url
         # 32M bits (~4MB) supports ~400K entries with negligible false-positive rate
         self._archive_bloom = self.helpers.bloom_filter(32000000)
         self._liveness_cache = LRUCache(maxsize=self._liveness_cache_size)
+        self._liveness_probing = not self.scan.config.get("web", {}).get("http_proxy")
+        if self.urls and not self._liveness_probing:
+            self.verbose("Emitting wayback URLs without liveness probing because an HTTP proxy is configured")
         self._junk_url_rules = self.helpers.yara.compile(source="\n".join(self._junk_url_yara_rules.values()))
         return await super().setup()
 

--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -242,7 +242,7 @@ rule akamai_bot_manager_url
         # 32M bits (~4MB) supports ~400K entries with negligible false-positive rate
         self._archive_bloom = self.helpers.bloom_filter(32000000)
         self._liveness_cache = LRUCache(maxsize=self._liveness_cache_size)
-        self._liveness_probing = not self.scan.config.get("web", {}).get("http_proxy")
+        self._liveness_probing = not self.scan.http_proxy
         if self.urls and not self._liveness_probing:
             self.verbose("Emitting wayback URLs without liveness probing because an HTTP proxy is configured")
         self._junk_url_rules = self.helpers.yara.compile(source="\n".join(self._junk_url_yara_rules.values()))

--- a/bbot/modules/wayback.py
+++ b/bbot/modules/wayback.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 import orjson
+from cachetools import LRUCache
 
 from bbot.core.helpers.misc import get_file_extension
 from bbot.core.helpers.validators import clean_url
@@ -158,6 +159,47 @@ rule akamai_bot_manager_url
         kept = [url for idx, url in enumerate(candidates) if idx not in junk_set]
         return kept, len(junk_set)
 
+    # HTTP liveness probing for hosts found in CDX results. A dead host's URLs are dropped
+    # instead of being emitted for the rest of the scan to chase.
+    # 40K (scheme, netloc) -> bool entries measures out to roughly 10MB.
+    _liveness_cache_size = 40000
+    _liveness_probe_threads = 25
+    # one retry, so a single dropped packet doesn't condemn a live host
+    _liveness_probe_retries = 1
+
+    async def _live_netlocs(self, keys):
+        """Return the subset of (scheme, netloc) keys that answer HTTP.
+
+        Any response counts as alive -- only connect failures and timeouts (after retries)
+        mark a host dead. Verdicts are cached for the rest of the scan.
+        """
+        live = set()
+        probes = []
+        probe_kwargs = {
+            "method": "HEAD",
+            "follow_redirects": False,
+            "retries": self._liveness_probe_retries,
+            "timeout": self.http_timeout,
+        }
+        for key in keys:
+            cached = self._liveness_cache.get(key)
+            if cached is not None:
+                if cached:
+                    live.add(key)
+                continue
+            scheme, netloc = key
+            probes.append((f"{scheme}://{netloc}/", probe_kwargs, key))
+        if probes:
+            self.verbose(f"Probing {len(probes):,} hosts for HTTP liveness")
+            async for _, response, key in self.helpers.request_batch_stream(
+                probes, threads=self._liveness_probe_threads
+            ):
+                is_live = response is not None
+                self._liveness_cache[key] = is_live
+                if is_live:
+                    live.add(key)
+        return live
+
     def _is_interesting_file(self, url):
         ext = get_file_extension(url)
         if ext and ext.lower() in self.interesting_extensions:
@@ -192,6 +234,7 @@ rule akamai_bot_manager_url
         # (multiple request URLs can redirect to the same archived snapshot)
         # 32M bits (~4MB) supports ~400K entries with negligible false-positive rate
         self._archive_bloom = self.helpers.bloom_filter(32000000)
+        self._liveness_cache = LRUCache(maxsize=self._liveness_cache_size)
         self._junk_url_rules = self.helpers.yara.compile(source="\n".join(self._junk_url_yara_rules.values()))
         return await super().setup()
 
@@ -490,14 +533,24 @@ rule akamai_bot_manager_url
                 https_key = parsed_url._replace(scheme="https").geturl()
                 if https_key not in url_dedup or parsed_url.scheme == "https":
                     url_dedup[https_key] = parsed_url
+            # only emit URLs for hosts that actually answer HTTP -- a dead host's URLs
+            # are pure cost for every downstream module
+            live_netlocs = await self._live_netlocs({(p.scheme, p.netloc) for p in url_dedup.values()})
+            dead_urls = 0
             for parsed_url in url_dedup.values():
                 url_str = parsed_url.geturl()
+                # dead hosts are exactly what the archive is for, so they still get cached for finish()
+                if self.archive and url_str in archive_urls:
+                    self._archive_cache[url_str] = archive_urls[url_str]
+                if (parsed_url.scheme, parsed_url.netloc) not in live_netlocs:
+                    dead_urls += 1
+                    continue
                 results.add((url_str, "URL_UNVERIFIED"))
                 if self.parameters and url_str in raw_url_params:
                     base_url = urlunparse((parsed_url.scheme, parsed_url.netloc, parsed_url.path, "", "", ""))
                     self._parameter_cache[url_str] = (raw_url_params[url_str], base_url)
-                if self.archive and url_str in archive_urls:
-                    self._archive_cache[url_str] = archive_urls[url_str]
+            if dead_urls:
+                self.verbose(f"Dropped {dead_urls:,} URLs belonging to hosts that don't answer HTTP")
         else:
             for parsed_url in parsed_urls:
                 collapsed_urls += 1

--- a/bbot/test/test_step_2/module_tests/test_module_wayback.py
+++ b/bbot/test/test_step_2/module_tests/test_module_wayback.py
@@ -141,6 +141,80 @@ class TestWaybackDeadHostSkip(ModuleTestBase):
         }, f"Unexpected liveness cache contents: {dict(module_test.module._liveness_cache)}"
 
 
+class TestWaybackDeadHostInterestingFile(ModuleTestBase):
+    """Interesting-file FINDINGs are not gated on host liveness. The file is fetched from
+    archive.org, not the host, and a backup.zip that no longer exists on a dead host is
+    exactly what the archive is worth searching for."""
+
+    module_name = "wayback"
+    modules_overrides = ["wayback"]
+    targets = ["blacklanternsecurity.com"]
+    config_overrides = {"modules": {"wayback": {"urls": True}}}
+
+    async def setup_after_prep(self, module_test):
+        await module_test.mock_dns({"blacklanternsecurity.com": {"A": ["127.0.0.88"]}})
+        module_test.blasthttp_mock.add_response(
+            url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
+            json=[["original"], ["http://blacklanternsecurity.com/backup/site.zip"]],
+        )
+        module_test.blasthttp_mock.add_response(
+            url="http://web.archive.org/web/http://blacklanternsecurity.com/backup/site.zip",
+            headers={"Content-Type": "application/zip", "Content-Length": "1048576"},
+        )
+        # no response registered for http://blacklanternsecurity.com/, so the host reads dead
+
+    def check(self, module_test, events):
+        assert not any(e.type == "URL_UNVERIFIED" for e in events), "Dead host should emit no URL_UNVERIFIED events"
+        assert module_test.module._liveness_cache == {("http", "blacklanternsecurity.com"): False}, (
+            f"Expected the host to be probed and marked dead: {dict(module_test.module._liveness_cache)}"
+        )
+        assert any(e.type == "FINDING" and "site.zip" in e.data["description"] for e in events), (
+            "Interesting-file FINDING should still be emitted for a dead host"
+        )
+
+
+class TestWaybackProxySkipsLivenessProbe(ModuleTestBase):
+    """A proxy answers on the target's behalf, so a response says nothing about the host.
+    With one configured, no probes are sent and every host's URLs are emitted."""
+
+    module_name = "wayback"
+    modules_overrides = ["wayback"]
+    targets = ["blacklanternsecurity.com"]
+    config_overrides = {
+        "modules": {"wayback": {"urls": True}},
+        "web": {"http_proxy": "http://127.0.0.1:9999"},
+    }
+
+    async def setup_after_prep(self, module_test):
+        await module_test.mock_dns(
+            {
+                "blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+                "dead.blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+            }
+        )
+        module_test.blasthttp_mock.add_response(
+            url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
+            json=[["original"], ["https://dead.blacklanternsecurity.com/one"]],
+        )
+        self.probes = []
+
+        def record_probe(request):
+            self.probes.append(request.url)
+            return MockResponse(status_code=502, text="Bad Gateway")
+
+        module_test.blasthttp_mock.add_callback(record_probe, url="https://dead.blacklanternsecurity.com/")
+
+    def check(self, module_test, events):
+        assert self.probes == [], f"No liveness probe should be sent when a proxy is configured: {self.probes}"
+        assert not module_test.module._liveness_cache, (
+            f"Liveness cache should stay empty under a proxy: {dict(module_test.module._liveness_cache)}"
+        )
+        emitted = sorted(e.url for e in events if e.type == "URL_UNVERIFIED")
+        assert emitted == ["https://dead.blacklanternsecurity.com/one"], (
+            f"URLs should be emitted unfiltered under a proxy, got: {emitted}"
+        )
+
+
 class TestWaybackArchive(ModuleTestBase):
     module_name = "wayback"
     modules_overrides = ["wayback", "badsecrets", "excavate"]

--- a/bbot/test/test_step_2/module_tests/test_module_wayback.py
+++ b/bbot/test/test_step_2/module_tests/test_module_wayback.py
@@ -4,6 +4,7 @@ from urllib.parse import unquote
 from werkzeug.wrappers import Response
 
 from bbot.modules.wayback import wayback
+from bbot.test.mock_blasthttp import MockResponse
 
 from .base import ModuleTestBase
 
@@ -35,6 +36,8 @@ class TestWaybackParameters(ModuleTestBase):
         )
         # serve a response on the local httpserver so the httpx binary gets a 200
         module_test.set_expect_requests(expect_args={"uri": "/page"}, respond_args={"response_data": "alive"})
+        # answer wayback's host liveness probe
+        module_test.set_expect_requests(expect_args={"uri": "/"}, respond_args={"response_data": "alive"})
 
     def check(self, module_test, events):
         assert any(e.type == "URL_UNVERIFIED" and "127.0.0.1" in e.url and "/page" in e.url for e in events), (
@@ -73,6 +76,7 @@ class TestWaybackInterestingFiles(ModuleTestBase):
             url="http://web.archive.org/web/http://blacklanternsecurity.com/backup/site.zip",
             headers={"Content-Type": "application/zip", "Content-Length": "1048576"},
         )
+        module_test.blasthttp_mock.add_response(url="http://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         assert any(
@@ -84,6 +88,57 @@ class TestWaybackInterestingFiles(ModuleTestBase):
         for e in events:
             if e.type == "FINDING" and "site.zip" in e.data.get("description", ""):
                 assert "web.archive.org" in e.data["url"]
+
+
+class TestWaybackDeadHostSkip(ModuleTestBase):
+    """URLs are only emitted for hosts that answer HTTP; a dead host's URLs are dropped."""
+
+    module_name = "wayback"
+    modules_overrides = ["wayback"]
+    targets = ["blacklanternsecurity.com"]
+    config_overrides = {"modules": {"wayback": {"urls": True}}}
+
+    async def setup_after_prep(self, module_test):
+        # both hosts resolve -- HTTP reachability is the only difference between them
+        await module_test.mock_dns(
+            {
+                "blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+                "live.blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+                "dead.blacklanternsecurity.com": {"A": ["127.0.0.88"]},
+            }
+        )
+        module_test.blasthttp_mock.add_response(
+            url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
+            json=[
+                ["original"],
+                ["https://live.blacklanternsecurity.com/one"],
+                ["https://live.blacklanternsecurity.com/two"],
+                ["https://dead.blacklanternsecurity.com/one"],
+                ["https://dead.blacklanternsecurity.com/two"],
+            ],
+        )
+        # only the live host answers the liveness probe -- dead.* has no registered
+        # response, so its probe errors out the way an unreachable host would
+        self.probes = []
+
+        def count_probe(request):
+            self.probes.append(request.url)
+            return MockResponse(status_code=200, text="alive")
+
+        module_test.blasthttp_mock.add_callback(count_probe, url="https://live.blacklanternsecurity.com/")
+
+    def check(self, module_test, events):
+        emitted = sorted(e.url for e in events if e.type == "URL_UNVERIFIED")
+        assert emitted == [
+            "https://live.blacklanternsecurity.com/one",
+            "https://live.blacklanternsecurity.com/two",
+        ], f"Expected only the live host's URLs, got: {emitted}"
+        # the host is probed once, no matter how many of its URLs came back from CDX
+        assert self.probes == ["https://live.blacklanternsecurity.com/"], f"Expected 1 probe, got: {self.probes}"
+        assert module_test.module._liveness_cache == {
+            ("https", "live.blacklanternsecurity.com"): True,
+            ("https", "dead.blacklanternsecurity.com"): False,
+        }, f"Unexpected liveness cache contents: {dict(module_test.module._liveness_cache)}"
 
 
 class TestWaybackArchive(ModuleTestBase):
@@ -156,6 +211,7 @@ class TestWaybackHttpHttpsDedup(ModuleTestBase):
                 ["https://blacklanternsecurity.com/page"],
             ],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         url_unverified = [e for e in events if e.type == "URL_UNVERIFIED" and "/page" in e.url]
@@ -182,6 +238,7 @@ class TestWaybackHttpOnlyKept(ModuleTestBase):
                 ["http://blacklanternsecurity.com/old-http-only"],
             ],
         )
+        module_test.blasthttp_mock.add_response(url="http://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         url_unverified = [e for e in events if e.type == "URL_UNVERIFIED" and "/old-http-only" in e.url]
@@ -208,6 +265,7 @@ class TestWaybackCdnCgiBlacklist(ModuleTestBase):
                 ["https://blacklanternsecurity.com/real-page"],
             ],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         # cdn-cgi URL should be filtered
@@ -547,6 +605,7 @@ class TestWaybackGarbageUrlFilter(ModuleTestBase):
                 ["https://blacklanternsecurity.com/real-page"],
             ],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         # garbage URL should be filtered
@@ -578,6 +637,7 @@ class TestWaybackGarbageUrlLength(ModuleTestBase):
                 ["https://blacklanternsecurity.com/normal-page"],
             ],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         # long URL should be filtered
@@ -620,6 +680,7 @@ class TestWaybackJunkUrlFilter(ModuleTestBase):
             url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
             json=[["original"], *([u] for u in self.junk_urls + self.legit_urls)],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         emitted = [e.url for e in events if e.type == "URL_UNVERIFIED"]
@@ -659,6 +720,7 @@ class TestWaybackJunkUrlFilterUnicode(ModuleTestBase):
             url="http://web.archive.org/cdx/search/cdx?url=blacklanternsecurity.com&matchType=domain&output=json&fl=original&collapse=original&limit=100000&filter=!statuscode:404&filter=!statuscode:301&filter=!statuscode:302&filter=!mimetype:image/.*&filter=!mimetype:text/css&filter=!mimetype:warc/revisit",
             json=[["original"], *([u] for u in all_urls)],
         )
+        module_test.blasthttp_mock.add_response(url="https://blacklanternsecurity.com/", text="alive")
 
     def check(self, module_test, events):
         emitted = [e.url for e in events if e.type == "URL_UNVERIFIED"]


### PR DESCRIPTION
## Problem

With `urls=True`, wayback emits a `URL_UNVERIFIED` for every URL that survives filtering, with no check that the host still exists. A CDX response for a large domain routinely contains hundreds of hosts that are long dead, and every one of their URLs gets emitted for the rest of the scan to chase: `http` requests each one, excavate parses the results, the spider follows them. That cost is large and entirely wasted.

Nothing in the emission path checked liveness. `_pre_process_urls` applies an in-scope test, but only for the archive/parameter/interesting-file metadata; the `URL_UNVERIFIED` list bypassed it. `abort_if` runs after DNS resolution but only requires the `in-scope` tag, which an unresolvable host still carries.

## Change

Probe each `(scheme, netloc)` once with `HEAD /` before emitting any of its URLs, and drop the URLs of hosts that don't answer.

- Batched through `request_batch_stream` at 25 concurrency, `follow_redirects=False`, so it's one request per host regardless of URL count.
- Any response counts as alive, including 4xx/5xx. Only connect failures and timeouts mark a host dead.
- Explicit `retries=1` rather than inheriting `web.http_retries`, so a single dropped packet can't condemn a live host even if a user sets that to 0.
- Verdicts cached in an `LRUCache(maxsize=40000)`, measured at 9.44 MB when full with realistic hostnames (248 bytes/entry). The cache lives on the module instance, so that figure is per scan.
- Skipped entirely when a proxy is configured. The proxy answers on the target's behalf, so an unreachable upstream comes back as a proxy 502 that's indistinguishable from a real one. Rather than let proxy config flip the verdict for the same target, no probe is sent and every host's URLs are emitted.

Only reachable from the `urls=True` branch, so the default config sends no probes.

## The archive path is deliberately unaffected

`_archive_cache` is populated *before* the liveness gate. Dead hosts are exactly what the archive feature exists for, so `finish()` still fetches every snapshot it would have before. Eviction behavior is unchanged too: it only fires on a live 2xx URL event, which a dead host never produced anyway. The six existing archive tests all run against `http://127.0.0.1:1/...`, i.e. dead hosts, and pass unchanged.

`_parameter_cache` is now only populated for live hosts. Those entries could only ever be read when a live 2xx URL event arrived, so nothing is lost.

## Interesting-file findings are deliberately unaffected

Same reasoning as the archive path, and worth stating explicitly since the gate sits between them. `interesting_files` is built in `_pre_process_urls`, and `_check_interesting_files` fetches from `web.archive.org`, not from the host. A `backup.zip` that no longer exists on a dead host is exactly what makes the archive worth searching, so those FINDINGs are emitted regardless of liveness.

Pinned by `TestWaybackDeadHostInterestingFile`, which asserts a dead host emits no `URL_UNVERIFIED` events but still produces the finding.

## Tests

New `TestWaybackDeadHostSkip`: two hosts with identical DNS, only one answering HTTP. Asserts only the live host's URLs are emitted, that the host is probed exactly once regardless of URL count, and the resulting cache contents.

Seven existing tests needed a liveness mock, since their hosts are mock-intercepted and an unmatched URL now reads as dead. `TestWaybackParameters` got an explicit `/` handler rather than relying on the httpserver's 500-fallback.

22 passed, 0 failed.

## Notes

- Verdicts are cached for the whole scan, so a host that's briefly unreachable at probe time loses its URLs for the rest of the run. The retry is the mitigation.
- http-only wayback records for a host that has since moved to HTTPS-only now get dropped rather than emitted. They were already dead ends, since `http` would have failed the same connection.
- This makes the module send target traffic when `urls=True` while it's still flagged `passive`. That's a pre-existing inconsistency (`_is_http_wildcard_host` already probes targets in every config) and is tracked separately in #3358 rather than fixed here.
