### PR TITLE
Raise process pool max_tasks_per_child from 25 to 250

### DIFF
--- a/bbot/core/helpers/helper.py
+++ b/bbot/core/helpers/helper.py
@@ -246,7 +246,7 @@ class ConfigAwareHelper:
         # max_tasks_per_child replaces workers after N tasks, preventing memory leaks
         # and reducing the chance of a degraded worker process causing hangs
         if sys.version_info >= (3, 11):
-            pool_kwargs["max_tasks_per_child"] = 25
+            pool_kwargs["max_tasks_per_child"] = 250
         return ProcessPoolExecutor(**pool_kwargs)
 
     def run_in_executor_io(self, callback, *args, **kwargs):


### PR DESCRIPTION
Closes #3366

Under spawn, retiring a worker every 25 tasks forces a cold re-import of the callback module (~742ms for badsecrets). badsecrets runs on every HTTP_RESPONSE and leaks ~0 memory (RSS flat to 5000 tasks), so 25 costs a ~25x throughput drop and ~130x p95 blowup for no benefit. 250 recovers full throughput while keeping the leak and degraded-worker safety net for the heavy infrequent tenants (kreuzberg, bevigil, waf_bypass).