### PR TITLE
fix TypeError when a hostless target is sorted against a /32

### DIFF
--- a/bbot/scanner/target.py
+++ b/bbot/scanner/target.py
@@ -114,7 +114,7 @@ class BaseTarget:
             event_seeds.add(event_seed)
 
         # sort by host size to ensure consistency
-        event_seeds = sorted(event_seeds, key=lambda e: (0, 0) if not e.host else host_size_key(str(e.host)))
+        event_seeds = sorted(event_seeds, key=lambda e: (0, "") if not e.host else host_size_key(str(e.host)))
         for event_seed in event_seeds:
             self.event_seeds.add(event_seed)
             # Some event seeds (e.g. ORG_STUB, USERNAME, BLACKLIST_REGEX) are not host-based and have

--- a/bbot/test/test_step_1/test_target.py
+++ b/bbot/test/test_step_1/test_target.py
@@ -725,6 +725,32 @@ def test_blacklist_get_invalid_host():
     assert result is not None
 
 
+def test_target_add_hostless_with_single_address():
+    """Hostless entries (e.g. BLACKLIST_REGEX) must sort against any host form without a type error.
+
+    host_size_key() returns a (size, str) tuple, so the hostless sentinel must also carry a str
+    in its second position. Explicitly-masked single addresses (/32, /128) share size 0 with the
+    sentinel, which forces the second elements to be compared.
+    """
+    from bbot.scanner.target import ScanBlacklist
+
+    # a hostless entry batched with an explicitly-masked single address
+    for single_address in ["1.2.3.4/32", "dead::beef/128"]:
+        blacklist = ScanBlacklist("RE:test", single_address)
+        assert "REGEX:test" in blacklist.inputs
+        assert blacklist.get(single_address.split("/")[0]) is not None
+
+    # a mixed batch of every host form alongside multiple hostless entries
+    blacklist = ScanBlacklist(
+        "RE:evil", "RE:test", "1.2.3.4/32", "1.2.3.0/24", "dead::beef/128", "5.6.7.8", "evilcorp.com"
+    )
+    assert {r.pattern for r in blacklist.blacklist_regexes} == {"evil", "test"}
+    for host in ["1.2.3.4", "1.2.3.5", "dead::beef", "5.6.7.8", "www.evilcorp.com"]:
+        assert blacklist.get(host) is not None
+    assert "test.com" in blacklist
+    assert "9.9.9.9" not in blacklist
+
+
 def test_no_double_parsing():
     """Regression test: when seeds are auto-populated from target, EventSeed parsing
     should happen only once (via ScanTarget), not twice. BBOTTarget should pass


### PR DESCRIPTION
Fixes #3390

The hostless sort sentinel in `Target.add()` was `(0, 0)`, but `host_size_key()` returns `(size, str)`. An explicitly-masked single address has size `0`, so batching a hostless entry (`BLACKLIST_REGEX`) with a `/32` or `/128` tied on the first element and compared `0` against a `str`:

```python
ScanBlacklist("RE:test", "1.2.3.4/32")
# TypeError: '<' not supported between instances of 'int' and 'str'
```

Reachable with no user-written `RE:` at all, since the `spider` preset ships a blacklist regex:

```
bbot -t example.com -p spider --blacklist 1.2.3.4/32
```

Changes the sentinel to `(0, "")`. Hostless entries are dropped before the radix tree (`_add` returns early on `host is None`), so their sort position is irrelevant and only the type matters.

Adds a regression test covering `/32` and `/128` batched with hostless entries in a single `add()`, plus a mixed batch of every host form.
