### PR TITLE
Clarify Version Updater workflow name

### DIFF
--- a/.github/workflows/version_updater.yml
+++ b/.github/workflows/version_updater.yml
@@ -1,4 +1,4 @@
-name: Version Updater
+name: Tool Version Updater
 on:
   schedule:
     # Runs at 00:00 every day


### PR DESCRIPTION
## Summary

Clarify the GitHub Actions workflow name by renaming `Version Updater` to `Tool Version Updater`.

The workflow updates pinned tool versions such as Nuclei and TruffleHog, while BBOT release/version handling is performed elsewhere.

No workflow logic or behavior is changed.

Fixes #3388

## Testing

- Verified the workflow YAML remains valid
- Relevant checks passed
- Confirmed the diff contains only the workflow display-name change

## AI assistance

AI assistance was used to review the issue scope and verify the minimal implementation. The final change and diff were reviewed locally.