### PR TITLE
Bound compare_body input to prevent quadratic DeepDiff scan stall

### DIFF
--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -294,6 +294,7 @@ class WebConfig(BaseModel):
     max_sleep_interval_429: Optional[int] = Field(default=None, alias="429_max_sleep_interval")
     debug: Optional[bool] = None
     http_max_redirects: Optional[int] = None
+    http_compare_max_differing_lines: Optional[int] = None
     ssl_verify_target: Optional[bool] = None
     ssl_verify_infrastructure: Optional[bool] = None
 

--- a/bbot/core/config/models.py
+++ b/bbot/core/config/models.py
@@ -294,7 +294,7 @@ class WebConfig(BaseModel):
     max_sleep_interval_429: Optional[int] = Field(default=None, alias="429_max_sleep_interval")
     debug: Optional[bool] = None
     http_max_redirects: Optional[int] = None
-    http_compare_max_differing_lines: Optional[int] = None
+    http_compare_max_differing_lines: Optional[int] = Field(default=None, ge=0)
     ssl_verify_target: Optional[bool] = None
     ssl_verify_infrastructure: Optional[bool] = None
 

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -100,7 +100,8 @@ class HttpCompare:
         self.headers = headers
         self.cookies = cookies
         self.timeout = 10
-        self.max_differing_lines = self.parent_helper.web_config.get("http_compare_max_differing_lines", 500) or 500
+        configured_max_differing_lines = self.parent_helper.web_config.get("http_compare_max_differing_lines", 500)
+        self.max_differing_lines = 500 if configured_max_differing_lines is None else configured_max_differing_lines
         # Optional async callback fired once with baseline_1 after the baseline is established.
         self.on_baseline_ready = on_baseline_ready
 
@@ -173,14 +174,22 @@ class HttpCompare:
                 baseline_1_json = baseline_1.text.split("\n")
                 baseline_2_json = baseline_2.text.split("\n")
 
-            ddiff = DeepDiff(
-                baseline_1_json, baseline_2_json, ignore_order=True, view="tree", threshold_to_diff_deeper=0
-            )
-            self.ddiff_filters = []
+            if isinstance(baseline_1_json, list) and isinstance(baseline_2_json, list):
+                self.ddiff_filters = self._unshared_line_paths(baseline_1_json, baseline_2_json)
+            else:
+                ddiff = await self.parent_helper.run_in_executor_cpu(
+                    DeepDiff,
+                    baseline_1_json,
+                    baseline_2_json,
+                    ignore_order=True,
+                    view="tree",
+                    threshold_to_diff_deeper=0,
+                )
+                self.ddiff_filters = []
 
