### PR TITLE
AGENTS.md: fix the options section and refresh stale module examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,7 +265,7 @@ setup()  -->  handle_event() (called many times)  -->  finish()  -->  report()  
 Event types this module wants to process. The module's `handle_event()` is only called for these types.
 
 ```python
-# sslcert.py - watches for open ports to grab SSL certs from
+# fingerprintx.py - watches for open ports to fingerprint the service behind them
 watched_events = ["OPEN_TCP_PORT"]
 
 # newsletters.py - watches HTTP responses to scan HTML
@@ -302,8 +302,8 @@ Common flags:
 # crt.py - queries a third-party API, never touches the target
 flags = ["subdomain-enum", "passive"]
 
-# sslcert.py - connects directly to target ports
-flags = ["affiliates", "subdomain-enum", "email-enum", "active", "web"]
+# sslcert.py - reads certs from responses the scan already fetched
+flags = ["safe", "affiliates", "subdomain-enum", "email-enum", "active", "web"]
 ```
 
 ##### `meta` (dict)
@@ -451,8 +451,8 @@ def _incoming_dedup_hash(self, event):
 How many `handle_event()` calls can run concurrently. Increase this for I/O-bound modules.
 
 ```python
-# sslcert.py - connects to many hosts in parallel
-_module_threads = 25
+# iis_shortnames.py - many short requests per host
+_module_threads = 4
 ```
 
 ##### `_batch_size` (int) -- default: `1`
@@ -486,16 +486,16 @@ _shuffle_incoming_queue = False
 Python packages to install.
 
 ```python
-# sslcert.py
-deps_pip = ["pyOpenSSL~=25.3.0"]
+# badsecrets.py
+deps_pip = ["badsecrets~=1.2.1"]
 ```
 
 ##### `deps_apt` (list)
 System packages to install.
 
 ```python
-# sslcert.py
-deps_apt = ["openssl"]
+# git_clone.py
+deps_apt = ["git"]
 ```
 
 ##### `deps_modules` (list)
@@ -601,10 +601,11 @@ async def handle_batch(self, *events):
 Called before `handle_event()`. Return `True` to accept, `False` to reject, or `(False, "reason")` to reject with a logged reason.
 
 ```python
-# sslcert.py - skip ports that don't typically use SSL
+# apkpure.py - only handle Android apps
 async def filter_event(self, event):
-    if self.skip_non_ssl and event.port in self.non_ssl_ports:
-        return False, f"Port {event.port} doesn't typically use SSL"
+    if event.type == "MOBILE_APP":
+        if "android" not in event.tags:
+            return False, "event is not an android app"
     return True
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,27 +324,33 @@ meta = {"description": "Query API for subdomains", "auth_required": True}
 
 #### Options
 
-##### `options` / `options_desc` (dict)
-User-configurable settings. Access them via `self.config.get("option_name")`.
+##### `class Config(BaseModuleConfig)`
+User-configurable settings are declared as a nested `Config` class using pydantic fields. Access
+them via `self.config.get("option_name")`.
+
+> The legacy `options` / `options_desc` dicts are **no longer supported in BBOT 3.0+** -- a module
+> that declares them fails to load with a `CRITICAL` message.
 
 ```python
 # robots.py - configurable parsing options
-options = {"include_sitemap": False, "include_allow": True, "include_disallow": True}
-options_desc = {
-    "include_sitemap": "Include 'sitemap' entries",
-    "include_allow": "Include 'Allow' Entries",
-    "include_disallow": "Include 'Disallow' Entries",
-}
+from bbot.core.config.models import BaseModuleConfig, Field
 
-# In handle_event():
-if self.config.get("include_sitemap") is True:
-    ...
+
+class robots(BaseModule):
+    class Config(BaseModuleConfig):
+        include_sitemap: bool = Field(False, description="Include 'sitemap' entries")
+        include_allow: bool = Field(True, description="Include 'Allow' Entries")
+        include_disallow: bool = Field(True, description="Include 'Disallow' Entries")
+
+    # In handle_event():
+    #   if self.config.get("include_sitemap") is True:
+    #       ...
 ```
 
 ```python
