### PR TITLE
feat: add rustywap module for RustedWappalyzer tech detection

### DIFF
--- a/bbot/modules/rustywap.py
+++ b/bbot/modules/rustywap.py
@@ -1,0 +1,494 @@
+import math
+import ipaddress
+from typing import Optional
+
+from bbot.core.config.models import BaseModuleConfig, Field
+from bbot.core.helpers.misc import is_ip
+from bbot.modules.base import BaseModule
+
+
+class rustywap(BaseModule):
+    """
+    Query a RustedWappalyzer API server for web technology detection.
+
+    URLs are submitted in batches to the server's /batch endpoint, which analyzes
+    each one and returns detected technologies with versions, CPEs, and (when the
+    server has a VulnVault/PocVault/AlertVault MongoDB configured) CVE, PoC, KEV,
+    and GHSA advisory data.
+
+    Batching is what keeps this module inside the server's rate limit: the default
+    limiter allows 600 requests/minute/IP, and one batch of 100 URLs costs a single
+    request, so 10,000 URLs cost 100 requests instead of 10,000.
+
+    Example /batch response (a bare JSON array, one entry per submitted URL):
+
+    [
+        {
+            "url": "https://evilcorp.com",
+            "technologies": [
+                {
+                    "technology": "Nginx",
+                    "confidence": 100,
+                    "version": "1.28.0",
+                    "cpe": "cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*",
+                    "cves": [
+                        {
+                            "id": "CVE-2024-7347",
+                            "score": 4.7,
+                            "severity": "MEDIUM",
+                            "description": "...",
+                            "published": "2024-08-14"
+                        }
+                    ],
+                    "kev": [],
+                    "pocs": [],
+                    "advisories": []
+                }
+            ],
+            "error": null
+        }
+    ]
+    """
+
+    watched_events = ["URL"]
+    produced_events = ["TECHNOLOGY", "FINDING"]
+    # "active" is deliberate: this module only talks to the RustedWappalyzer API, but
+    # that API fetches the target itself, so running it generates traffic to the target.
+    # Flagging it passive would let it run in passive-only scans and quietly touch hosts.
+    flags = ["active", "safe", "web"]
+    meta = {
+        "description": "Detect web technologies via a RustedWappalyzer API server",
+        "created_date": "2026-08-23",
+        "author": "@shart123456",
+    }
+
+    class Config(BaseModuleConfig):
+        api_url: str = Field("http://localhost:3000", description="Base URL of the RustedWappalyzer API")
+        api_key: Optional[str] = Field(None, description="Bearer token, if the API server requires one")
+        batch_size: int = Field(100, description="URLs submitted per API request (server maximum is 100)")
+        concurrency: int = Field(10, description="How many URLs the server analyzes concurrently per batch")
+        confidence: int = Field(50, description="Minimum detection confidence (0-100) to emit")
+        full_scan: bool = Field(
+            False, description="Probe extra endpoints for version info (roughly doubles server-side cost)"
+        )
+        emit_findings: bool = Field(True, description="Emit FINDINGs for extracted versions and CVEs")
+        max_cves_per_tech: int = Field(
+            5, description="Maximum CVE FINDINGs to emit per technology, highest CVSS first"
+        )
+
+    # matches the server's WappalyzerConfig::max_batch_size — submitting more than
+    # this makes the server reject the entire request with a 400
+    MAX_API_BATCH = 100
+    _batch_size = MAX_API_BATCH
+    _module_threads = 2
+
+    # One analysis per host, not per URL and not per host:port.
+    #
+    # per_hostport_only would treat http://host:80 and https://host:443 as two separate
+    # services and analyze both. In practice port 80 almost always redirects to 443, the
+    # API follows the redirect, and the result is two identical sets of TECHNOLOGY events
+    # at double the API cost. The trade-off is that a genuinely different stack on a
+    # second port (an admin app on :8080, say) is only analyzed once per host.
+    per_host_only = True
+
+    # the API is usually local; a brief restart shouldn't kill the module, but a
+    # genuinely dead server should eventually disable it
+    _api_failure_abort_threshold = 20
+
+    # GHSA severity_level uses "MODERATE" where bbot's FINDING schema wants "MEDIUM"
+    _ghsa_severity_map = {"MODERATE": "MEDIUM"}
+
+    # CVSS v3 thresholds per FIRST.org, mapped onto bbot's FINDING severity levels
+    _cvss_severity_thresholds = (
+        (9.0, "CRITICAL"),
+        (7.0, "HIGH"),
+        (4.0, "MEDIUM"),
+        (0.1, "LOW"),
+    )
+
+    async def setup(self):
+        await super().setup()
+        self.api_url = self.config.get("api_url", "http://localhost:3000").rstrip("/")
+        self._api_key = self.config.get("api_key", None)
+        self.min_confidence = self.config.get("confidence", 50)
+        self.full_scan = self.config.get("full_scan", False)
+        self.api_concurrency = self.config.get("concurrency", 10)
+        self.emit_findings = self.config.get("emit_findings", True)
+        self.max_cves_per_tech = self.config.get("max_cves_per_tech", 5)
+        self._dropped_urls = 0
+
+        if self.full_scan:
+            self.info("full_scan is enabled — expect roughly double the server-side cost per URL")
+
+        # soft-fail (None) rather than hard-fail (False): a missing local API should
+        # disable this one module, not abort the operator's entire scan
+        health_url = f"{self.api_url}/health"
+        r = await self.helpers.request(health_url, headers=self._headers())
+        if r is None:
+            return None, f"Unable to reach RustedWappalyzer API at {health_url}"
+        if r.status_code != 200:
+            return None, f"RustedWappalyzer API at {health_url} returned status {r.status_code}"
+        return True
+
+    @property
+    def batch_size(self):
+        # BaseModule lets operators override batch_size via config. The server hard-rejects
+        # anything over MAX_API_BATCH, so clamp instead of letting every request 400.
+        return min(super().batch_size, self.MAX_API_BATCH)
+
+    @property
+    def max_bisect_depth(self):
+        """
+        How many times a rejected batch may be halved before we give up on it.
+
+        This must be deep enough to reach a *single* URL, or good URLs get discarded
+        alongside the offending one: at depth d the chunk size is batch_size / 2**d,
+        so a fixed depth of 4 against a 100-URL batch bottoms out at ~6 URLs and
+        throws away 6 good results to isolate 1 bad one. ceil(log2(batch_size))
+        guarantees we can always narrow down to one.
+        """
+        return max(1, math.ceil(math.log2(max(self.batch_size, 2))))
+
+    def _headers(self):
+        if self._api_key:
+            return {"Authorization": f"Bearer {self._api_key}"}
+        return {}
+
+    def _is_internal(self, event):
+        """
+        True if this URL's host is known to be private/loopback.
+
+        The API runs its own SSRF check and rejects the *entire* batch if any single
+        URL fails it, so filtering these out locally avoids poisoning good batches.
+        This is best-effort — anything we miss is caught by the bisect fallback.
+        """
+        candidates = [str(event.host)]
+        candidates.extend(str(h) for h in (event.resolved_hosts or []))
+        for candidate in candidates:
+            if not is_ip(candidate):
+                continue
+            try:
+                ip = ipaddress.ip_address(candidate)
+            except ValueError:
+                continue
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                return True
+        return False
+
+    async def handle_batch(self, *events):
+        url_map = {}
+        for event in events:
+            if self._is_internal(event):
+                self.debug(f"Skipping {event.url} (resolves to private/internal address)")
+                self._dropped_urls += 1
+                continue
+            # last writer wins; per_hostport_only already keeps this near-1:1
+            url_map[event.url] = event
+
+        if not url_map:
+            self.verbose(f"No submittable URLs in batch of {len(events):,}")
+            return
+
+        results = await self._submit(list(url_map))
+        for result in results:
+            event = url_map.get(result.get("url", ""))
+            if event is None:
+                # the server normalizes some URLs (e.g. adding a trailing slash),
+                # so fall back to matching on the normalized form
+                event = self._match_loose(result.get("url", ""), url_map)
+            if event is None:
+                self.debug(f"Could not correlate API result for {result.get('url', '')!r} back to an event")
+                continue
+            await self._emit_result(result, event)
+
+    def _match_loose(self, url, url_map):
+        stripped = url.rstrip("/")
+        for candidate, event in url_map.items():
+            if candidate.rstrip("/") == stripped:
+                return event
+        return None
+
+    async def _submit(self, urls, depth=0):
+        """
+        POST a list of URLs to /batch, bisecting on a 400.
+
+        The server returns 400 for the *whole* batch if any single URL fails its
+        SSRF check, so one bad host would otherwise discard up to 99 good results.
+        Halving costs ~7 extra requests to isolate one offender out of 100.
+        """
+        if not urls:
+            return []
+
+        payload = {
+            "urls": urls,
+            "concurrency": self.api_concurrency,
+            "confidence": self.min_confidence,
+            "full_scan": self.full_scan,
+        }
+        r = await self.api_request(
+            f"{self.api_url}/batch",
+            method="POST",
+            json=payload,
+            headers=self._headers(),
+        )
+        if r is None:
+            self.verbose(f"No response from API for batch of {len(urls):,} URLs")
+            self._dropped_urls += len(urls)
+            return []
+
+        if r.status_code == 400:
+            return await self._bisect(urls, depth, r)
+
+        if r.status_code != 200:
+            self.verbose(f"API returned status {r.status_code} for batch of {len(urls):,} URLs")
+            self._dropped_urls += len(urls)
+            return []
+
+        try:
+            data = r.json()
+        except Exception as e:
+            self.verbose(f"Error parsing JSON from API batch response: {e}")
+            self.trace()
+            self._dropped_urls += len(urls)
+            return []
+
+        if not isinstance(data, list):
+            # the error path returns an object, not an array
+            message = data.get("error", data) if isinstance(data, dict) else data
+            self.verbose(f"Unexpected API batch response: {message}")
+            self._dropped_urls += len(urls)
+            return []
+        return data
+
+    async def _bisect(self, urls, depth, response):
+        reason = ""
+        try:
+            reason = response.json().get("error", "")
+        except Exception:
+            reason = getattr(response, "text", "")
+
+        if len(urls) == 1:
+            # never silently drop: an unreported discard reads as "nothing detected"
+            self.verbose(f"API rejected {urls[0]}: {reason}")
+            self._dropped_urls += 1
+            return []
+
+        if depth >= self.max_bisect_depth:
+            self.warning(
+                f"Giving up on {len(urls):,} URLs after {depth} bisect attempts (last error: {reason})",
+                trace=False,
+            )
+            self._dropped_urls += len(urls)
+            return []
+
+        self.debug(f"API rejected batch of {len(urls):,} URLs ({reason}); splitting")
+        midpoint = len(urls) // 2
+        left = await self._submit(urls[:midpoint], depth + 1)
+        right = await self._submit(urls[midpoint:], depth + 1)
+        return left + right
+
+    async def _emit_result(self, result, event):
+        error = result.get("error", None)
+        if error:
+            self.debug(f"API error for {event.url}: {error}")
+            return
+
+        host = str(event.host)
+        url = result.get("url", event.url)
+
+        for tech in result.get("technologies", []) or []:
+            name = tech.get("technology", "")
+            if not name:
+                continue
+
+            await self.emit_event(
+                {"technology": name.lower(), "url": url, "host": host},
+                "TECHNOLOGY",
+                parent=event,
+                context=f"{{module}} analyzed {url} and identified {{event.type}}: {name.lower()}",
+            )
+
+            if not self.emit_findings:
+                continue
+
+            version = tech.get("version", None)
+            if version:
+                # TECHNOLOGY's schema is {host, technology, url} — a "version" key is
+                # silently dropped by its pydantic validator, so versions go here instead
+                cpe = tech.get("cpe", None)
+                description = f"{name} {version}"
+                if cpe:
+                    description += f" ({cpe})"
+                await self.emit_event(
+                    {
+                        "host": host,
+                        "url": url,
+                        "severity": "INFO",
+                        "name": f"Software Version - {name}",
+                        "description": f"Version detected: {description}",
+                        "confidence": self._finding_confidence(tech.get("confidence", 0)),
+                    },
+                    "FINDING",
+                    parent=event,
+                    context=f"{{module}} analyzed {url} and identified {{event.type}}: {description}",
+                )
+
+            emitted_cves = await self._emit_cve_findings(tech, event, url, host, name)
+            await self._emit_advisory_findings(tech, event, url, host, name, emitted_cves)
+
+    async def _emit_cve_findings(self, tech, event, url, host, name):
+        """Emit one FINDING per CVE, capped at max_cves_per_tech. Returns the CVE ids emitted."""
+        cves = tech.get("cves", []) or []
+        if not cves:
+            return set()
+
+        kev_ids = {k.get("cve_id", "") for k in (tech.get("kev", []) or [])}
+        pocs_by_cve = {}
+        for poc in tech.get("pocs", []) or []:
+            pocs_by_cve.setdefault(poc.get("cve_id", ""), []).append(poc)
+
+        # highest CVSS first, so the cap keeps the worst rather than an arbitrary slice
+        ranked = sorted(cves, key=lambda c: c.get("score", 0) or 0, reverse=True)
+        emitted = ranked[: self.max_cves_per_tech]
+        if len(ranked) > len(emitted):
+            self.verbose(
+                f"{name} on {url}: emitting top {len(emitted)} of {len(ranked)} CVEs "
+                f"(max_cves_per_tech={self.max_cves_per_tech})"
+            )
+
+        version = tech.get("version", None)
+        tech_label = f"{name} {version}" if version else name
+        emitted_ids = set()
+
+        for cve in emitted:
+            cve_id = cve.get("id", "")
+            if not cve_id:
+                continue
+            emitted_ids.add(cve_id)
+            score = cve.get("score", 0) or 0
+            severity = self._severity_from_score(score, cve.get("severity", ""))
+
+            description = f"{tech_label} is affected by {cve_id} (CVSS {score})"
+            summary = (cve.get("description", "") or "").strip()
+            if summary:
+                description += f": {summary[:300]}"
+            if cve_id in kev_ids:
+                description += " [CISA KEV - known exploited]"
+            pocs = pocs_by_cve.get(cve_id, [])
+            if pocs:
+                poc_urls = ", ".join(p.get("url", "") for p in pocs[:3] if p.get("url", ""))
+                if poc_urls:
+                    description += f" [PoC: {poc_urls}]"
+
+            await self.emit_event(
+                {
+                    "host": host,
+                    "url": url,
+                    "severity": severity,
+                    "name": f"Vulnerable Software - {tech_label}",
+                    "description": description,
+                    "confidence": "MEDIUM" if not version else "HIGH",
+                    "cves": [cve_id],
+                },
+                "FINDING",
+                parent=event,
+                context=f"{{module}} analyzed {url} and identified {severity.lower()} {{event.type}}: {cve_id} in {tech_label}",
+            )
+
+        return emitted_ids
+
+    async def _emit_advisory_findings(self, tech, event, url, host, name, emitted_cves):
+        """
+        Emit FINDINGs for GHSA advisories the CVE pass didn't already cover.
+
+        The API supplements CVE lookups with package-level GitHub advisories, so an
+        advisory may carry no CVE at all — those would be lost entirely if we only
+        walked the `cves` list. Advisories whose cve_id was already emitted above are
+        skipped so the same vulnerability isn't reported twice.
+        """
+        advisories = tech.get("advisories", []) or []
+        if not advisories:
+            return
+
+        # an advisory with no CVE is always fresh; one whose CVE we already emitted is not
+        fresh = [a for a in advisories if not (a.get("cve_id") and a.get("cve_id") in emitted_cves)]
+        if not fresh:
+            return
+
+        ranked = sorted(fresh, key=lambda a: a.get("severity", 0) or 0, reverse=True)
+        selected = ranked[: self.max_cves_per_tech]
+        if len(ranked) > len(selected):
+            self.verbose(
+                f"{name} on {url}: emitting top {len(selected)} of {len(ranked)} GHSA advisories "
+                f"(max_cves_per_tech={self.max_cves_per_tech})"
+            )
+
+        version = tech.get("version", None)
+        tech_label = f"{name} {version}" if version else name
+
+        for advisory in selected:
+            ghsa_id = advisory.get("id", "")
+            if not ghsa_id:
+                continue
+            score = advisory.get("severity", 0) or 0
+            level = str(advisory.get("severity_level", "") or "").strip().upper()
+            level = self._ghsa_severity_map.get(level, level)
+            severity = self._severity_from_score(score, level)
+
+            package = advisory.get("package_name", "")
+            ecosystem = advisory.get("ecosystem", "")
+            pkg_label = f"{ecosystem}:{package}" if ecosystem and package else (package or ecosystem)
+
+            description = f"{tech_label} is affected by {ghsa_id}"
+            if pkg_label:
+                description += f" ({pkg_label})"
+            summary = (advisory.get("summary", "") or "").strip()
+            if summary:
+                description += f": {summary[:300]}"
+
+            data = {
+                "host": host,
+                "url": url,
+                "severity": severity,
+                "name": f"Vulnerable Package - {tech_label}",
+                "description": description,
+                "confidence": "MEDIUM" if not version else "HIGH",
+            }
+            # GHSA ids are not CVE ids, so only populate `cves` when a real CVE is mapped
+            cve_id = advisory.get("cve_id", None)
+            if cve_id:
+                data["cves"] = [cve_id]
+
+            await self.emit_event(
+                data,
+                "FINDING",
+                parent=event,
+                context=f"{{module}} analyzed {url} and identified {severity.lower()} {{event.type}}: {ghsa_id} in {tech_label}",
+            )
+
+    def _severity_from_score(self, score, reported):
+        reported = str(reported).strip().upper()
+        if reported in ("INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"):
+            return reported
+        for threshold, severity in self._cvss_severity_thresholds:
+            if score >= threshold:
+                return severity
+        return "INFO"
+
+    def _finding_confidence(self, confidence):
+        # the API reports 0-100; FINDING wants one of bbot's confidence labels
+        try:
+            confidence = int(confidence)
+        except (TypeError, ValueError):
+            return "UNKNOWN"
+        if confidence >= 100:
+            return "CONFIRMED"
+        if confidence >= 75:
+            return "HIGH"
+        if confidence >= 50:
+            return "MEDIUM"
+        return "LOW"
+
+    async def finish(self):
+        if self._dropped_urls:
+            self.info(f"{self._dropped_urls:,} URLs were not analyzed (internal address, API error, or rejection)")