-            for k in ddiff.keys():
-                for x in list(ddiff[k]):
-                    self.ddiff_filters.append(x.path())
+                for k in ddiff.keys():
+                    for x in list(ddiff[k]):
+                        self.ddiff_filters.append(x.path())
 
             self.baseline_json = baseline_1_json
             self.baseline_ignore_headers = [
@@ -237,12 +246,19 @@ class HttpCompare:
                 differing_headers.append(header_value)
         return differing_headers
 
-    def _leaf_counts(self, content):
+    @staticmethod
+    def _unshared_line_paths(lines_1, lines_2):
+        set_1, set_2 = set(lines_1), set(lines_2)
+        paths = {f"root[{index}]" for index, line in enumerate(lines_1) if line not in set_2}
+        paths |= {f"root[{index}]" for index, line in enumerate(lines_2) if line not in set_1}
+        return sorted(paths)
+
+    def _leaf_counts(self, content, filters):
         counts = Counter()
         stack = [("root", content)]
         while stack:
             path, node = stack.pop()
-            if path in self.ddiff_filters:
+            if path in filters:
                 continue
             if isinstance(node, dict):
                 for key, value in node.items():
@@ -258,11 +274,12 @@ class HttpCompare:
         if content_1 == content_2:
             return True
 
-        counts_1 = self._leaf_counts(content_1)
-        counts_2 = self._leaf_counts(content_2)
+        filters = frozenset(self.ddiff_filters)
+        counts_1 = self._leaf_counts(content_1, filters)
+        counts_2 = self._leaf_counts(content_2, filters)
         differing = counts_1 - counts_2
-        differing.update(counts_2 - counts_1)
-        if sum(differing.values()) > self.max_differing_lines:
+        removed = counts_2 - counts_1
+        if max(sum(differing.values()), sum(removed.values())) > self.max_differing_lines:
             return False
 
         ddiff = DeepDiff(

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -1,5 +1,6 @@
 import logging
 import xmltodict
+from collections import Counter
 from deepdiff import DeepDiff
 from contextlib import suppress
 from xml.parsers.expat import ExpatError
@@ -99,6 +100,7 @@ class HttpCompare:
         self.headers = headers
         self.cookies = cookies
         self.timeout = 10
+        self.max_differing_lines = self.parent_helper.web_config.get("http_compare_max_differing_lines", 500)
         # Optional async callback fired once with baseline_1 after the baseline is established.
         self.on_baseline_ready = on_baseline_ready
 
@@ -238,6 +240,14 @@ class HttpCompare:
     def compare_body(self, content_1, content_2):
         if content_1 == content_2:
             return True
+
+        if isinstance(content_1, list) and isinstance(content_2, list):
+            counts_1 = Counter(content_1)
+            counts_2 = Counter(content_2)
+            differing = counts_1 - counts_2
+            differing.update(counts_2 - counts_1)
+            if sum(differing.values()) > self.max_differing_lines:
+                return False
 
         ddiff = DeepDiff(
             content_1,

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -237,17 +237,33 @@ class HttpCompare:
                 differing_headers.append(header_value)
         return differing_headers
 
+    def _leaf_counts(self, content):
+        counts = Counter()
+        stack = [("root", content)]
+        while stack:
+            path, node = stack.pop()
+            if path in self.ddiff_filters:
+                continue
+            if isinstance(node, dict):
+                for key, value in node.items():
+                    stack.append((f"{path}[{key!r}]", value))
+            elif isinstance(node, list):
+                for index, value in enumerate(node):
+                    stack.append((f"{path}[{index}]", value))
+            else:
+                counts[str(node)] += 1
+        return counts
+
     def compare_body(self, content_1, content_2):
         if content_1 == content_2:
             return True
 
-        if isinstance(content_1, list) and isinstance(content_2, list):
-            counts_1 = Counter(content_1)
-            counts_2 = Counter(content_2)
-            differing = counts_1 - counts_2
-            differing.update(counts_2 - counts_1)
-            if sum(differing.values()) > self.max_differing_lines:
-                return False
+        counts_1 = self._leaf_counts(content_1)
+        counts_2 = self._leaf_counts(content_2)
+        differing = counts_1 - counts_2
+        differing.update(counts_2 - counts_1)
+        if sum(differing.values()) > self.max_differing_lines:
+            return False
 
         ddiff = DeepDiff(
             content_1,

--- a/bbot/core/helpers/diff.py
+++ b/bbot/core/helpers/diff.py
@@ -100,7 +100,7 @@ class HttpCompare:
         self.headers = headers
         self.cookies = cookies
         self.timeout = 10
-        self.max_differing_lines = self.parent_helper.web_config.get("http_compare_max_differing_lines", 500)
+        self.max_differing_lines = self.parent_helper.web_config.get("http_compare_max_differing_lines", 500) or 500
         # Optional async callback fired once with baseline_1 after the baseline is established.
         self.on_baseline_ready = on_baseline_ready
 

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -130,6 +130,7 @@ web:
   debug: false
   # Maximum number of HTTP redirects to follow
   http_max_redirects: 5
+  # Skip the body comparison when more than this many leaves differ (0 disables the guard's short-circuit)
   http_compare_max_differing_lines: 500
   # Whether to verify SSL certificates for target-directed traffic (probes, crawls, etc.)
   ssl_verify_target: false

--- a/bbot/defaults.yml
+++ b/bbot/defaults.yml
@@ -130,6 +130,7 @@ web:
   debug: false
   # Maximum number of HTTP redirects to follow
   http_max_redirects: 5
+  http_compare_max_differing_lines: 500
   # Whether to verify SSL certificates for target-directed traffic (probes, crawls, etc.)
   ssl_verify_target: false
   # Whether to verify SSL certificates for non-target traffic (APIs, wordlist downloads, etc.)

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -426,13 +426,35 @@ async def test_web_http_compare(blasthttp_mock, bbot_scanner):
 
     assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "c"]) is True
     assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "x"]) is False
+    assert compare_helper.compare_body(["a", "b", "c"], ["c", "b", "a"]) is True
+    assert compare_helper.compare_body({"a": 1}, {"a": 2}) is False
+    assert compare_helper.compare_body({"a": 1}, {"a": 1}) is True
 
     compare_helper.max_differing_lines = 10