-# sslcert.py - timeout and behavior options
-options = {"timeout": 5.0, "skip_non_ssl": True}
-options_desc = {"timeout": "Socket connect timeout in seconds", "skip_non_ssl": "Don't try common non-SSL ports"}
+# shodan_dns.py - an API key, marked sensitive and mandatory
+class Config(BaseModuleConfig):
+    api_key: str | list[str] = Field("", description="Shodan API key", sensitive=True, mandatory=True)
 ```
 
 ---


### PR DESCRIPTION
# AGENTS.md: fix the options section and refresh stale module examples

## Summary
Two docs-only commits to `AGENTS.md`. The first fixes a section that sends contributors into a
module that won't load; the second repoints example snippets at modules that still have the
attributes being illustrated.

## 1. The Options section documents a form BBOT 3.0 rejects

`AGENTS.md` §Options documented `options` / `options_desc` dicts. BBOT 3.0+ refuses to load a module
that declares them. Dropping a module with a legacy dict into `bbot/modules/` and running `bbot -l`:

```
[CRIT] Module "ztest_legacy" (/path/bbot/modules/ztest_legacy.py:9) declares a legacy `options` dict,
       which is no longer supported in BBOT 3.0+.
```

Since `AGENTS.md` is the file you hand contributors — and explicitly tell them to feed to their LLM —
before they write a module, this is the one doc bug that reliably produces a broken first module.

Replaced with the pydantic form actually in use. `robots.py` is quoted from its current source (it
was already the example in this section), plus a `shodan_dns.py` example showing `sensitive` /
`mandatory` on an API key.

For scale: on `dev` today, **118 modules use `class Config` and 6 use the legacy dicts** — and those
6 are `bbot/modules/templates/*` + `base.py`, where the dicts appear vestigial (concrete modules like
`shodan_dns` declare their own `Config`, and their options surface correctly in
`--list-module-options`). I left those alone — happy to open a separate issue if you'd like them
cleaned up, but that's a code change and your call.

## 2. `sslcert` examples no longer match the module

`sslcert` was reworked in 3.0: it watches `HTTP_RESPONSE` rather than `OPEN_TCP_PORT`, and no longer
declares `options`, `_module_threads`, `filter_event`, `deps_pip`, or `deps_apt`. `AGENTS.md` still
cited it for each of those, so those snippets describe attributes the module doesn't have.

Each is repointed to a module that currently has the attribute, keeping the same teaching point:

| Section | was | now |
|---|---|---|
| `watched_events` (OPEN_TCP_PORT) | sslcert | `fingerprintx` |
| `_module_threads` | sslcert (25) | `iis_shortnames` (4) |
| `deps_pip` | sslcert | `badsecrets` |
| `deps_apt` | sslcert | `git_clone` |
| `filter_event` `(False, "reason")` | sslcert | `apkpure` |

Also corrected sslcert's own `flags` example: it carries `safe` (which the section immediately above
requires: "Must also include `safe`, `loud`, or `invasive`"), and it reads certs from responses the
scan already fetched rather than connecting to ports itself.

The sslcert citations that are **still accurate** — `produced_events`, `scope_distance_modifier = 1`,
`_priority = 2` — are unchanged. Every replacement was verified against the module source on `dev`.

## Notes
- Docs only; no code, no behavior change.
- Split into two commits so you can take just the first if you prefer — they're independent.
- Happy to adjust which modules are used as examples if you'd rather showcase different ones.

---

### AI Use Disclosure

Model: Claude Opus. I hit the `options` guidance while writing a module, the module wouldn't load, and I used Claude to trace why and to check how widely the doc had drifted from the code. It drafted the edits; I confirmed each one against the source on `dev` and reproduced the load failure myself before filing.
