### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bbot"
-version = "3.0.1"
+version = "3.0.2"
 description = "OSINT automation for hackers."
 readme = "README.md"
 license = "AGPL-3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -180,7 +180,7 @@ wheels = [
 
 [[package]]
 name = "bbot"
-version = "3.0.1"
+version = "3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "ansible-core", version = "2.17.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Bumps the version from 3.0.1 to 3.0.2 ahead of the 3.0.2 release (#3332).

Both references to the project version are updated:

- `pyproject.toml` (`[project] version`)
- `uv.lock` (the `bbot` package entry)

`uv lock --check` passes. The other `3.0.1` in `uv.lock` belongs to `requests-file` and is left alone.
