### PR TITLE
Update trufflehog to 3.97.1

### DIFF
--- a/bbot/modules/trufflehog.py
+++ b/bbot/modules/trufflehog.py
@@ -15,7 +15,7 @@ class trufflehog(BaseModule):
     }
 
     class Config(BaseModuleConfig):
-        version: str = Field("3.97.0", description="trufflehog version")
+        version: str = Field("3.97.1", description="trufflehog version")
         config: str = Field("", description="File path or URL to YAML trufflehog config")
         only_verified: bool = Field(True, description="Only report credentials that have been verified")
         concurrency: int = Field(8, description="Number of concurrent workers")


### PR DESCRIPTION
This PR uses https://api.github.com/repos/trufflesecurity/trufflehog/releases/latest to obtain the latest version of trufflehog and update the version in bbot/modules/trufflehog.py.

# Release notes:
## What's Changed
* Update module github.com/go-git/go-git/v5 to v5.19.2 [SECURITY] by @renovate[bot] in https://github.com/trufflesecurity/trufflehog/pull/5196
* Fix GHEC with Data Residency (`*.ghe.com`) base URL by @shahzadhaider1 in https://github.com/trufflesecurity/trufflehog/pull/4777
* docs: add generic config-secret custom detector example by @pgmpofu in https://github.com/trufflesecurity/trufflehog/pull/5195
* fix(detectors/docker): don't greedy match in keyPat by @mariduv in https://github.com/trufflesecurity/trufflehog/pull/5214
* [SCAN-1020] neon scram pgx by @alafiand in https://github.com/trufflesecurity/trufflehog/pull/5217
* Raised MongoDB detector timeout value by @jordanTunstill in https://github.com/trufflesecurity/trufflehog/pull/5222
* preallocate bindings capacity in dockerhub and groq, with unit tests by @jordanTunstill in https://github.com/trufflesecurity/trufflehog/pull/5213
* [SCAN-101] S3 Source accept persisted unit envelopes in UnmarshalSourceUnit by @amanfcp in https://github.com/trufflesecurity/trufflehog/pull/5224
* Refine SECURITY.md by @bradlarsen in https://github.com/trufflesecurity/trufflehog/pull/5216
* Carry GitHub App installation ID on repo units by @bill-rich in https://github.com/trufflesecurity/trufflehog/pull/5215

## New Contributors
* @pgmpofu made their first contribution in https://github.com/trufflesecurity/trufflehog/pull/5195

**Full Changelog**: https://github.com/trufflesecurity/trufflehog/compare/v3.97.0...v3.97.1