-    base = [f"line {i}" for i in range(2000)]
-    similar = [f"line {i} X" if i < 50 else f"line {i}" for i in range(2000)]
+    shared = [f"line {i}" for i in range(100)]
+    at_threshold = compare_helper.compare_body(
+        shared + [f"a{i}" for i in range(5)],
+        shared + [f"b{i}" for i in range(5)],
+    )
+    over_threshold = compare_helper.compare_body(
+        shared + [f"a{i}" for i in range(6)],
+        shared + [f"b{i}" for i in range(6)],
+    )
+    assert at_threshold is False
+    assert over_threshold is False
+
+    compare_helper.max_differing_lines = 500
+    base = [f"line {i}" for i in range(20000)]
+    similar = [f"line {i} X" if i < 5000 else f"line {i}" for i in range(20000)]
     start = time.monotonic()
     assert compare_helper.compare_body(base, similar) is False
     assert (time.monotonic() - start) < 5
+
+    config_scan = bbot_scanner(config={"web": {"http_compare_max_differing_lines": 42}})
+    await config_scan._prep()
+    config_helper = config_scan.helpers.http_compare("http://www.example.com")
+    assert config_helper.max_differing_lines == 42
+    await config_scan._cleanup()
 
     await scan._cleanup()
 

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -2,6 +2,7 @@ import re
 import time
 
 from blasthttp import HTTPStatusError
+from deepdiff import DeepDiff
 
 from ..bbot_fixtures import *
 
@@ -430,19 +431,6 @@ async def test_web_http_compare(blasthttp_mock, bbot_scanner):
     assert compare_helper.compare_body({"a": 1}, {"a": 2}) is False
     assert compare_helper.compare_body({"a": 1}, {"a": 1}) is True
 
-    compare_helper.max_differing_lines = 10
-    shared = [f"line {i}" for i in range(100)]
-    at_threshold = compare_helper.compare_body(
-        shared + [f"a{i}" for i in range(5)],
-        shared + [f"b{i}" for i in range(5)],
-    )
-    over_threshold = compare_helper.compare_body(
-        shared + [f"a{i}" for i in range(6)],
-        shared + [f"b{i}" for i in range(6)],
-    )
-    assert at_threshold is False
-    assert over_threshold is False
-
     compare_helper.max_differing_lines = 500
     base = [f"line {i}" for i in range(20000)]
     similar = [f"line {i} X" if i < 5000 else f"line {i}" for i in range(20000)]