--- a/bbot/test/test_step_2/module_tests/test_module_rustywap.py
+++ b/bbot/test/test_step_2/module_tests/test_module_rustywap.py
@@ -1,0 +1,555 @@
+import json
+
+from bbot.test.mock_blasthttp import MockResponse
+
+from .base import ModuleTestBase
+
+# The mock passes through localhost/127.0.0.1 (see _should_mock in conftest.py) so the
+# API URL must be a non-local host, or requests hit a real server on port 3000.
+API_URL = "http://rustywap-api.test:3000"
+
+# bbot's test harness maps DNS to 127.0.0.88, and the module deliberately refuses
+# private/loopback hosts, so these tests drive the module with synthetic public URLs
+# rather than running a full scan against the local httpserver.
+PUBLIC_HOST = "1.2.3.4"
+
+
+def tech_entry(name, version=None, confidence=100, cpe=None, cves=None, kev=None, pocs=None):
+    entry = {"technology": name, "confidence": confidence, "version": version}
+    if cpe is not None:
+        entry["cpe"] = cpe
+    if cves is not None:
+        entry["cves"] = cves
+    if kev is not None:
+        entry["kev"] = kev
+    if pocs is not None:
+        entry["pocs"] = pocs
+    return entry
+
+
+class RustywapTestBase(ModuleTestBase):
+    module_name = "rustywap"
+    modules_overrides = ["rustywap"]
+    config_overrides = {"modules": {"rustywap": {"api_url": API_URL}}}
+
+    async def setup_before_prep(self, module_test):
+        # setup() runs during scan._prep(), so the health mock must exist before that
+        module_test.blasthttp_mock.add_response(url=f"{API_URL}/health", json={"status": "ok"})
+
+    def make_urls(self, module_test, count, host=PUBLIC_HOST):
+        urls = [f"http://{host}/page{i}" for i in range(count)]
+        events = [
+            module_test.scan.make_event(u, "URL", parent=module_test.scan.root_event, tags=["status-200"])
+            for u in urls
+        ]
+        return urls, events
+
+    def capture_events(self, module_test):
+        """Capture emit_event() calls instead of relying on the scan's event stream."""
+        captured = []
+        module = module_test.scan.modules["rustywap"]
+
+        async def fake_emit_event(data, event_type, parent=None, context=None, **kwargs):
+            captured.append((event_type, data))
+
+        module_test.monkeypatch.setattr(module, "emit_event", fake_emit_event)
+        return captured
+
+
+class TestRustywap(RustywapTestBase):
+    """Detections map onto TECHNOLOGY, and versions onto FINDINGs."""
+
+    async def setup_after_prep(self, module_test):
+        def batch_callback(request):
+            body = json.loads(request.content)
+            return MockResponse(
+                status_code=200,
+                json=[
+                    {
+                        "url": u,
+                        "error": None,
+                        "technologies": [
+                            tech_entry("Nginx", version="1.28.0", cpe="cpe:2.3:a:f5:nginx:*:*:*:*:*:*:*:*"),
+                            tech_entry("jQuery", version=None),
+                        ],
+                    }
+                    for u in body["urls"]
+                ],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+        module_test.requests = []
+
+        module = module_test.scan.modules["rustywap"]
+        original_submit = module._submit
+
+        async def spy_submit(urls, depth=0):
+            module_test.requests.append(list(urls))
+            return await original_submit(urls, depth)
+
+        module_test.monkeypatch.setattr(module, "_submit", spy_submit)
+
+        module_test.captured = self.capture_events(module_test)
+        _, events = self.make_urls(module_test, 1)
+        await module.handle_batch(*events)
+
+    def check(self, module_test, events):
+        captured = module_test.captured
+        techs = [d for t, d in captured if t == "TECHNOLOGY"]
+        findings = [d for t, d in captured if t == "FINDING"]
+
+        tech_names = {d["technology"] for d in techs}
+        assert tech_names == {"nginx", "jquery"}, f"unexpected technologies: {tech_names}"
+
+        # TECHNOLOGY's validator only permits {host, technology, url}; a version key would
+        # be silently dropped, so versions must arrive as FINDINGs instead
+        for d in techs:
+            assert set(d) == {"technology", "url", "host"}, f"unexpected TECHNOLOGY keys: {sorted(d)}"
+
+        version_findings = [d for d in findings if d["name"] == "Software Version - Nginx"]
+        assert len(version_findings) == 1, f"expected one Nginx version FINDING, got {len(version_findings)}"
+        assert "1.28.0" in version_findings[0]["description"]
+        assert "cpe:2.3:a:f5:nginx" in version_findings[0]["description"]
+        assert version_findings[0]["confidence"] == "CONFIRMED"
+
+        # jQuery had no version, so no version FINDING
+        assert not [d for d in findings if d["name"] == "Software Version - jQuery"]
+
+        assert module_test.requests, "module never called _submit"
+
+
+class TestRustywapRequestPayload(RustywapTestBase):
+    """Config values are forwarded to the API in the request body."""
+
+    config_overrides = {
+        "modules": {
+            "rustywap": {
+                "api_url": API_URL,
+                "concurrency": 25,
+                "confidence": 70,
+                "full_scan": True,
+                "api_key": "sekrit",
+            }
+        }
+    }
+
+    async def setup_after_prep(self, module_test):
+        module_test.bodies = []
+        module_test.headers = []
+
+        def batch_callback(request):
+            module_test.bodies.append(json.loads(request.content))
+            module_test.headers.append(dict(request.headers or {}))
+            return MockResponse(status_code=200, json=[])
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        _, events = self.make_urls(module_test, 2)
+        await module.handle_batch(*events)
+
+    def check(self, module_test, events):
+        assert module_test.bodies, "module never called /batch"
+        body = module_test.bodies[0]
+        assert body["concurrency"] == 25
+        assert body["confidence"] == 70
+        assert body["full_scan"] is True
+        assert len(body["urls"]) == 2
+
+        headers = {k.lower(): v for k, v in module_test.headers[0].items()}
+        assert headers.get("authorization") == "Bearer sekrit", f"missing bearer token: {headers}"
+
+
+class TestRustywapBatching(RustywapTestBase):
+    """More URLs than the server maximum must be split across multiple requests."""
+
+    async def setup_after_prep(self, module_test):
+        module_test.batch_sizes = []
+
+        def batch_callback(request):
+            body = json.loads(request.content)
+            module_test.batch_sizes.append(len(body["urls"]))
+            return MockResponse(
+                status_code=200,
+                json=[{"url": u, "error": None, "technologies": []} for u in body["urls"]],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        _, events = self.make_urls(module_test, 250)
+        # bbot hands handle_batch at most batch_size events, so mirror that here
+        for start in range(0, len(events), module.batch_size):
+            await module.handle_batch(*events[start : start + module.batch_size])
+
+    def check(self, module_test, events):
+        sizes = module_test.batch_sizes
+        assert sizes, "module never called /batch"
+        # 250 URLs at a clamped batch size of 100 => 100 + 100 + 50
+        assert sizes == [100, 100, 50], f"unexpected batch split: {sizes}"
+        assert max(sizes) <= 100, f"batch exceeded the server maximum: {sizes}"
+        assert sum(sizes) == 250, f"URLs lost or duplicated: {sizes}"
+
+
+class TestRustywapBatchSizeClamp(RustywapTestBase):
+    """An operator batch_size above the server maximum is clamped rather than sent."""
+
+    config_overrides = {"modules": {"rustywap": {"api_url": API_URL, "batch_size": 5000}}}
+
+    async def setup_after_prep(self, module_test):
+        pass
+
+    def check(self, module_test, events):
+        module = module_test.scan.modules["rustywap"]
+        assert module.batch_size == 100, f"batch_size not clamped: {module.batch_size}"
+
+
+class TestRustywapBisect(RustywapTestBase):
+    """
+    The API rejects an entire batch with 400 if any single URL fails its SSRF check.
+    The module must halve the batch and still recover results from the clean half.
+    """
+
+    bad_url = f"http://{PUBLIC_HOST}/page3"
+
+    async def setup_after_prep(self, module_test):
+        module_test.request_count = 0
+        bad_url = self.bad_url
+
+        def batch_callback(request):
+            module_test.request_count += 1
+            body = json.loads(request.content)
+            if bad_url in body["urls"]:
+                return MockResponse(status_code=400, json={"error": f"SSRF check failed for {bad_url}"})
+            return MockResponse(
+                status_code=200,
+                json=[
+                    {"url": u, "error": None, "technologies": [tech_entry("Nginx", version="1.28.0")]}
+                    for u in body["urls"]
+                ],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        urls, _ = self.make_urls(module_test, 8)
+        module_test.results = await module._submit(urls)
+        module_test.dropped = module._dropped_urls
+
+    def check(self, module_test, events):
+        returned = {r["url"] for r in module_test.results}
+        assert self.bad_url not in returned, "the rejected URL should not appear in results"
+        assert len(returned) == 7, f"expected 7 surviving URLs, got {len(returned)}: {sorted(returned)}"
+        assert module_test.request_count > 1, "module did not retry after the 400"
+        assert module_test.dropped == 1, f"expected exactly 1 dropped URL, got {module_test.dropped}"
+
+
+class TestRustywapPrivateFilter(RustywapTestBase):
+    """URLs whose host is private/loopback are never submitted to the API."""
+
+    async def setup_after_prep(self, module_test):
+        module_test.submitted = []
+
+        def batch_callback(request):
+            body = json.loads(request.content)
+            module_test.submitted.extend(body["urls"])
+            return MockResponse(
+                status_code=200,
+                json=[{"url": u, "error": None, "technologies": []} for u in body["urls"]],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        private = [
+            module_test.scan.make_event(u, "URL", parent=module_test.scan.root_event, tags=["status-200"])
+            for u in ("http://10.115.2.50/", "http://127.0.0.1/", "http://192.168.1.10/", "http://172.16.4.4/")
+        ]
+        public = module_test.scan.make_event(
+            f"http://{PUBLIC_HOST}/", "URL", parent=module_test.scan.root_event, tags=["status-200"]
+        )
+        await module.handle_batch(*private, public)
+
+    def check(self, module_test, events):
+        assert module_test.submitted == [f"http://{PUBLIC_HOST}/"], (
+            f"only the public URL should have been submitted, got {module_test.submitted}"
+        )
+
+
+class TestRustywapCveCap(RustywapTestBase):
+    """CVE FINDINGs are capped at max_cves_per_tech, keeping the highest CVSS scores."""
+
+    config_overrides = {"modules": {"rustywap": {"api_url": API_URL, "max_cves_per_tech": 5}}}
+
+    async def setup_after_prep(self, module_test):
+        cves = [
+            {"id": "CVE-2024-0001", "score": 2.3, "severity": "LOW", "description": "low", "published": "2024-01-01"},
+            {"id": "CVE-2024-0002", "score": 4.7, "severity": "MEDIUM", "description": "m", "published": "2024-01-01"},
+            {"id": "CVE-2024-0003", "score": 5.4, "severity": "MEDIUM", "description": "m", "published": "2024-01-01"},
+            {"id": "CVE-2024-0004", "score": 6.1, "severity": "MEDIUM", "description": "m", "published": "2024-01-01"},
+            {"id": "CVE-2024-0005", "score": 7.5, "severity": "HIGH", "description": "h", "published": "2024-01-01"},
+            {"id": "CVE-2024-0006", "score": 8.8, "severity": "HIGH", "description": "h", "published": "2024-01-01"},
+            {
+                "id": "CVE-2024-0007",
+                "score": 9.1,
+                "severity": "CRITICAL",
+                "description": "c",
+                "published": "2024-01-01",
+            },
+            {
+                "id": "CVE-2024-0008",
+                "score": 9.8,
+                "severity": "CRITICAL",
+                "description": "c",
+                "published": "2024-01-01",
+            },
+        ]
+        kev = [
+            {
+                "cve_id": "CVE-2024-0008",
+                "vulnerability_name": "bad thing",
+                "date_added": "2024-02-01",
+                "due_date": "2024-03-01",
+                "known_ransomware": True,
+                "required_action": "patch",
+            }
+        ]
+        pocs = [
+            {
+                "cve_id": "CVE-2024-0007",
+                "url": "https://github.com/example/poc",
+                "name": "poc",
+                "stars": 10,
+                "pushed_at": "2024-05-01",
+                "verified": True,
+            }
+        ]
+
+        def batch_callback(request):
+            body = json.loads(request.content)
+            return MockResponse(
+                status_code=200,
+                json=[
+                    {
+                        "url": u,
+                        "error": None,
+                        "technologies": [
+                            tech_entry("Apache HTTP Server", version="2.4.37", cves=cves, kev=kev, pocs=pocs)
+                        ],
+                    }
+                    for u in body["urls"]
+                ],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        module_test.captured = self.capture_events(module_test)
+        _, events = self.make_urls(module_test, 1)
+        await module.handle_batch(*events)
+
+    def check(self, module_test, events):
+        findings = [d for t, d in module_test.captured if t == "FINDING"]
+        cve_findings = [d for d in findings if d.get("cves")]
+
+        assert len(cve_findings) == 5, f"expected 5 CVE FINDINGs, got {len(cve_findings)}"
+
+        emitted = {c for d in cve_findings for c in d["cves"]}
+        assert emitted == {
+            "CVE-2024-0008",
+            "CVE-2024-0007",
+            "CVE-2024-0006",
+            "CVE-2024-0005",
+            "CVE-2024-0004",
+        }, f"the cap kept the wrong CVEs: {sorted(emitted)}"
+        # the lowest-scoring CVEs are the ones dropped
+        assert "CVE-2024-0001" not in emitted
+        assert "CVE-2024-0002" not in emitted
+        assert "CVE-2024-0003" not in emitted
+
+        by_cve = {d["cves"][0]: d for d in cve_findings}
+        assert by_cve["CVE-2024-0008"]["severity"] == "CRITICAL"
+        assert by_cve["CVE-2024-0005"]["severity"] == "HIGH"
+        assert by_cve["CVE-2024-0004"]["severity"] == "MEDIUM"
+        assert "2.4.37" in by_cve["CVE-2024-0008"]["name"]
+
+        assert "CISA KEV" in by_cve["CVE-2024-0008"]["description"]
+        assert "CISA KEV" not in by_cve["CVE-2024-0007"]["description"]
+        assert "github.com/example/poc" in by_cve["CVE-2024-0007"]["description"]
+
+
+class TestRustywapApiDown(RustywapTestBase):
+    """An unreachable API soft-fails: the module is disabled, the scan continues."""
+
+    async def setup_before_prep(self, module_test):
+        module_test.blasthttp_mock.add_response(url=f"{API_URL}/health", status_code=503, json={"error": "nope"})
+
+    async def setup_after_prep(self, module_test):
+        pass
+
+    def check(self, module_test, events):
+        # soft-fail leaves the scan running; the module just isn't in play
+        assert module_test.scan.status not in ("FAILED", "ABORTING"), (
+            f"a dead API should not abort the scan (status={module_test.scan.status})"
+        )
+
+
+class TestRustywapBisectFullBatch(RustywapTestBase):
+    """
+    Regression: one bad URL in a FULL batch must cost only that one URL.
+
+    A fixed bisect depth of 4 bottomed out at ~6-URL chunks against a 100-URL batch
+    and discarded 6 good results to isolate 1 bad one. The depth is now derived from
+    batch_size, so halving can always reach a single URL.
+    """
+
+    bad_url = f"http://{PUBLIC_HOST}/page57"
+
+    async def setup_after_prep(self, module_test):
+        bad_url = self.bad_url
+        module_test.request_count = 0
+
+        def batch_callback(request):
+            module_test.request_count += 1
+            body = json.loads(request.content)
+            if bad_url in body["urls"]:
+                return MockResponse(status_code=400, json={"error": f"SSRF check failed for {bad_url}"})
+            return MockResponse(
+                status_code=200,
+                json=[{"url": u, "error": None, "technologies": []} for u in body["urls"]],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        urls, _ = self.make_urls(module_test, 100)
+        module_test.results = await module._submit(urls)
+        module_test.dropped = module._dropped_urls
+        module_test.depth = module.max_bisect_depth
+
+    def check(self, module_test, events):
+        # ceil(log2(100)) == 7 halvings to narrow 100 URLs down to 1
+        assert module_test.depth == 7, f"expected bisect depth 7 for a 100-URL batch, got {module_test.depth}"
+
+        recovered = {r["url"] for r in module_test.results}
+        assert self.bad_url not in recovered, "the rejected URL should not appear in results"
+        assert len(recovered) == 99, (
+            f"expected all 99 good URLs, recovered {len(recovered)} (dropped {module_test.dropped})"
+        )
+        assert module_test.dropped == 1, f"only the offending URL should be dropped, got {module_test.dropped}"
+
+
+class TestRustywapAdvisories(RustywapTestBase):
+    """GHSA advisories produce FINDINGs, including ones carrying no CVE."""
+
+    async def setup_after_prep(self, module_test):
+        cves = [
+            {
+                "id": "CVE-2024-1111",
+                "score": 9.8,
+                "severity": "CRITICAL",
+                "description": "already covered by the CVE pass",
+                "published": "2024-01-01",
+            }
+        ]
+        advisories = [
+            # duplicate of the CVE emitted above — must be suppressed
+            {
+                "id": "GHSA-dupe-dupe-dupe",
+                "cve_id": "CVE-2024-1111",
+                "summary": "duplicate",
+                "severity": 9.8,
+                "severity_level": "CRITICAL",
+                "ecosystem": "npm",
+                "package_name": "thing",
+                "published": "2024-01-01",
+            },
+            # no CVE at all — would be lost entirely if advisories were ignored
+            {
+                "id": "GHSA-aaaa-bbbb-cccc",
+                "cve_id": None,
+                "summary": "prototype pollution in thing",
+                "severity": 7.5,
+                "severity_level": "HIGH",
+                "ecosystem": "npm",
+                "package_name": "thing",
+                "published": "2024-02-01",
+            },
+            # GHSA "MODERATE" has no bbot equivalent and must map to MEDIUM
+            {
+                "id": "GHSA-dddd-eeee-ffff",
+                "cve_id": None,
+                "summary": "moderate issue",
+                "severity": 5.3,
+                "severity_level": "MODERATE",
+                "ecosystem": "npm",
+                "package_name": "thing",
+                "published": "2024-03-01",
+            },
+        ]
+
+        def batch_callback(request):
+            body = json.loads(request.content)
+            return MockResponse(
+                status_code=200,
+                json=[
+                    {
+                        "url": u,
+                        "error": None,
+                        "technologies": [tech_entry("Thing", version="1.0.0", cves=cves) | {"advisories": advisories}],
+                    }
+                    for u in body["urls"]
+                ],
+            )
+
+        module_test.blasthttp_mock.add_callback(batch_callback, url=f"{API_URL}/batch")
+
+        module = module_test.scan.modules["rustywap"]
+        module_test.captured = self.capture_events(module_test)
+        _, events = self.make_urls(module_test, 1)
+        await module.handle_batch(*events)
+
+    def check(self, module_test, events):
+        findings = [d for t, d in module_test.captured if t == "FINDING"]
+        advisory_findings = [d for d in findings if d["name"].startswith("Vulnerable Package")]
+
+        assert len(advisory_findings) == 2, (
+            f"expected 2 advisory FINDINGs (the CVE-duplicated one suppressed), got {len(advisory_findings)}: "
+            f"{[d['description'] for d in advisory_findings]}"
+        )
+
+        descriptions = " | ".join(d["description"] for d in advisory_findings)
+        assert "GHSA-aaaa-bbbb-cccc" in descriptions, "the CVE-less advisory was dropped"
+        assert "GHSA-dupe-dupe-dupe" not in descriptions, "advisory duplicating an emitted CVE was not suppressed"
+        assert "npm:thing" in descriptions, "ecosystem:package label missing"
+        assert "prototype pollution" in descriptions, "advisory summary missing"
+
+        severities = {d["severity"] for d in advisory_findings}
+        assert severities == {"HIGH", "MEDIUM"}, f"MODERATE should map to MEDIUM, got {severities}"
+
+        # advisories with no CVE must not populate the FINDING's cves field
+        assert all("cves" not in d for d in advisory_findings), "GHSA ids must not be written into the cves field"
+
+
+class TestRustywapPerHostOnly(RustywapTestBase):
+    """
+    Regression: a host must be analyzed once, not once per scheme/port.
+
+    per_hostport_only treated http://host:80 and https://host:443 as two services, so a
+    host whose port 80 redirects to 443 produced two identical sets of TECHNOLOGY events
+    and cost two API calls.
+    """
+
+    async def setup_after_prep(self, module_test):
+        pass
+
+    def check(self, module_test, events):
+        module = module_test.scan.modules["rustywap"]
+        assert module.per_host_only is True, "module must dedupe incoming URLs per host"
+        assert module.per_hostport_only is False, "per_hostport_only would re-analyze the same host on both 80 and 443"
+        # the dedup hash BaseModule actually uses must be the per-host one
+        event = module_test.scan.make_event(
+            f"https://{PUBLIC_HOST}/", "URL", parent=module_test.scan.root_event, tags=["status-200"]
+        )
+        _, reason = module._incoming_dedup_hash(event)
+        assert reason == "per_host_only=True", f"unexpected dedup strategy: {reason}"


### PR DESCRIPTION
Adds a scan module that submits URLs in **batches** to a [RustedWappalyzer](https://github.com/shart123456/RustedWappalyzer) API server and emits `TECHNOLOGY` plus `FINDING` events for detected software, versions, CVEs, and GHSA advisories.

`watched_events = ["URL"]` · `produced_events = ["TECHNOLOGY", "FINDING"]` · `flags = ["active", "safe", "web"]`

## Why batching

The API's rate limiter allows 600 req/min/IP and its `max_batch_size` is 100. One batch of 100 URLs costs a single request, so 10,000 URLs cost 100 requests instead of 10,000. `_batch_size = 100` is hard-matched to the server maximum, and an operator-supplied `batch_size` above it is clamped rather than sent (the server 400s the whole request otherwise).

## Analyzes once per host

`per_hostport_only` treats `http://host:80` and `https://host:443` as separate services and analyzes both. In practice port 80 redirects to 443, the API follows the redirect, and you get two identical sets of `TECHNOLOGY` events at double the API cost. `per_host_only = True` instead.

Measured against one host:

| | Events | URLs consumed |
|---|---|---|
| `per_hostport_only` | 36 (28 TECHNOLOGY + 8 FINDING) | 2 |
| `per_host_only` | 18 (14 TECHNOLOGY + 4 FINDING) | 1 |

Trade-off: a genuinely different stack on a second port (an admin app on `:8080`) is only analyzed once per host. Happy to switch this to a config option if reviewers prefer per-port coverage by default.

## Flagged `active`, deliberately

The module itself only talks to the API, but the API fetches the target on our behalf. Flagging it `passive` would let it run in passive-only scans while generating traffic to the target.

## Batch rejection is bisected

`/batch` returns 400 for the **entire** batch if any single URL fails its SSRF check, so one bad host would discard up to 99 good results. On a 400 the module halves the batch and retries each side.

Bisect depth is derived from `batch_size` as `ceil(log2(n))` rather than fixed. A fixed depth of 4 bottoms out at ~6-URL chunks against a 100-URL batch and discards 6 good results to isolate 1 bad one — measured 94/99 recovered before, 99/99 after. Private/loopback hosts are also filtered locally before submitting, since the API rejects them anyway.

## Versions go in FINDINGs, not TECHNOLOGY

`TECHNOLOGY`'s `_data_validator` permits only `{host, technology, url}`, and `_sanitize_data` runs `self._data_validator(**data).model_dump()`, so pydantic silently drops an extra `version` key. Versions and CPEs are emitted as `INFO` FINDINGs; CVEs as one FINDING each (capped at `max_cves_per_tech`, highest CVSS first, KEV and PoC annotated); GHSA advisories as `Vulnerable Package` FINDINGs, with advisories duplicating an already-emitted CVE suppressed.

## Config

`api_url` · `api_key` · `batch_size` · `concurrency` · `confidence` · `full_scan` · `emit_findings` · `max_cves_per_tech`

A missing or unreachable API **soft-fails** (`return None, msg`) so it disables this module rather than aborting the scan.

## Testing

11 tests in `test_module_rustywap.py`, all passing: batching split, batch-size clamp, bisect on a small batch and on a full 100-URL batch, private-host filtering, request payload and bearer auth, TECHNOLOGY/FINDING mapping, CVE cap ordering, GHSA advisory handling, per-host dedup, and API-down soft-fail.

The tests drive `handle_batch`/`_submit` directly rather than running a full scan. Two harness facts make an end-to-end scan test impossible here: `_should_mock` passes `localhost`/`127.0.0.1` through to real servers, and the harness maps test DNS to `127.0.0.88` — so a default-config test hits a real API on port 3000, and any local target is then correctly refused by the module's own private-address filter.

Also verified live against a real host, which is where the per-host numbers above come from.

## Known limitation

The CVE and GHSA paths are **mock-verified only**. They are written against the API's `CveEntry` / `KevEntry` / `PocEntry` / `GhsaEntry` structs field-for-field, but the enrichment MongoDB is optional and was not configured in my environment, so the API returned empty `cves`/`advisories` in live testing. The parsing is unexercised against real enrichment data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
