### PR TITLE
Set url_extension on HTTP_RESPONSE events

### DIFF
--- a/bbot/core/event/base.py
+++ b/bbot/core/event/base.py
@@ -142,6 +142,9 @@ class BaseEvent:
     _discovery_context_regex = re.compile(r"\{(?:event|module)[^}]*\}")
     # Stats class for the status line — override in subclasses for custom formatting
     _stats_class = None
+    # Whether this event is subject to `url_extension_special` distribution filtering.
+    # False for events representing already-retrieved content, whose consumers analyze the body.
+    _url_special_filterable = True
 
     # using __slots__ dramatically reduces memory usage in large scans
     __slots__ = [
@@ -1164,18 +1167,24 @@ class DefaultEvent(BaseEvent):
 class DictEvent(BaseEvent):
     __slots__ = ["url_extension"]
 
+    def _set_url_extension(self):
+        """Extract the file extension from self.parsed_url and record it as an attribute and a tag."""
+        parsed_url = getattr(self, "parsed_url", None)
+        if parsed_url is None:
+            return
+        url_path = parsed_url.path
+        if not url_path:
+            return
+        extension = get_file_extension(str(url_path).lower())
+        if extension:
+            self.url_extension = extension
+            self.add_tag(f"extension-{extension}")
+
     def sanitize_data(self, data):
         url = data.get("url", "")
         if url:
             self.parsed_url = self.validators.validate_url_parsed(url)
-            # extract url_extension from any dict event with a URL
-            url_path = self.parsed_url.path
-            if url_path:
-                parsed_path_lower = str(url_path).lower()
-                extension = get_file_extension(parsed_path_lower)
-                if extension:
-                    self.url_extension = extension
-                    self.add_tag(f"extension-{extension}")
+            self._set_url_extension()
         return data
 
     def _data_load(self, data):
@@ -1446,15 +1455,7 @@ class URL_UNVERIFIED(DictHostEvent):
         self.parsed_url = self.validators.validate_url_parsed(url)
         data["url"] = self.parsed_url.geturl()
 
-        # special handling of URL extensions
-        if self.parsed_url is not None:
-            url_path = self.parsed_url.path
-            if url_path:
-                parsed_path_lower = str(url_path).lower()
-                extension = get_file_extension(parsed_path_lower)
-                if extension:
-                    self.url_extension = extension
-                    self.add_tag(f"extension-{extension}")
+        self._set_url_extension()
 
         # tag as dir or endpoint
         if str(self.parsed_url.path).endswith("/"):
@@ -1703,6 +1704,10 @@ class EMAIL_ADDRESS(BaseEvent):
 
 
 class HTTP_RESPONSE(URL_UNVERIFIED):
+    # the response body has already been retrieved, so content-analysis modules
+    # should still receive it even for special extensions like .js
+    _url_special_filterable = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # count number of consecutive redirects
@@ -1756,6 +1761,7 @@ class HTTP_RESPONSE(URL_UNVERIFIED):
         url = data.get("url", "")
         self.parsed_url = self.validators.validate_url_parsed(url)
         data["url"] = self.parsed_url.geturl()
+        self._set_url_extension()
 
         if not "raw_header" in data:
             raise ValueError("raw_header is required for HTTP_RESPONSE events")

--- a/bbot/modules/base.py
+++ b/bbot/modules/base.py
@@ -871,7 +871,7 @@ class BaseModule:
             return False, "it did not meet target_only filter criteria"
 
         # limit events with special URL extensions (e.g. .js) to modules that opt in
-        if not self.accept_url_special:
+        if not self.accept_url_special and event._url_special_filterable:
             extension = getattr(event, "url_extension", "")
             if extension in self.scan.url_extension_special:
                 return (

--- a/bbot/test/test_step_1/test_events.py
+++ b/bbot/test/test_step_1/test_events.py
@@ -175,6 +175,28 @@ async def test_events(events, helpers):
     )
     assert getattr(wp_no_ext, "url_extension", "NOT_SET") == "NOT_SET"
 
+    # url_extension: HTTP_RESPONSE events
+    # modules that filter on url_extension (e.g. paramminer, lightfuzz) rely on this being set
+    def _http_response(url):
+        return scan.make_event(
+            {"url": url, "raw_header": "HTTP/1.1 200 OK\r\n\r\n"},
+            "HTTP_RESPONSE",
+            dummy=True,
+        )
+
+    hr_pdf = _http_response("https://evilcorp.com/files/document.pdf?foo=bar")
+    assert getattr(hr_pdf, "url_extension", "") == "pdf"
+    assert "extension-pdf" in hr_pdf.tags
+    hr_no_ext = _http_response("https://evilcorp.com/search")
+    assert getattr(hr_no_ext, "url_extension", "NOT_SET") == "NOT_SET"
+
+    # special extensions (.js) must still reach modules that don't opt in to special URLs,
+    # since the response body has already been retrieved
+    hr_js = _http_response("https://evilcorp.com/app.js")
+    assert getattr(hr_js, "url_extension", "") == "js"
+    assert hr_js._url_special_filterable is False
+    assert scan.make_event("https://evilcorp.com/app.js", dummy=True)._url_special_filterable is True
+
     # http response
     assert events.http_response.host == "example.com"
     assert events.http_response.port == 80

--- a/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
+++ b/bbot/test/test_step_2/module_tests/test_module_paramminer_getparams.py
@@ -288,3 +288,11 @@ class TestParamminer_Getparams_filter_static(TestParamminer_Getparams_finish):
         assert excavate_extracted_param, "Excavate should still extract the parameter from the HTML link"
         assert not paramminer_recycled_to_php, "Paramminer should not recycle words from static-URL WEB_PARAMETERs"
         assert not paramminer_bruted_pdf, "Paramminer should not brute-force parameters on static URLs"
+
+        # paramminer's static filter also applies to HTTP_RESPONSE events, which requires
+        # url_extension to be populated on them
+        pdf_responses = [e for e in events if e.type == "HTTP_RESPONSE" and e.data["url"].endswith("test2.pdf")]
+        assert pdf_responses, "expected an HTTP_RESPONSE for the .pdf URL"
+        assert getattr(pdf_responses[0], "url_extension", None) == "pdf", (
+            "HTTP_RESPONSE is missing url_extension, so paramminer's static filter is bypassed"
+        )


### PR DESCRIPTION
## Problem

`HTTP_RESPONSE.sanitize_data()` overrides `URL_UNVERIFIED.sanitize_data()` without calling `super()` and without extracting the URL file extension. Since `url_extension` is declared in `__slots__` with no default, it is never set on HTTP_RESPONSE events.

Paramminer's `filter_event` reads `getattr(event, "url_extension", None)`, gets `None`, and lets every static-file URL through:

```
https://example.com/files/doc.pdf  ->  HTTP_RESPONSE.url_extension = None
                                       URL_UNVERIFIED.url_extension = 'pdf'
```

Every PDF, DOCX, ZIP etc. then receives the full paramminer treatment: 2 baseline requests plus a 0.5s sleep, then a binary search across the 5,289-word wordlist (~13 rounds of ~40-param batches). On `wayback-heavy` scans this dominates runtime and produces blasthttp timeouts. All three paramminer variants are affected, since they all watch HTTP_RESPONSE and share `filter_event`.

This is the same class of bug as 52c0cc85a, which hoisted `url_extension` to `DictEvent` so WEB_PARAMETER events would get it. HTTP_RESPONSE was missed because it overrides `sanitize_data` and never picks up the inherited logic.

## Fix

The extension logic was already duplicated between `DictEvent` and `URL_UNVERIFIED`, so it is extracted into `DictEvent._set_url_extension()` and used at all three call sites rather than adding a third copy.

## The second half

Populating `url_extension` alone introduces a regression. `url_extension_special: [js]` is enforced in `bbot/modules/base.py`, and since 52c0cc85a that check applies to all event types rather than URL types only. Giving HTTP_RESPONSE the attribute newly drags it under that gate:

```
badsecrets on .js HTTP_RESPONSE
   before: (True,  'precheck succeeded')
   after:  (False, 'it has a special URL extension (js)...')
```

`http` fetches JS URLs (`accept_url_special = True`) and emits HTTP_RESPONSEs for them, which `badsecrets` and other content-analysis modules consume today. Without a guard they would silently stop.

HTTP_RESPONSE was only ever exempt from that gate by accident, because it lacked the attribute. `_url_special_filterable` makes the exemption explicit: events representing already-retrieved content stay out of a gate whose purpose (per `defaults.yml`: "URLs with these extensions are not distributed to modules") is deciding which URLs to hand out, not which response bodies to analyze.

## Notes

`retirejs` and `lightfuzz` are unaffected. `retirejs` watches `URL_UNVERIFIED`, and lightfuzz's static filter is scoped to `WEB_PARAMETER`. Both types already had `url_extension`.

The existing `TestParamminer_Getparams_filter_static` passed before this fix, because it only asserted that no parameter was confirmed on the `.pdf` URL rather than that the work was skipped. It is strengthened here to assert the invariant, and both new tests fail without the one-line fix.