@@ -455,6 +443,97 @@ async def test_web_http_compare(blasthttp_mock, bbot_scanner):
     config_helper = config_scan.helpers.http_compare("http://www.example.com")
     assert config_helper.max_differing_lines == 42
     await config_scan._cleanup()
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_filtered_lines_not_counted(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner()
+    await scan._prep()
+    blasthttp_mock.add_response(url=re.compile(r"http://www\.example\.com.*"), text="wat")
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+    compare_helper.max_differing_lines = 500
+
+    static = [f"line {i}" for i in range(400)]
+    dynamic_a = [f"nonce {i} A" for i in range(600)]
+    dynamic_b = [f"nonce {i} B" for i in range(600)]
+    dynamic_c = [f"nonce {i} C" for i in range(600)]
+
+    baseline_1 = dynamic_a + static
+    baseline_2 = dynamic_b + static
+    subject = dynamic_c + static
+
+    ddiff = DeepDiff(baseline_1, baseline_2, ignore_order=True, view="tree", threshold_to_diff_deeper=0)
+    compare_helper.ddiff_filters = [x.path() for k in ddiff.keys() for x in list(ddiff[k])]
+    assert len(compare_helper.ddiff_filters) == 600
+
+    assert compare_helper.compare_body(baseline_1, subject) is True
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_bounds_dict_bodies(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner()
+    await scan._prep()
+    blasthttp_mock.add_response(url=re.compile(r"http://www\.example\.com.*"), text="wat")
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+    compare_helper.max_differing_lines = 500
+    compare_helper.ddiff_filters = []
+
+    def rows(salt):
+        return [
+            f'<div class="r{i}" tok="{salt}{i}">item {i}{salt}</div>'
+            if i < 1000
+            else f'<div class="r{i}">item {i}</div>'
+            for i in range(4000)
+        ]
+
+    content_1 = {"html": {"body": {"div": rows("a")}}}
+    content_2 = {"html": {"body": {"div": rows("b")}}}
+
+    start = time.monotonic()
+    assert compare_helper.compare_body(content_1, content_2) is False
+    assert (time.monotonic() - start) < 5
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_threshold_boundary(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner()
+    await scan._prep()
+    blasthttp_mock.add_response(url=re.compile(r"http://www\.example\.com.*"), text="wat")
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+    compare_helper.max_differing_lines = 10
+
+    static = [f"line {i}" for i in range(100)]
+    at_threshold_1 = [f"nonce {i} A" for i in range(5)] + static
+    at_threshold_2 = [f"nonce {i} B" for i in range(5)] + static
+
+    ddiff = DeepDiff(at_threshold_1, at_threshold_2, ignore_order=True, view="tree", threshold_to_diff_deeper=0)
+    compare_helper.ddiff_filters = [x.path() for k in ddiff.keys() for x in list(ddiff[k])]
+
+    assert compare_helper.compare_body(at_threshold_1, at_threshold_2) is True
+
+    over_threshold_1 = [f"nonce {i} A" for i in range(6)] + static
+    over_threshold_2 = [f"nonce {i} B" for i in range(6)] + static
+    compare_helper.ddiff_filters = []
+    assert compare_helper.compare_body(over_threshold_1, over_threshold_2) is False
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_null_threshold_config(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner(config={"web": {"http_compare_max_differing_lines": None}})
+    await scan._prep()
+    blasthttp_mock.add_response(url=re.compile(r"http://www\.example\.com.*"), text="wat")
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+    compare_helper.ddiff_filters = []
+
+    assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "x"]) is False
 
     await scan._cleanup()
 

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -5,6 +5,7 @@ from blasthttp import HTTPStatusError
 from deepdiff import DeepDiff
 
 from ..bbot_fixtures import *
+from bbot.test.mock_blasthttp import MockResponse
 
 from bbot.test.worker import BBOT_TEST_DIR
 
@@ -534,6 +535,48 @@ async def test_web_http_compare_null_threshold_config(blasthttp_mock, bbot_scann
     compare_helper.ddiff_filters = []
 
     assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "x"]) is False
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_line_filters_match_deepdiff(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner()
+    await scan._prep()
+    blasthttp_mock.add_response(url=re.compile(r"http://www\.example\.com.*"), text="wat")
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+
+    static = [f"line {i}" for i in range(200)]
+    sample_1 = [f"nonce {i} A" for i in range(50)] + static
+    sample_2 = [f"nonce {i} B" for i in range(50)] + static
+
+    ddiff = DeepDiff(sample_1, sample_2, ignore_order=True, view="tree", threshold_to_diff_deeper=0)
+    expected = sorted({x.path() for k in ddiff.keys() for x in list(ddiff[k])})
+
+    assert compare_helper._unshared_line_paths(sample_1, sample_2) == expected
+
+    await scan._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_web_http_compare_baseline_bounded_on_dynamic_pages(blasthttp_mock, bbot_scanner):
+    scan = bbot_scanner()
+    await scan._prep()
+
+    static = "\n".join(f"line {i}" for i in range(3000))
+
+    def dynamic(request):
+        nonce = "\n".join(f"nonce {i} {rand_string(8)}" for i in range(1000))
+        return MockResponse(status_code=200, text=f"{nonce}\n{static}")
+
+    blasthttp_mock.add_callback(dynamic, url=re.compile(r"http://www\.example\.com.*"))
+    blasthttp_mock.add_callback(dynamic, url=re.compile(r"http://www\.example\.com.*"))
+    compare_helper = scan.helpers.http_compare("http://www.example.com")
+
+    start = time.monotonic()
+    await compare_helper._baseline()
+    assert (time.monotonic() - start) < 10
+    assert len(compare_helper.ddiff_filters) == 1000
 
     await scan._cleanup()
 

--- a/bbot/test/test_step_1/test_web.py
+++ b/bbot/test/test_step_1/test_web.py
@@ -1,4 +1,5 @@
 import re
+import time
 
 from blasthttp import HTTPStatusError
 
@@ -422,6 +423,16 @@ async def test_web_http_compare(blasthttp_mock, bbot_scanner):
     compare_helper.compare_body({"asdf": "fdsa"}, {"fdsa": "asdf"})
     for mode in ("getparam", "header", "cookie"):
         assert await compare_helper.canary_check("http://www.example.com", mode=mode) is True
+
+    assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "c"]) is True
+    assert compare_helper.compare_body(["a", "b", "c"], ["a", "b", "x"]) is False
+
+    compare_helper.max_differing_lines = 10
+    base = [f"line {i}" for i in range(2000)]
+    similar = [f"line {i} X" if i < 50 else f"line {i}" for i in range(2000)]
+    start = time.monotonic()
+    assert compare_helper.compare_body(base, similar) is False
+    assert (time.monotonic() - start) < 5
 
     await scan._cleanup()
 


### PR DESCRIPTION
Fixes #3339.

## Problem
`HttpCompare` runs `DeepDiff(..., ignore_order=True, threshold_to_diff_deeper=0)` on two HTTP bodies in two places, and its `ignore_order` pairing is quadratic in the number of differing lines.

`_baseline()` is the one that stalls scans. It diffs two full page samples that differ maximally by design, runs directly on the event loop rather than through `run_in_executor_cpu`, and so blocks every queue instead of one worker thread: queues drain, no events emit, one module sits in `processing`, and the scan never finishes.

`compare_body()` hits the same pairing on subject comparisons, but its inputs are already filtered by `ddiff_filters`.

Wildcard detection (`_probe_wildcard_host`) manufactures the worst-case shape on purpose: on a catch-all host all responses are the same large page differing only where the path/token/timestamp is echoed in. It is reached from the web helper, not a module, so it can fire with no fuzzing modules enabled.

## Fix
Two independent bounds.

**`_baseline`**: for line-list bodies, `ddiff_filters` is just "which lines are not shared between the two samples", so compute it with set membership instead of DeepDiff. Dict bodies (parsed XML/JSON) keep the DeepDiff path, now dispatched through `run_in_executor_cpu` so it no longer blocks the loop.

**`compare_body`**: before the DeepDiff call, take the multiset difference of leaves outside `ddiff_filters` (a cheap O(n) `Counter` op). If either direction exceeds `web.http_compare_max_differing_lines` (default 500), the bodies are clearly different, so return `False` without running the pairing. This fires on dict bodies too, since the leaf walk is shape-agnostic.

## Benchmark

### `_baseline` filter construction
Two page samples of `body lines` total, differing on `differing lines` where a token or timestamp is echoed back. Filter output is identical to the DeepDiff path in every row.

| body lines | differing lines | DeepDiff | set-based | identical output |
|---|---|---|---|---|
| 2,000 | 400 | 14.01 s | 1.2 ms | yes |
| 4,000 | 1,000 | 89.76 s | 2.5 ms | yes |
| 8,000 | 2,000 | 301.51 s | 5.4 ms | yes |

Also verified identical over 300 randomized realistic shapes (`test_web_http_compare_line_filters_match_deepdiff` pins one).

### `compare_body` guard
Each shape is two bodies of `body lines` total, identical except for `differing lines`. Every row is in the quadratic zone, so the guard fires in all of them. Each run is an isolated subprocess; wall is monotonic, CPU is `process_time`, peak RSS is `ru_maxrss`.

| body lines | differing lines | wall before | wall after | CPU before | CPU after | peak RSS before | peak RSS after |
|---|---|---|---|---|---|---|---|
| 2,000 | 300 | 11 s | 3 ms | 11 s | 2 ms | 49 MB | 47 MB |
| 2,000 | 600 | 45 s | 2 ms | 44 s | 2 ms | 50 MB | 47 MB |
| 4,000 | 1,000 | 123 s | 4 ms | 118 s | 4 ms | 52 MB | 48 MB |
| 8,000 | 2,000 | did not finish (>150s) | 11 ms | n/a | 11 ms | n/a | 49 MB |
| 16,000 | 4,000 | did not finish (>150s) | 22 ms | n/a | 21 ms | n/a | 51 MB |

Below the threshold the guard does not fire and behavior is unchanged.

## Tests
- `test_web_http_compare_line_filters_match_deepdiff`: set-based filters match DeepDiff exactly on the realistic shape
- `test_web_http_compare_baseline_bounded_on_dynamic_pages`: `_baseline` against a 4,000-line page with 1,000 dynamic lines completes in bounded time with 1,000 filters
- `test_web_http_compare_filtered_lines_not_counted`: filtered lines do not count toward the threshold
- `test_web_http_compare_bounds_dict_bodies`: the guard bounds dict bodies too
- `test_web_http_compare_threshold_boundary`: at-threshold passes, over-threshold short-circuits
- `test_web_http_compare_null_threshold_config`: a null config value falls back to the default

`test_web.py` (21) plus paramminer headers/getparams and `test_scan.py` (28) pass. ruff clean.
